### PR TITLE
add option to disable multicast in fastrtps

### DIFF
--- a/rmw_fastrtps_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_cpp/CMakeLists.txt
@@ -33,6 +33,8 @@ find_package(rosidl_typesupport_introspection_c REQUIRED)
 find_package(rosidl_typesupport_introspection_cpp REQUIRED)
 find_package(rosidl_typesupport_cpp REQUIRED)
 
+find_package(Boost REQUIRED)
+
 ament_export_dependencies(rmw)
 ament_export_dependencies(rosidl_generator_c)
 ament_export_dependencies(rosidl_generator_cpp)
@@ -40,13 +42,13 @@ ament_export_dependencies(rosidl_typesupport_cpp)
 ament_export_dependencies(rosidl_typesupport_introspection_c)
 ament_export_dependencies(rosidl_typesupport_introspection_cpp)
 
-include_directories(include)
+include_directories(include ${Boost_INCLUDE_DIRS})
 
 add_library(rmw_fastrtps_cpp SHARED
   src/functions.cpp
 )
 target_link_libraries(rmw_fastrtps_cpp
-  fastcdr fastrtps)
+  fastcdr fastrtps ${Boost_LIBRARIES})
 
 ament_target_dependencies(rmw_fastrtps_cpp
   "rosidl_typesupport_introspection_c"

--- a/rmw_fastrtps_cpp/src/functions.cpp
+++ b/rmw_fastrtps_cpp/src/functions.cpp
@@ -23,11 +23,11 @@
 #include <set>
 #include <string>
 
-#include <boost/date_time.hpp>
-#include <boost/interprocess/allocators/allocator.hpp>
-#include <boost/interprocess/containers/set.hpp>
-#include <boost/interprocess/managed_shared_memory.hpp>
-#include <boost/interprocess/sync/named_mutex.hpp>
+#include "boost/date_time.hpp"
+#include "boost/interprocess/allocators/allocator.hpp"
+#include "boost/interprocess/containers/set.hpp"
+#include "boost/interprocess/managed_shared_memory.hpp"
+#include "boost/interprocess/sync/named_mutex.hpp"
 
 #include "rmw/allocators.h"
 #include "rmw/rmw.h"
@@ -638,7 +638,7 @@ get_loaned_shared_participant_id()
   using bip::open_or_create;
 
   // Create and acquire the mutex.
-  named_mutex named_mtx{open_or_create, "rmw_fastrtps_cpp_pid_mutex"};
+  named_mutex named_mtx {open_or_create, "rmw_fastrtps_cpp_pid_mutex"};
   while (!named_mtx.timed_lock(bpt::microsec_clock::universal_time() + bpt::seconds(1))) {
     fprintf(stderr, "WARNING: failed to lock the named_mutex while getting participant ID\n");
     fprintf(stderr, "  Note: The lock can get stuck when a previous program crashes.\n");
@@ -648,7 +648,7 @@ get_loaned_shared_participant_id()
   }
 
   // Create or open the shared memory and find an unused participant ID.
-  managed_shared_memory segment{open_or_create, "rmw_fastrtps_cpp", 1024};
+  managed_shared_memory segment {open_or_create, "rmw_fastrtps_cpp", 1024};
   typedef bip::allocator<int32_t, managed_shared_memory::segment_manager> Int32ShmemAllocator;
   typedef bip::set<int32_t, std::less<int32_t>, Int32ShmemAllocator> Int32ShmemSet;
 
@@ -679,7 +679,7 @@ return_loaned_shared_participant_id(int32_t participant_id)
   using bip::shared_memory_object;
 
   // Create and acquire the mutex.
-  named_mutex named_mtx{open_or_create, "rmw_fastrtps_cpp_pid_mutex"};
+  named_mutex named_mtx {open_or_create, "rmw_fastrtps_cpp_pid_mutex"};
   while (!named_mtx.timed_lock(bpt::microsec_clock::universal_time() + bpt::seconds(1))) {
     fprintf(stderr, "WARNING: failed to lock the named_mutex while getting participant ID\n");
     fprintf(stderr, "  Note: The lock can get stuck when a previous program crashes.\n");
@@ -689,7 +689,7 @@ return_loaned_shared_participant_id(int32_t participant_id)
   }
 
   // Create or open the shared memory and return the participant ID.
-  managed_shared_memory segment{open_or_create, "rmw_fastrtps_cpp", 1024};
+  managed_shared_memory segment {open_or_create, "rmw_fastrtps_cpp", 1024};
   typedef bip::allocator<int32_t, managed_shared_memory::segment_manager> Int32ShmemAllocator;
   typedef bip::set<int32_t, std::less<int32_t>, Int32ShmemAllocator> Int32ShmemSet;
 
@@ -756,16 +756,16 @@ rmw_node_t * rmw_create_node(const char * name, size_t domain_id)
       // Disable multicast by explicitly listing only unicast locators.
       LocatorList_t loclist;
       IPFinder::getIP4Address(&loclist);
-      for(auto it = loclist.begin(); it != loclist.end(); ++it) {
-          (*it).port = (
-            participantParam.rtps.port.portBase +
-            participantParam.rtps.port.domainIDGain * participantParam.rtps.builtin.domainId +
-            participantParam.rtps.port.offsetd3 +
-            participantParam.rtps.port.participantIDGain * participantParam.rtps.participantID
+      for (auto it = loclist.begin(); it != loclist.end(); ++it) {
+        (*it).port = (
+          participantParam.rtps.port.portBase +
+          participantParam.rtps.port.domainIDGain * participantParam.rtps.builtin.domainId +
+          participantParam.rtps.port.offsetd3 +
+          participantParam.rtps.port.participantIDGain * participantParam.rtps.participantID
           );
-          (*it).kind = LOCATOR_KIND_UDPv4;
+        (*it).kind = LOCATOR_KIND_UDPv4;
 
-          participantParam.rtps.defaultUnicastLocatorList.push_back((*it));
+        participantParam.rtps.defaultUnicastLocatorList.push_back((*it));
       }
     }
   }

--- a/rmw_fastrtps_cpp/src/functions.cpp
+++ b/rmw_fastrtps_cpp/src/functions.cpp
@@ -14,6 +14,7 @@
 
 #include <cassert>
 #include <condition_variable>
+#include <functional>
 #include <limits>
 #include <list>
 #include <map>
@@ -21,6 +22,12 @@
 #include <utility>
 #include <set>
 #include <string>
+
+#include <boost/date_time.hpp>
+#include <boost/interprocess/allocators/allocator.hpp>
+#include <boost/interprocess/containers/set.hpp>
+#include <boost/interprocess/managed_shared_memory.hpp>
+#include <boost/interprocess/sync/named_mutex.hpp>
 
 #include "rmw/allocators.h"
 #include "rmw/rmw.h"
@@ -618,6 +625,93 @@ rmw_ret_t rmw_init()
   return RMW_RET_OK;
 }
 
