### PR TITLE
Export FastRTPS libraries

### DIFF
--- a/fastrtps_cmake_module/cmake/Modules/FindFastRTPS.cmake
+++ b/fastrtps_cmake_module/cmake/Modules/FindFastRTPS.cmake
@@ -42,3 +42,11 @@ find_package_handle_standard_args(FastRTPS
   REQUIRED_VARS
     FastRTPS_INCLUDE_DIR
 )
+
+find_library(FastRTPS_LIBRARY
+    NAMES fastrtps)
+
+find_library(FastCDR_LIBRARY
+    NAMES fastcdr)
+
+set(FastRTPS_LIBRARIES ${FastRTPS_LIBRARY} ${FastCDR_LIBRARY})

--- a/fastrtps_cmake_module/cmake/Modules/FindFastRTPS.cmake
+++ b/fastrtps_cmake_module/cmake/Modules/FindFastRTPS.cmake
@@ -39,14 +39,14 @@ find_path(FastRTPS_INCLUDE_DIR
 find_package(fastcdr REQUIRED CONFIG)
 find_package(fastrtps REQUIRED CONFIG)
 
-string(REGEX MATCH "^[0-9]+\\.[0-9]+" fastcdr_DLL_VERSION "${fastcdr_VERSION}")
-string(REGEX MATCH "^[0-9]+\\.[0-9]+" fastrtps_DLL_VERSION "${fastrtps_VERSION}")
+string(REGEX MATCH "^[0-9]+\\.[0-9]+" fastcdr_MAJOR_MINOR_VERSION "${fastcdr_VERSION}")
+string(REGEX MATCH "^[0-9]+\\.[0-9]+" fastrtps_MAJOR_MINOR_VERSION "${fastrtps_VERSION}")
 
 find_library(FastRTPS_LIBRARY
-    NAMES fastrtps-${fastrtps_DLL_VERSION} fastrtps)
+    NAMES fastrtps-${fastrtps_MAJOR_MINOR_VERSION} fastrtps)
 
 find_library(FastCDR_LIBRARY
-    NAMES fastcdr-${fastcdr_DLL_VERSION} fastcdr)
+    NAMES fastcdr-${fastcdr_MAJOR_MINOR_VERSION} fastcdr)
 
 set(FastRTPS_LIBRARIES ${FastRTPS_LIBRARY} ${FastCDR_LIBRARY})
 

--- a/fastrtps_cmake_module/cmake/Modules/FindFastRTPS.cmake
+++ b/fastrtps_cmake_module/cmake/Modules/FindFastRTPS.cmake
@@ -37,10 +37,10 @@ find_path(FastRTPS_INCLUDE_DIR
   NAMES fastrtps/)
 
 find_library(FastRTPS_LIBRARY
-    NAMES fastrtps)
+    NAMES fastrtps-1.4 fastrtps)
 
 find_library(FastCDR_LIBRARY
-    NAMES fastcdr)
+    NAMES fastcdr-1.0 fastcdr)
 
 set(FastRTPS_LIBRARIES ${FastRTPS_LIBRARY} ${FastCDR_LIBRARY})
 

--- a/fastrtps_cmake_module/cmake/Modules/FindFastRTPS.cmake
+++ b/fastrtps_cmake_module/cmake/Modules/FindFastRTPS.cmake
@@ -36,13 +36,6 @@ set(FastRTPS_FOUND FALSE)
 find_path(FastRTPS_INCLUDE_DIR
   NAMES fastrtps/)
 
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(FastRTPS
-  FOUND_VAR FastRTPS_FOUND
-  REQUIRED_VARS
-    FastRTPS_INCLUDE_DIR
-)
-
 find_library(FastRTPS_LIBRARY
     NAMES fastrtps)
 
@@ -50,3 +43,13 @@ find_library(FastCDR_LIBRARY
     NAMES fastcdr)
 
 set(FastRTPS_LIBRARIES ${FastRTPS_LIBRARY} ${FastCDR_LIBRARY})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(FastRTPS
+  FOUND_VAR FastRTPS_FOUND
+  REQUIRED_VARS
+    FastRTPS_INCLUDE_DIR
+    FastCDR_LIBRARY
+    FastRTPS_LIBRARY
+    FastRTPS_LIBRARIES
+)

--- a/fastrtps_cmake_module/cmake/Modules/FindFastRTPS.cmake
+++ b/fastrtps_cmake_module/cmake/Modules/FindFastRTPS.cmake
@@ -36,11 +36,17 @@ set(FastRTPS_FOUND FALSE)
 find_path(FastRTPS_INCLUDE_DIR
   NAMES fastrtps/)
 
+find_package(fastcdr REQUIRED CONFIG)
+find_package(fastrtps REQUIRED CONFIG)
+
+string(REGEX MATCH "^[0-9]+\\.[0-9]+" fastcdr_DLL_VERSION "${fastcdr_VERSION}")
+string(REGEX MATCH "^[0-9]+\\.[0-9]+" fastrtps_DLL_VERSION "${fastrtps_VERSION}")
+
 find_library(FastRTPS_LIBRARY
-    NAMES fastrtps-1.4 fastrtps)
+    NAMES fastrtps-${fastrtps_DLL_VERSION} fastrtps)
 
 find_library(FastCDR_LIBRARY
-    NAMES fastcdr-1.0 fastcdr)
+    NAMES fastcdr-${fastcdr_DLL_VERSION} fastcdr)
 
 set(FastRTPS_LIBRARIES ${FastRTPS_LIBRARY} ${FastCDR_LIBRARY})
 

