### PR TITLE
Default TTL to 0 and allow setting with env variable

### DIFF
--- a/rmw_fastrtps_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_cpp/CMakeLists.txt
@@ -42,6 +42,29 @@ ament_export_dependencies(rosidl_typesupport_introspection_cpp)
 
 include_directories(include)
 
+# try to compile some test code which uses the TTL field in the UDP
+# transport descriptions so that we can know if we can use it in this package
+try_compile(FAST_RTPS_HAS_TTL_IN_UDP_DESC
+  "${CMAKE_BINARY_DIR}/temp"
+  "${CMAKE_SOURCE_DIR}/compile_tests/test_for_ttl_in_udp_desc.cpp"
+  OUTPUT_VARIABLE FAST_RTPS_HAS_TTL_IN_UDP_DESC__STDOUT
+  LINK_LIBRARIES
+    fastrtps
+  CMAKE_FLAGS
+    "-DINCLUDE_DIRECTORIES=${fastrtps_INCLUDE_DIR}")
+
+if(FAST_RTPS_HAS_TTL_IN_UDP_DESC)
+  message(STATUS "Fast-RTPS has the feature required to default the multicast TTL to 0.")
+  add_definitions(-DRMW_FASTRTPS_FAST_RTPS_HAS_TTL_IN_UDP_DESC)
+else()
+  message(WARNING "Fast-RTPS does not have the feature required to default "
+                  "the multicast TTL to 0, the multicast TTL will default to 1.")
+  # uncomment lines below for debugging the try compile
+  # message(STATUS "\n>>>>>> Begin output from try_compile:")
+  # message(${FAST_RTPS_HAS_TTL_IN_UDP_DESC__STDOUT})
+  # message(STATUS "\n>>>>>> End output from try_compile.")
+endif()
+
 add_library(rmw_fastrtps_cpp SHARED
   src/functions.cpp
 )

--- a/rmw_fastrtps_cpp/compile_tests/test_for_ttl_in_udp_desc.cpp
+++ b/rmw_fastrtps_cpp/compile_tests/test_for_ttl_in_udp_desc.cpp
@@ -1,3 +1,17 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <memory>
 
 #include "fastrtps/transport/UDPv4TransportDescriptor.h"

--- a/rmw_fastrtps_cpp/compile_tests/test_for_ttl_in_udp_desc.cpp
+++ b/rmw_fastrtps_cpp/compile_tests/test_for_ttl_in_udp_desc.cpp
@@ -1,0 +1,16 @@
+#include <memory>
+
+#include "fastrtps/transport/UDPv4TransportDescriptor.h"
+#include "fastrtps/transport/UDPv6TransportDescriptor.h"
+
+int main(void)
+{
+  using eprosima::fastrtps::rtps::UDPv4TransportDescriptor;
+  auto udpv4_transport_desc = std::make_shared<UDPv4TransportDescriptor>();
+  udpv4_transport_desc->TTL = 0;  // may fail to compile
+
+  using eprosima::fastrtps::rtps::UDPv6TransportDescriptor;
+  auto udpv6_transport_desc = std::make_shared<UDPv6TransportDescriptor>();
+  udpv6_transport_desc->TTL = 0;  // may fail to compile
+  return 0;
+}

--- a/rmw_fastrtps_cpp/src/functions.cpp
+++ b/rmw_fastrtps_cpp/src/functions.cpp
@@ -18,6 +18,7 @@
 #include <limits>
 #include <list>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <utility>
 #include <set>

--- a/rmw_fastrtps_cpp/src/functions.cpp
+++ b/rmw_fastrtps_cpp/src/functions.cpp
@@ -14,6 +14,7 @@
 
 #include <cassert>
 #include <condition_variable>
+#include <cstdlib>
 #include <limits>
 #include <list>
 #include <map>
@@ -27,6 +28,7 @@
 #include "rmw/error_handling.h"
 #include "rmw/sanity_checks.h"
 #include "rmw/impl/cpp/macros.hpp"
+#include "rmw/impl/getenv.h"
 #include "rmw_fastrtps_cpp/MessageTypeSupport.h"
 #include "rmw_fastrtps_cpp/ServiceTypeSupport.h"
 
@@ -40,6 +42,8 @@
 #include "fastrtps/subscriber/SubscriberListener.h"
 #include "fastrtps/subscriber/SampleInfo.h"
 #include "fastrtps/attributes/SubscriberAttributes.h"
+#include "fastrtps/transport/UDPv4TransportDescriptor.h"
+#include "fastrtps/transport/UDPv6TransportDescriptor.h"
 
 #include "fastrtps/rtps/RTPSDomain.h"
 #include "fastrtps/rtps/builtin/data/WriterProxyData.h"
@@ -630,6 +634,35 @@ rmw_node_t * rmw_create_node(const char * name, size_t domain_id)
   ParticipantAttributes participantParam;
   participantParam.rtps.builtin.domainId = static_cast<uint32_t>(domain_id);
   participantParam.rtps.setName(name);
+
+#ifdef RMW_FASTRTPS_FAST_RTPS_HAS_TTL_IN_UDP_DESC
+  // Disable the built in transport configurations.
+  participantParam.rtps.useBuiltinTransports = false;
+
+  // Get the TTL level from the RMW_FASTRTPS_TTL_LEVEL env variable if set.
+  const char * rmw_fastrtps_ttl_level_env_value = nullptr;
+  rmw_ret_t rmw_ret = rmw_impl_getenv("RMW_FASTRTPS_TTL_LEVEL", &rmw_fastrtps_ttl_level_env_value);
+  if (rmw_ret != RMW_RET_OK) {
+    return NULL;
+  }
+  auto ttl = 0;  // default to 0
+  std::string rmw_fastrtps_ttl_level_str(rmw_fastrtps_ttl_level_env_value);
+  if (rmw_fastrtps_ttl_level_str != "" && rmw_fastrtps_ttl_level_str != "0") {
+    ttl = std::atoi(rmw_fastrtps_ttl_level_str.c_str());
+  }
+
+  // Create a UDPv4 tranport descriptor and explcitly set the TTL.
+  // Then add it to the list of user transports.
+  auto udpv4_transport_desc = std::make_shared<UDPv4TransportDescriptor>();
+  udpv4_transport_desc->TTL = ttl;
+  participantParam.rtps.userTransports.push_back(udpv4_transport_desc);
+
+  // Create a UDPv6 tranport descriptor and explcitly set the TTL.
+  // Then add it to the list of user transports.
+  auto udpv6_transport_desc = std::make_shared<UDPv6TransportDescriptor>();
+  udpv6_transport_desc->TTL = ttl;
+  participantParam.rtps.userTransports.push_back(udpv6_transport_desc);
+#endif
 
   Participant * participant = Domain::createParticipant(participantParam);
   if (!participant) {


### PR DESCRIPTION
This pr will detect if Fast-RTPS has the feature that allows us to set the TTL for multicast UDP packets, and if it does it will default it to 0 (rather than 1 as it is now) and will allow users to control that setting using the `RMW_FASTRTPS_TTL_LEVEL` environment variable.

The idea behind making the default 0 instead of 1 is to avoid accidentally taking down WiFi networks when people run the camera demo. This will prevent people from using fast rtps across two computers unless they set the TTL to 1 on both machines using the environment variable.

In order for this pr to have any effect we need to either get this pr merged or carry the patch into a fork of Fast-RTPS which we use until it is merged: https://github.com/eProsima/Fast-RTPS/pull/68