+inline
+int32_t
+get_loaned_shared_participant_id()
+{
+  namespace bip = boost::interprocess;
+  namespace bpt = boost::posix_time;
+  using bip::managed_shared_memory;
+  using bip::named_mutex;
+  using bip::open_or_create;
+
+  // Create and acquire the mutex.
+  named_mutex named_mtx{open_or_create, "rmw_fastrtps_cpp_pid_mutex"};
+  while (!named_mtx.timed_lock(bpt::microsec_clock::universal_time() + bpt::seconds(1))) {
+    fprintf(stderr, "WARNING: failed to lock the named_mutex while getting participant ID\n");
+    fprintf(stderr, "  Note: The lock can get stuck when a previous program crashes.\n");
+    fprintf(stderr, "  Note: If this message appears repeatedly, something else is wrong.\n");
+    fprintf(stderr, "  Could not get the lock after waiting 1 second, unlocking to retry.\n");
+    named_mtx.unlock();
+  }
+
+  // Create or open the shared memory and find an unused participant ID.
+  managed_shared_memory segment{open_or_create, "rmw_fastrtps_cpp", 1024};
+  typedef bip::allocator<int32_t, managed_shared_memory::segment_manager> Int32ShmemAllocator;
+  typedef bip::set<int32_t, std::less<int32_t>, Int32ShmemAllocator> Int32ShmemSet;
+
+  const Int32ShmemAllocator alloc_inst(segment.get_segment_manager());
+  Int32ShmemSet * participant_ids =
+    segment.find_or_construct<Int32ShmemSet>("participant_ids")(alloc_inst);
+
+  int32_t candidate_participant_id = 0;
+  while (participant_ids->find(candidate_participant_id) != participant_ids->end()) {
+    candidate_participant_id += 1;
+  }
+  participant_ids->insert(candidate_participant_id);
+
+  // Release the mutex.
+  named_mtx.unlock();
+  return candidate_participant_id;
+}
+
+inline
+void
+return_loaned_shared_participant_id(int32_t participant_id)
+{
+  namespace bip = boost::interprocess;
+  namespace bpt = boost::posix_time;
+  using bip::managed_shared_memory;
+  using bip::named_mutex;
+  using bip::open_or_create;
+  using bip::shared_memory_object;
+
+  // Create and acquire the mutex.
+  named_mutex named_mtx{open_or_create, "rmw_fastrtps_cpp_pid_mutex"};
+  while (!named_mtx.timed_lock(bpt::microsec_clock::universal_time() + bpt::seconds(1))) {
+    fprintf(stderr, "WARNING: failed to lock the named_mutex while getting participant ID\n");
+    fprintf(stderr, "  Note: The lock can get stuck when a previous program crashes.\n");
+    fprintf(stderr, "  Note: If this message appears repeatedly, something else is wrong.\n");
+    fprintf(stderr, "  Could not get the lock after waiting 1 second, unlocking to retry.\n");
+    named_mtx.unlock();
+  }
+
+  // Create or open the shared memory and return the participant ID.
+  managed_shared_memory segment{open_or_create, "rmw_fastrtps_cpp", 1024};
+  typedef bip::allocator<int32_t, managed_shared_memory::segment_manager> Int32ShmemAllocator;
+  typedef bip::set<int32_t, std::less<int32_t>, Int32ShmemAllocator> Int32ShmemSet;
+
+  const Int32ShmemAllocator alloc_inst(segment.get_segment_manager());
+  Int32ShmemSet * participant_ids =
+    segment.find_or_construct<Int32ShmemSet>("participant_ids")(alloc_inst);
+
+  if (participant_ids->find(participant_id) == participant_ids->end()) {
+    fprintf(stderr,
+      "Trying to return a participant id (%d) which is not currently loaned.\n", participant_id);
+    return;
+  }
+  participant_ids->erase(participant_id);
+
+  // If the loaned participant ids is empty, no one else is using it, remove it.
+  if (participant_ids->empty()) {
+    // Nobody is using it anymore, remove the memory object.
+    shared_memory_object::remove("rmw_fastrtps_cpp");
+  }
+
+  // Release the mutex.
+  named_mtx.unlock();
+}
+
 rmw_node_t * rmw_create_node(const char * name, size_t domain_id)
 {
   if (!name) {
@@ -630,6 +724,13 @@ rmw_node_t * rmw_create_node(const char * name, size_t domain_id)
   ParticipantAttributes participantParam;
   participantParam.rtps.builtin.domainId = static_cast<uint32_t>(domain_id);
   participantParam.rtps.setName(name);
+
+  {
+    // fast-rtps does not make system wide, unique participant id's,
+    // so we ensure one for them.
+    // TODO(wjwwood): remove this when Fast-RTPS creates unique participant id's.
+    participantParam.rtps.participantID = get_loaned_shared_participant_id();
+  }
 
   Participant * participant = Domain::createParticipant(participantParam);
   if (!participant) {
@@ -715,6 +816,7 @@ rmw_ret_t rmw_destroy_node(rmw_node_t * node)
   }
 
   Participant * participant = impl->participant;
+  int32_t participant_id = participant->getAttributes().rtps.participantID;
 
   std::pair<StatefulReader *, StatefulReader *> EDPReaders = participant->getEDPReaders();
   EDPReaders.first->setListener(nullptr);
@@ -729,6 +831,7 @@ rmw_ret_t rmw_destroy_node(rmw_node_t * node)
   }
 
   Domain::removeParticipant(participant);
+  return_loaned_shared_participant_id(participant_id);
 
   delete (impl);
   if (node->name) {


### PR DESCRIPTION
So, based on the feedback from @codebot with respect to https://github.com/ros2/rmw_fastrtps/pull/79, I set out to disable multicast in fastrtps (or provide an option to do so). This pr is trying to do that, but along the way I ran into some serious issues and I'm not sure we should spend the time to merge this at this point.

----

My goal was to disable multicast to avoid the issue of disrupting your WiFi when running the image demo on your laptop due to lots of multicast data going nowhere. Also, my goal was do this while avoiding changes to Fast-RTPS so that we didn't have to maintain a patch for the beta release.

I was able to disable the multicast (with some duplication of code from Fast-RTPS), but the issue I ran into at that point was that the participant id's generated by Fast-RTPS are only unique within a single process. The issue with that is that the participant id is the most important factor used to calculate the unicast port for communication. Since the participant ids were duplicated within different processes, more than one process would try to use the same UDP port and one would silently fail to listen on that port. Combined with the silent failure to acquire the overlapping port in all processes, the issue was masked because data could always be delivered by the multicast communication. When I removed the multicast locator and disabled multicast for topics, the talker listener example stopped working. @codebot and I figured out that the port was the issue by looking at wireshark and then that duplicate participant ids were the root cause of the problem.

I was able to hack the talker and listener without multicast back to working by adding random numbers to the participant id. So I tried to figure out how to address this problem without modifying Fast-RTPS, and I thought I could address the issue by explicitly setting the participant id (which is possible) and ensuring those ids were unique for participants on the same computer. @codebot showed me how he did this in freertps by trying ports until he found a participant/port combination which were free. I wanted to do this, but because Fast-RTPS did not fail when the port was not available I could not easily do this without a race condition.

So I ended up trying to solve this by using `boost::interprocess` and that's what is in this pr. I use a `named_mutex` and a `shared_memory_object` containing the equivalent of a `std::set`. I used the set to keep track of which participant ids were in use and the mutex to protect access to the shared memory. There are some drawbacks to this approach and I only intended this for a short term solution until we could get a proper fix into Fast-RTPS, but I thought the issues would be manageable. However, once I started testing on the build farm I started running into bad_alloc's associated with the shared memory. So something is wrong with the implementation and I don't think I have time to address them before the beta. I just opened this pr for anyone who was interested in what I had come up with.

I think it's important to point out that without some kind of patch unicast pub/sub does not work between two processes on the same computer with Fast-RTPS at all. It works between different computers because they don't share a port number pool with each other, i.e. they are namespaced by ip address.

----

At this point I don't know what to do in order to address this issue of multicast interfering with WiFi even when running demos all on one computer. I'm open to suggestions as to what we could do between now and the beta which would address this problem. I think my other patch in https://github.com/ros2/rmw_fastrtps/pull/79 is still viable, but I guess it was deemed too intrusive at this late time.

----

This pr also uses https://github.com/ros2/rcl/pull/97 and https://github.com/ros2/rmw/pull/87 so that a "getenv" function is available at a lower level than `rcl`.

In this implementation, you could disable multicast by setting the env variable `RMW_FASTRTPS_DISABLE_MULTICAST` to any value. I could easily invert the logic if we wanted to.