--- a/rmw_fastrtps_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_cpp/CMakeLists.txt
@@ -27,6 +27,7 @@ find_package(rcutils REQUIRED)
 find_package(fastrtps_cmake_module REQUIRED)
 find_package(fastcdr REQUIRED CONFIG)
 find_package(fastrtps REQUIRED CONFIG)
+find_package(FastRTPS REQUIRED MODULE)
 
 find_package(rmw REQUIRED)
 find_package(rosidl_generator_c REQUIRED)
@@ -59,7 +60,7 @@ ament_target_dependencies(rmw_fastrtps_cpp
 
 configure_rmw_library(rmw_fastrtps_cpp)
 
-ament_export_libraries(rmw_fastrtps_cpp fastcdr fastrtps)
+ament_export_libraries(rmw_fastrtps_cpp fastcdr fastrtps ${FastRTPS_LIBRARIES})
 if(NOT WIN32 AND NOT ANDROID)
   ament_export_libraries(pthread)
 endif()

--- a/rmw_fastrtps_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_cpp/CMakeLists.txt
@@ -60,7 +60,7 @@ ament_target_dependencies(rmw_fastrtps_cpp
 
 configure_rmw_library(rmw_fastrtps_cpp)
 
-ament_export_libraries(rmw_fastrtps_cpp fastcdr fastrtps ${FastRTPS_LIBRARIES})
+ament_export_libraries(rmw_fastrtps_cpp ${FastRTPS_LIBRARIES})
 if(NOT WIN32 AND NOT ANDROID)
   ament_export_libraries(pthread)
 endif()


### PR DESCRIPTION
This PR ensures that the FastRTPS and FastCDR libraries are exported to downstream packages.

Tested on OSX, before:

```sh
$ otool -L install_isolated/rclcpp_examples/bin/talker__rmw_fastrtps_cpp
install_isolated/rclcpp_examples/bin/talker__rmw_fastrtps_cpp:
        @rpath/librclcpp.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/librcl.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/librcl_interfaces__rosidl_typesupport_cpp.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/librcl_interfaces__rosidl_typesupport_introspection_cpp.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/librcl_interfaces__rosidl_generator_c.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/librcl_interfaces__rosidl_typesupport_introspection_c.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/librmw.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/librmw_fastrtps_cpp.dylib (compatibility version 0.0.0, current version 0.0.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1238.0.0)
        @rpath/libstd_msgs__rosidl_typesupport_introspection_c.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/libstd_msgs__rosidl_generator_c.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/libstd_msgs__rosidl_typesupport_introspection_cpp.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/libstd_msgs__rosidl_typesupport_cpp.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/libbuiltin_interfaces__rosidl_typesupport_cpp.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/libbuiltin_interfaces__rosidl_typesupport_introspection_cpp.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/libbuiltin_interfaces__rosidl_generator_c.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/libbuiltin_interfaces__rosidl_typesupport_introspection_c.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/librosidl_generator_c.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/librosidl_typesupport_introspection_c.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/librosidl_typesupport_introspection_cpp.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/librosidl_typesupport_cpp.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/libexample_interfaces__rosidl_typesupport_introspection_c.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/libexample_interfaces__rosidl_generator_c.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/libexample_interfaces__rosidl_typesupport_introspection_cpp.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/libexample_interfaces__rosidl_typesupport_cpp.dylib (compatibility version 0.0.0, current version 0.0.0)
        /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 307.4.0)
```

After:

<pre>
$ otool -L install_isolated/rclcpp_examples/bin/talker__rmw_fastrtps_cpp  
install_isolated/rclcpp_examples/bin/talker__rmw_fastrtps_cpp:
        @rpath/librclcpp.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/librcl.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/librcl_interfaces__rosidl_typesupport_cpp.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/librcl_interfaces__rosidl_typesupport_introspection_cpp.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/librcl_interfaces__rosidl_generator_c.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/librcl_interfaces__rosidl_typesupport_introspection_c.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/librmw.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/librmw_fastrtps_cpp.dylib (compatibility version 0.0.0, current version 0.0.0)
        <b>libfastrtps.dylib (compatibility version 0.0.0, current version 0.0.0)</b>
        <b>libfastcdr.dylib (compatibility version 0.0.0, current version 0.0.0)</b>
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1238.0.0)
        @rpath/libstd_msgs__rosidl_typesupport_introspection_c.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/libstd_msgs__rosidl_generator_c.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/libstd_msgs__rosidl_typesupport_introspection_cpp.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/libstd_msgs__rosidl_typesupport_cpp.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/libbuiltin_interfaces__rosidl_typesupport_cpp.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/libbuiltin_interfaces__rosidl_typesupport_introspection_cpp.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/libbuiltin_interfaces__rosidl_generator_c.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/libbuiltin_interfaces__rosidl_typesupport_introspection_c.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/librosidl_generator_c.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/librosidl_typesupport_introspection_c.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/librosidl_typesupport_introspection_cpp.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/librosidl_typesupport_cpp.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/libexample_interfaces__rosidl_typesupport_introspection_c.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/libexample_interfaces__rosidl_generator_c.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/libexample_interfaces__rosidl_typesupport_introspection_cpp.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/libexample_interfaces__rosidl_typesupport_cpp.dylib (compatibility version 0.0.0, current version 0.0.0)
        /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 307.4.0)
</pre>