### PR TITLE
Refactor to isolate C and C++ specializations

### DIFF
--- a/fastrtps_cmake_module/cmake/Modules/FindFastRTPS.cmake
+++ b/fastrtps_cmake_module/cmake/Modules/FindFastRTPS.cmake
@@ -64,13 +64,6 @@ endif()
 find_path(FastRTPS_INCLUDE_DIR
     NAMES fastrtps/)
 
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(FastRTPS
-  FOUND_VAR FastRTPS_FOUND
-  REQUIRED_VARS
-    FastRTPS_INCLUDE_DIR
-)
-
 find_library(FastRTPS_LIBRARY
     NAMES fastrtps)
 
@@ -78,3 +71,13 @@ find_library(FastCDR_LIBRARY
     NAMES fastcdr)
 
 set(FastRTPS_LIBRARIES ${FastRTPS_LIBRARY} ${FastCDR_LIBRARY})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(FastRTPS
+  FOUND_VAR FastRTPS_FOUND
+  REQUIRED_VARS
+    FastRTPS_INCLUDE_DIR
+    FastCDR_LIBRARY
+    FastRTPS_LIBRARY
+    FastRTPS_LIBRARIES
+)

--- a/fastrtps_cmake_module/cmake/Modules/FindFastRTPS.cmake
+++ b/fastrtps_cmake_module/cmake/Modules/FindFastRTPS.cmake
@@ -70,3 +70,11 @@ find_package_handle_standard_args(FastRTPS
   REQUIRED_VARS
     FastRTPS_INCLUDE_DIR
 )
+
+find_library(FastRTPS_LIBRARY
+    NAMES fastrtps)
+
+find_library(FastCDR_LIBRARY
+    NAMES fastcdr)
+
+set(FastRTPS_LIBRARIES ${FastRTPS_LIBRARY} ${FastCDR_LIBRARY})

--- a/rmw_fastrtps_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_cpp/CMakeLists.txt
@@ -25,6 +25,7 @@ find_package(ament_cmake REQUIRED)
 find_package(fastrtps_cmake_module REQUIRED)
 find_package(fastcdr REQUIRED CONFIG)
 find_package(fastrtps REQUIRED CONFIG)
+find_package(FastRTPS REQUIRED MODULE)
 
 find_package(rmw REQUIRED)
 find_package(rosidl_generator_c REQUIRED)
@@ -55,7 +56,7 @@ ament_target_dependencies(rmw_fastrtps_cpp
 
 configure_rmw_library(rmw_fastrtps_cpp)
 
-ament_export_libraries(rmw_fastrtps_cpp fastcdr fastrtps)
+ament_export_libraries(rmw_fastrtps_cpp fastcdr fastrtps ${FastRTPS_LIBRARIES})
 if(NOT WIN32 AND NOT ANDROID)
   ament_export_libraries(pthread)
 endif()

--- a/rmw_fastrtps_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_cpp/CMakeLists.txt
@@ -41,29 +41,31 @@ ament_export_dependencies(rosidl_typesupport_introspection_cpp)
 
 include_directories(include)
 
-add_library(rmw_fastrtps_cpp SHARED
+add_library(${PROJECT_NAME} SHARED
   src/functions.cpp
+  src/functions_impl_cpp.cpp
 )
-target_link_libraries(rmw_fastrtps_cpp
+target_link_libraries(${PROJECT_NAME}
   fastcdr fastrtps)
 
-ament_target_dependencies(rmw_fastrtps_cpp
+ament_target_dependencies(${PROJECT_NAME}
   "rosidl_typesupport_introspection_c"
   "rosidl_typesupport_introspection_cpp"
   "rmw"
   "rosidl_generator_c"
   "rosidl_generator_cpp")
 
-configure_rmw_library(rmw_fastrtps_cpp)
+configure_rmw_library(${PROJECT_NAME})
 
-ament_export_libraries(rmw_fastrtps_cpp fastcdr fastrtps ${FastRTPS_LIBRARIES})
+ament_export_libraries(${PROJECT_NAME} fastcdr fastrtps ${FastRTPS_LIBRARIES})
 if(NOT WIN32 AND NOT ANDROID)
   ament_export_libraries(pthread)
 endif()
 
 register_rmw_implementation(
   "c:rosidl_typesupport_c:rosidl_typesupport_introspection_c"
-  "cpp:rosidl_typesupport_cpp:rosidl_typesupport_introspection_cpp")
+  "cpp:rosidl_typesupport_cpp:rosidl_typesupport_introspection_cpp"
+)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
@@ -78,7 +80,7 @@ install(
 )
 
 install(
-  TARGETS rmw_fastrtps_cpp
+  TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/MessageTypeSupport.h
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/MessageTypeSupport.h
@@ -22,10 +22,8 @@
 #include <memory>
 
 #include "TypeSupport.h"
-#include "rosidl_typesupport_introspection_cpp/message_introspection.hpp"
-#include "rosidl_typesupport_introspection_cpp/field_types.hpp"
 
-namespace rmw_fastrtps_cpp
+namespace rmw_fastrtps_common
 {
 
 template<typename MembersType>
@@ -35,7 +33,7 @@ public:
   explicit MessageTypeSupport(const MembersType * members);
 };
 
-}  // namespace rmw_fastrtps_cpp
+}  // namespace rmw_fastrtps_common
 
 #include "MessageTypeSupport_impl.h"
 

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/MessageTypeSupport_impl.h
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/MessageTypeSupport_impl.h
@@ -23,9 +23,8 @@
 #include <string>
 
 #include "rmw_fastrtps_cpp/MessageTypeSupport.h"
-#include "rosidl_typesupport_introspection_cpp/field_types.hpp"
 
-namespace rmw_fastrtps_cpp
+namespace rmw_fastrtps_common
 {
 
 template<typename MembersType>
@@ -47,6 +46,6 @@ MessageTypeSupport<MembersType>::MessageTypeSupport(const MembersType * members)
   }
 }
 
-}  // namespace rmw_fastrtps_cpp
+}  // namespace rmw_fastrtps_common
 
 #endif  // RMW_FASTRTPS_CPP__MESSAGETYPESUPPORT_IMPL_H_

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/ServiceTypeSupport.h
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/ServiceTypeSupport.h
@@ -20,11 +20,10 @@
 #include <cassert>
 
 #include "TypeSupport.h"
-#include "rosidl_typesupport_introspection_cpp/field_types.hpp"
 
 struct CustomServiceInfo;
 
-namespace rmw_fastrtps_cpp
+namespace rmw_fastrtps_common
 {
 
 template<typename MembersType>
@@ -48,7 +47,7 @@ public:
   explicit ResponseTypeSupport(const ServiceMembersType * members);
 };
 
-}  // namespace rmw_fastrtps_cpp
+}  // namespace rmw_fastrtps_common
 
 #include "ServiceTypeSupport_impl.h"
 

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/ServiceTypeSupport_impl.h
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/ServiceTypeSupport_impl.h
@@ -21,9 +21,8 @@
 #include <string>
 
 #include "rmw_fastrtps_cpp/ServiceTypeSupport.h"
-#include "rosidl_typesupport_introspection_cpp/field_types.hpp"
 
-namespace rmw_fastrtps_cpp
+namespace rmw_fastrtps_common
 {
 
 template<typename MembersType>
@@ -71,6 +70,6 @@ ResponseTypeSupport<ServiceMembersType, MessageMembersType>::ResponseTypeSupport
   }
 }
 
-}  // namespace rmw_fastrtps_cpp
+}  // namespace rmw_fastrtps_common
 
 #endif  // RMW_FASTRTPS_CPP__SERVICETYPESUPPORT_IMPL_H_

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport.h
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport.h
@@ -25,81 +25,13 @@
 #include <cassert>
 #include <string>
 
-#include "rosidl_typesupport_introspection_cpp/field_types.hpp"
-#include "rosidl_typesupport_introspection_cpp/identifier.hpp"
-#include "rosidl_typesupport_introspection_cpp/message_introspection.hpp"
-#include "rosidl_typesupport_introspection_cpp/service_introspection.hpp"
-#include "rosidl_typesupport_introspection_cpp/visibility_control.h"
-
-#include "rosidl_typesupport_introspection_c/field_types.h"
-#include "rosidl_typesupport_introspection_c/identifier.h"
-#include "rosidl_typesupport_introspection_c/message_introspection.h"
-#include "rosidl_typesupport_introspection_c/service_introspection.h"
-#include "rosidl_typesupport_introspection_c/visibility_control.h"
-
-namespace rmw_fastrtps_cpp
+namespace rmw_fastrtps_common
 {
 
 // Helper class that uses template specialization to read/write string types to/from a
 // eprosima::fastcdr::Cdr
 template<typename MembersType>
-struct StringHelper;
-
-// For C introspection typesupport we create intermediate instances of std::string so that
-// eprosima::fastcdr::Cdr can handle the string properly.
-template<>
-struct StringHelper<rosidl_typesupport_introspection_c__MessageMembers>
-{
-  using type = rosidl_generator_c__String;
-
-  static std::string convert_to_std_string(void * data)
-  {
-    auto c_string = static_cast<rosidl_generator_c__String *>(data);
-    if (!c_string) {
-      fprintf(stderr, "Failed to cast data as rosidl_generator_c__String\n");
-      return "";
-    }
-    if (!c_string->data) {
-      fprintf(stderr, "rosidl_generator_c_String had invalid data\n");
-      return "";
-    }
-    return std::string(c_string->data);
-  }
-
-  static std::string convert_to_std_string(rosidl_generator_c__String & data)
-  {
-    return std::string(data.data);
-  }
-
-  static void assign(eprosima::fastcdr::Cdr & deser, void * field, bool)
-  {
-    std::string str;
-    deser >> str;
-    rosidl_generator_c__String * c_str = static_cast<rosidl_generator_c__String *>(field);
-    rosidl_generator_c__String__assign(c_str, str.c_str());
-  }
-};
-
-// For C++ introspection typesupport we just reuse the same std::string transparently.
-template<>
-struct StringHelper<rosidl_typesupport_introspection_cpp::MessageMembers>
-{
-  using type = std::string;
-
-  static std::string & convert_to_std_string(void * data)
-  {
-    return *(static_cast<std::string *>(data));
-  }
-
-  static void assign(eprosima::fastcdr::Cdr & deser, void * field, bool call_new)
-  {
-    std::string & str = *(std::string *)field;
-    if (call_new) {
-      new(&str) std::string;
-    }
-    deser >> str;
-  }
-};
+struct TypeSupportHelper;
 
 template<typename MembersType>
 class TypeSupport : public eprosima::fastrtps::TopicDataType
@@ -134,8 +66,6 @@ private:
     void * ros_message, bool call_new);
 };
 
-}  // namespace rmw_fastrtps_cpp
-
-#include "TypeSupport_impl.h"
+}  // namespace rmw_fastrtps_common
 
 #endif  // RMW_FASTRTPS_CPP__TYPESUPPORT_H_

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport_impl.h
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport_impl.h
@@ -21,85 +21,51 @@
 #include <string>
 #include <vector>
 
-#include "rmw_fastrtps_cpp/TypeSupport.h"
-#include "rmw_fastrtps_cpp/macros.hpp"
-#include "rosidl_typesupport_introspection_cpp/field_types.hpp"
-#include "rosidl_typesupport_introspection_cpp/message_introspection.hpp"
-#include "rosidl_typesupport_introspection_cpp/service_introspection.hpp"
+#include "rmw/rmw.h"
+#include "rmw/error_handling.h"
 
-#include "rosidl_typesupport_introspection_c/message_introspection.h"
-#include "rosidl_typesupport_introspection_c/service_introspection.h"
+#include "rmw_fastrtps_cpp/macros.hpp"
+#include "rosidl_typesupport_introspection_c/field_types.h"
 
 #include "rosidl_generator_c/primitives_array_functions.h"
 
-namespace rmw_fastrtps_cpp
+namespace rmw_fastrtps_common
 {
-
-template<typename T>
-struct GenericCArray;
-
-// multiple definitions of ambiguous primitive types
-SPECIALIZE_GENERIC_C_ARRAY(bool, bool)
-SPECIALIZE_GENERIC_C_ARRAY(byte, uint8_t)
-SPECIALIZE_GENERIC_C_ARRAY(char, char)
-SPECIALIZE_GENERIC_C_ARRAY(float32, float)
-SPECIALIZE_GENERIC_C_ARRAY(float64, double)
-SPECIALIZE_GENERIC_C_ARRAY(int8, int8_t)
-SPECIALIZE_GENERIC_C_ARRAY(int16, int16_t)
-SPECIALIZE_GENERIC_C_ARRAY(uint16, uint16_t)
-SPECIALIZE_GENERIC_C_ARRAY(int32, int32_t)
-SPECIALIZE_GENERIC_C_ARRAY(uint32, uint32_t)
-SPECIALIZE_GENERIC_C_ARRAY(int64, int64_t)
-SPECIALIZE_GENERIC_C_ARRAY(uint64, uint64_t)
-
-typedef struct rosidl_generator_c__void__Array
+template<typename MembersType>
+inline std::string
+_create_type_name(
+  const void * untyped_members,
+  const std::string & sep)
 {
-  void * data;
-  /// The number of valid items in data
-  size_t size;
-  /// The number of allocated items in data
-  size_t capacity;
-} rosidl_generator_c__void__Array;
-
-bool
-rosidl_generator_c__void__Array__init(
-  rosidl_generator_c__void__Array * array, size_t size, size_t member_size)
-{
-  if (!array) {
-    return false;
+  auto members = static_cast<const MembersType *>(untyped_members);
+  if (!members) {
+    RMW_SET_ERROR_MSG("members handle is null");
+    return "";
   }
-  void * data = NULL;
-  if (size) {
-    data = (void *)calloc(size, member_size);
-    if (!data) {
-      return false;
-    }
-  }
-  array->data = data;
-  array->size = size;
-  array->capacity = size;
-  return true;
+  return
+    std::string(members->package_name_) + "::" + sep + "::dds_::" + members->message_name_ + "_";
 }
 
-void
-rosidl_generator_c__void__Array__fini(rosidl_generator_c__void__Array * array)
+template<typename ServiceType>
+const void * get_request_ptr(const void * untyped_service_members)
 {
-  if (!array) {
-    return;
+  auto service_members = static_cast<const ServiceType *>(untyped_service_members);
+  if (!service_members) {
+    RMW_SET_ERROR_MSG("service members handle is null");
+    return NULL;
   }
-  if (array->data) {
-    // ensure that data and capacity values are consistent
-    assert(array->capacity > 0);
-    // finalize all array elements
-    free(array->data);
-    array->data = NULL;
-    array->size = 0;
-    array->capacity = 0;
-  } else {
-    // ensure that data, size, and capacity values are consistent
-    assert(0 == array->size);
-    assert(0 == array->capacity);
+  return service_members->request_members_;
+}
+
+template<typename ServiceType>
+const void * get_response_ptr(const void * untyped_service_members)
+{
+  auto service_members = static_cast<const ServiceType *>(untyped_service_members);
+  if (!service_members) {
+    RMW_SET_ERROR_MSG("service members handle is null");
+    return NULL;
   }
+  return service_members->response_members_;
 }
 
 template<typename MembersType>
@@ -142,53 +108,47 @@ static size_t calculateMaxAlign(const MembersType * members)
       alignment = alignof(std::vector<unsigned char>);
     } else {
       switch (member.type_id_) {
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_BOOL:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_BOOL:
           alignment = alignof(bool);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_BYTE:
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT8:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_BYTE:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_UINT8:
           alignment = alignof(uint8_t);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_CHAR:
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT8:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_CHAR:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_INT8:
           alignment = alignof(char);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_FLOAT32:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_FLOAT32:
           alignment = alignof(float);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_FLOAT64:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_FLOAT64:
           alignment = alignof(double);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT16:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_INT16:
           alignment = alignof(int16_t);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT16:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_UINT16:
           alignment = alignof(uint16_t);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT32:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_INT32:
           alignment = alignof(int32_t);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT32:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_UINT32:
           alignment = alignof(uint32_t);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT64:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_INT64:
           alignment = alignof(int64_t);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT64:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_UINT64:
           alignment = alignof(uint64_t);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_STRING:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_STRING:
           // Note: specialization needed because calculateMaxAlign is called before
           // casting submembers as std::string, returned value is the same on i386
-          if (std::is_same<MembersType,
-            rosidl_typesupport_introspection_c__MessageMembers>::value)
-          {
-            alignment = alignof(rosidl_generator_c__String);
-          } else {
-            alignment = alignof(std::string);
-          }
+          alignment = TypeSupportHelper<MembersType>::string_alignment;
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_MESSAGE:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_MESSAGE:
           {
             const MembersType * sub_members = (const MembersType *)member.members_->data;
             alignment = calculateMaxAlign(sub_members);
@@ -216,51 +176,45 @@ static size_t size_of(const MembersType * members)
     size = sizeof(std::vector<unsigned char>);
   } else {
     switch (last_member.type_id_) {
-      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_BOOL:
+      case rosidl_typesupport_introspection_c__ROS_TYPE_BOOL:
         size = sizeof(bool);
         break;
-      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_BYTE:
-      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT8:
+      case rosidl_typesupport_introspection_c__ROS_TYPE_BYTE:
+      case rosidl_typesupport_introspection_c__ROS_TYPE_UINT8:
         size = sizeof(uint8_t);
         break;
-      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_CHAR:
-      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT8:
+      case rosidl_typesupport_introspection_c__ROS_TYPE_CHAR:
+      case rosidl_typesupport_introspection_c__ROS_TYPE_INT8:
         size = sizeof(char);
         break;
-      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_FLOAT32:
+      case rosidl_typesupport_introspection_c__ROS_TYPE_FLOAT32:
         size = sizeof(float);
         break;
-      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_FLOAT64:
+      case rosidl_typesupport_introspection_c__ROS_TYPE_FLOAT64:
         size = sizeof(double);
         break;
-      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT16:
+      case rosidl_typesupport_introspection_c__ROS_TYPE_INT16:
         size = sizeof(int16_t);
         break;
-      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT16:
+      case rosidl_typesupport_introspection_c__ROS_TYPE_UINT16:
         size = sizeof(uint16_t);
         break;
-      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT32:
+      case rosidl_typesupport_introspection_c__ROS_TYPE_INT32:
         size = sizeof(int32_t);
         break;
-      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT32:
+      case rosidl_typesupport_introspection_c__ROS_TYPE_UINT32:
         size = sizeof(uint32_t);
         break;
-      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT64:
+      case rosidl_typesupport_introspection_c__ROS_TYPE_INT64:
         size = sizeof(int64_t);
         break;
-      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT64:
+      case rosidl_typesupport_introspection_c__ROS_TYPE_UINT64:
         size = sizeof(uint64_t);
         break;
-      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_STRING:
-        // Note: specialization needed because size_of is called before
-        // casting submembers as std::string
-        if (std::is_same<MembersType, rosidl_typesupport_introspection_c__MessageMembers>::value) {
-          size = sizeof(rosidl_generator_c__String);
-        } else {
-          size = sizeof(std::string);
-        }
+      case rosidl_typesupport_introspection_c__ROS_TYPE_STRING:
+        size = TypeSupportHelper<MembersType>::string_size;
         break;
-      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_MESSAGE:
+      case rosidl_typesupport_introspection_c__ROS_TYPE_MESSAGE:
         {
           const MembersType * sub_members = (const MembersType *)last_member.members_->data;
           size = size_of(sub_members);
@@ -276,97 +230,6 @@ static size_t size_of(const MembersType * members)
   return last_member.offset_ + size;
 }
 
-// C++ specialization
-template<typename T>
-void serialize_array(
-  const rosidl_typesupport_introspection_cpp::MessageMember * member,
-  void * field,
-  eprosima::fastcdr::Cdr & ser)
-{
-  if (member->array_size_ && !member->is_upper_bound_) {
-    ser.serializeArray(static_cast<T *>(field), member->array_size_);
-  } else {
-    std::vector<T> & data = *reinterpret_cast<std::vector<T> *>(field);
-    ser << data;
-  }
-}
-
-// C specialization
-template<typename T>
-void serialize_array(
-  const rosidl_typesupport_introspection_c__MessageMember * member,
-  void * field,
-  eprosima::fastcdr::Cdr & ser)
-{
-  if (member->array_size_ && !member->is_upper_bound_) {
-    ser.serializeArray(static_cast<T *>(field), member->array_size_);
-  } else {
-    auto & data = *reinterpret_cast<typename GenericCArray<T>::type *>(field);
-    ser.serializeSequence(static_cast<T *>(data.data), data.size);
-  }
-}
-
-template<>
-void serialize_array<std::string>(
-  const rosidl_typesupport_introspection_c__MessageMember * member,
-  void * field,
-  eprosima::fastcdr::Cdr & ser)
-{
-  using CStringHelper = StringHelper<rosidl_typesupport_introspection_c__MessageMembers>;
-  // First, cast field to rosidl_generator_c
-  // Then convert to a std::string using StringHelper and serialize the std::string
-  if (member->array_size_ && !member->is_upper_bound_) {
-    // tmpstring is defined here and not below to avoid
-    // memory allocation in every iteration of the for loop
-    std::string tmpstring;
-    auto string_field = (rosidl_generator_c__String *) field;
-    for (size_t i = 0; i < member->array_size_; ++i) {
-      tmpstring = string_field[i].data;
-      ser.serialize(tmpstring);
-    }
-  } else {
-    auto & string_array_field = *reinterpret_cast<rosidl_generator_c__String__Array *>(field);
-    std::vector<std::string> cpp_string_vector;
-    for (size_t i = 0; i < string_array_field.size; ++i) {
-      cpp_string_vector.push_back(
-        CStringHelper::convert_to_std_string(string_array_field.data[i]));
-    }
-    ser << cpp_string_vector;
-  }
-}
-
-size_t get_array_size_and_assign_field(
-  const rosidl_typesupport_introspection_cpp::MessageMember * member,
-  void * field,
-  void * & subros_message,
-  size_t sub_members_size,
-  size_t max_align,
-  size_t space)
-{
-  std::vector<unsigned char> * vector = reinterpret_cast<std::vector<unsigned char> *>(field);
-  void * ptr = (void *)sub_members_size;
-  size_t vsize = vector->size() / (size_t)align_(max_align, 0, ptr, space);
-  if (member->is_upper_bound_ && vsize > member->array_size_) {
-    throw std::runtime_error("vector overcomes the maximum length");
-  }
-  subros_message = reinterpret_cast<void *>(vector->data());
-  return vsize;
-}
-
-size_t get_array_size_and_assign_field(
-  const rosidl_typesupport_introspection_c__MessageMember * member,
-  void * field,
-  void * & subros_message,
-  size_t, size_t, size_t)
-{
-  rosidl_generator_c__void__Array * tmparray = (rosidl_generator_c__void__Array *) field;
-  if (member->is_upper_bound_ && tmparray->size > member->array_size_) {
-    throw std::runtime_error("vector overcomes the maximum length");
-  }
-  subros_message = reinterpret_cast<void *>(tmparray->data);
-  return tmparray->size;
-}
-
 template<typename MembersType>
 bool TypeSupport<MembersType>::serializeROSmessage(
   eprosima::fastcdr::Cdr & ser, const MembersType * members, const void * ros_message)
@@ -380,7 +243,7 @@ bool TypeSupport<MembersType>::serializeROSmessage(
 
     if (!member->is_array_) {
       switch (member->type_id_) {
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_BOOL:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_BOOL:
           {
             bool sb = false;
             // don't cast to bool here because if the bool is
@@ -389,41 +252,41 @@ bool TypeSupport<MembersType>::serializeROSmessage(
             ser << sb;
           }
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_BYTE:
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT8:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_BYTE:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_UINT8:
           ser << *(uint8_t *)field;
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_CHAR:
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT8:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_CHAR:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_INT8:
           ser << *(char *)field;
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_FLOAT32:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_FLOAT32:
           ser << *(float *)field;
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_FLOAT64:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_FLOAT64:
           ser << *(double *)field;
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT16:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_INT16:
           ser << *(int16_t *)field;
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT16:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_UINT16:
           ser << *(uint16_t *)field;
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT32:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_INT32:
           ser << *(int32_t *)field;
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT32:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_UINT32:
           ser << *(uint32_t *)field;
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT64:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_INT64:
           ser << *(int64_t *)field;
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT64:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_UINT64:
           ser << *(uint64_t *)field;
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_STRING:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_STRING:
           {
-            auto && str = StringHelper<MembersType>::convert_to_std_string(field);
+            auto && str = TypeSupportHelper<MembersType>::convert_to_std_string(field);
 
             // Control maximum length.
             if (member->string_upper_bound_ && str.length() > member->string_upper_bound_ + 1) {
@@ -432,7 +295,7 @@ bool TypeSupport<MembersType>::serializeROSmessage(
             ser << str;
           }
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_MESSAGE:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_MESSAGE:
           {
             const MembersType * sub_members = (const MembersType *)member->members_->data;
             serializeROSmessage(ser, sub_members, field);
@@ -443,45 +306,45 @@ bool TypeSupport<MembersType>::serializeROSmessage(
       }
     } else {
       switch (member->type_id_) {
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_BOOL:
-          serialize_array<bool>(member, field, ser);
+        case rosidl_typesupport_introspection_c__ROS_TYPE_BOOL:
+          TypeSupportHelper<MembersType>::template serialize_array<bool>(member, field, ser);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_BYTE:
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT8:
-          serialize_array<uint8_t>(member, field, ser);
+        case rosidl_typesupport_introspection_c__ROS_TYPE_BYTE:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_UINT8:
+          TypeSupportHelper<MembersType>::template serialize_array<uint8_t>(member, field, ser);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_CHAR:
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT8:
-          serialize_array<char>(member, field, ser);
+        case rosidl_typesupport_introspection_c__ROS_TYPE_CHAR:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_INT8:
+          TypeSupportHelper<MembersType>::template serialize_array<char>(member, field, ser);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_FLOAT32:
-          serialize_array<float>(member, field, ser);
+        case rosidl_typesupport_introspection_c__ROS_TYPE_FLOAT32:
+          TypeSupportHelper<MembersType>::template serialize_array<float>(member, field, ser);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_FLOAT64:
-          serialize_array<double>(member, field, ser);
+        case rosidl_typesupport_introspection_c__ROS_TYPE_FLOAT64:
+          TypeSupportHelper<MembersType>::template serialize_array<double>(member, field, ser);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT16:
-          serialize_array<int16_t>(member, field, ser);
+        case rosidl_typesupport_introspection_c__ROS_TYPE_INT16:
+          TypeSupportHelper<MembersType>::template serialize_array<int16_t>(member, field, ser);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT16:
-          serialize_array<uint16_t>(member, field, ser);
+        case rosidl_typesupport_introspection_c__ROS_TYPE_UINT16:
+          TypeSupportHelper<MembersType>::template serialize_array<uint16_t>(member, field, ser);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT32:
-          serialize_array<int32_t>(member, field, ser);
+        case rosidl_typesupport_introspection_c__ROS_TYPE_INT32:
+          TypeSupportHelper<MembersType>::template serialize_array<int32_t>(member, field, ser);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT32:
-          serialize_array<uint32_t>(member, field, ser);
+        case rosidl_typesupport_introspection_c__ROS_TYPE_UINT32:
+          TypeSupportHelper<MembersType>::template serialize_array<uint32_t>(member, field, ser);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT64:
-          serialize_array<int64_t>(member, field, ser);
+        case rosidl_typesupport_introspection_c__ROS_TYPE_INT64:
+          TypeSupportHelper<MembersType>::template serialize_array<int64_t>(member, field, ser);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT64:
-          serialize_array<uint64_t>(member, field, ser);
+        case rosidl_typesupport_introspection_c__ROS_TYPE_UINT64:
+          TypeSupportHelper<MembersType>::template serialize_array<uint64_t>(member, field, ser);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_STRING:
-          serialize_array<std::string>(member, field, ser);
+        case rosidl_typesupport_introspection_c__ROS_TYPE_STRING:
+          TypeSupportHelper<MembersType>::template serialize_array<std::string>(member, field, ser);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_MESSAGE:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_MESSAGE:
           {
             const MembersType * sub_members = (const MembersType *)member->members_->data;
             void * subros_message = nullptr;
@@ -494,7 +357,7 @@ bool TypeSupport<MembersType>::serializeROSmessage(
               subros_message = field;
               array_size = member->array_size_;
             } else {
-              array_size = get_array_size_and_assign_field(
+              array_size = TypeSupportHelper<MembersType>::get_array_size_and_assign_field(
                 member, field, subros_message, sub_members_size, max_align, space);
 
               // Serialize length
@@ -518,125 +381,6 @@ bool TypeSupport<MembersType>::serializeROSmessage(
   return true;
 }
 
-template<typename T>
-void deserialize_array(
-  const rosidl_typesupport_introspection_cpp::MessageMember * member,
-  void * field,
-  eprosima::fastcdr::Cdr & deser,
-  bool call_new)
-{
-  if (member->array_size_ && !member->is_upper_bound_) {
-    deser.deserializeArray(static_cast<T *>(field), member->array_size_);
-  } else {
-    std::vector<T> & vector = *reinterpret_cast<std::vector<T> *>(field);
-    if (call_new) {
-      new(&vector) std::vector<T>;
-    }
-    deser >> vector;
-  }
-}
-
-template<typename T>
-void deserialize_array(
-  const rosidl_typesupport_introspection_c__MessageMember * member,
-  void * field,
-  eprosima::fastcdr::Cdr & deser,
-  bool call_new)
-{
-  (void)call_new;
-  if (member->array_size_ && !member->is_upper_bound_) {
-    deser.deserializeArray(static_cast<T *>(field), member->array_size_);
-  } else {
-    auto & data = *reinterpret_cast<typename GenericCArray<T>::type *>(field);
-    int32_t dsize = 0;
-    deser >> dsize;
-    GenericCArray<T>::init(&data, dsize);
-    deser.deserializeArray(static_cast<T *>(data.data), dsize);
-  }
-}
-
-
-template<>
-void deserialize_array<std::string>(
-  const rosidl_typesupport_introspection_c__MessageMember * member,
-  void * field,
-  eprosima::fastcdr::Cdr & deser,
-  bool call_new)
-{
-  (void)call_new;
-  if (member->array_size_ && !member->is_upper_bound_) {
-    auto deser_field = (rosidl_generator_c__String *)field;
-    // tmpstring is defined here and not below to avoid
-    // memory allocation in every iteration of the for loop
-    std::string tmpstring;
-    for (size_t i = 0; i < member->array_size_; ++i) {
-      deser.deserialize(tmpstring);
-      if (!rosidl_generator_c__String__assign(&deser_field[i], tmpstring.c_str())) {
-        throw std::runtime_error("unable to assign rosidl_generator_c__String");
-      }
-    }
-  } else {
-    std::vector<std::string> cpp_string_vector;
-    deser >> cpp_string_vector;
-
-    auto & string_array_field = *reinterpret_cast<rosidl_generator_c__String__Array *>(field);
-    if (!rosidl_generator_c__String__Array__init(&string_array_field, cpp_string_vector.size())) {
-      throw std::runtime_error("unable to initialize rosidl_generator_c__String array");
-    }
-
-    for (size_t i = 0; i < cpp_string_vector.size(); ++i) {
-      if (!rosidl_generator_c__String__assign(&string_array_field.data[i],
-        cpp_string_vector[i].c_str()))
-      {
-        throw std::runtime_error("unable to assign rosidl_generator_c__String");
-      }
-    }
-  }
-}
-
-size_t get_submessage_array_deserialize(
-  const rosidl_typesupport_introspection_cpp::MessageMember * member,
-  eprosima::fastcdr::Cdr & deser,
-  void * field,
-  void * & subros_message,
-  bool call_new,
-  size_t sub_members_size,
-  size_t max_align,
-  size_t space)
-{
-  (void)member;
-  uint32_t vsize = 0;
-  // Deserialize length
-  deser >> vsize;
-  std::vector<unsigned char> * vector = reinterpret_cast<std::vector<unsigned char> *>(field);
-  if (call_new) {
-    new(vector) std::vector<unsigned char>;
-  }
-  void * ptr = (void *)sub_members_size;
-  vector->resize(vsize * (size_t)align_(max_align, 0, ptr, space));
-  subros_message = reinterpret_cast<void *>(vector->data());
-  return vsize;
-}
-
-size_t get_submessage_array_deserialize(
-  const rosidl_typesupport_introspection_c__MessageMember * member,
-  eprosima::fastcdr::Cdr & deser,
-  void * field,
-  void * & subros_message,
-  bool,
-  size_t sub_members_size,
-  size_t, size_t)
-{
-  (void)member;
-  // Deserialize length
-  uint32_t vsize = 0;
-  deser >> vsize;
-  rosidl_generator_c__void__Array * tmparray = (rosidl_generator_c__void__Array *)field;
-  rosidl_generator_c__void__Array__init(tmparray, vsize, sub_members_size);
-  subros_message = reinterpret_cast<void *>(tmparray->data);
-  return vsize;
-}
-
 template<typename MembersType>
 bool TypeSupport<MembersType>::deserializeROSmessage(
   eprosima::fastcdr::Cdr & deser, const MembersType * members, void * ros_message, bool call_new)
@@ -650,47 +394,47 @@ bool TypeSupport<MembersType>::deserializeROSmessage(
 
     if (!member->is_array_) {
       switch (member->type_id_) {
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_BOOL:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_BOOL:
           deser >> *(bool *)field;
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_BYTE:
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT8:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_BYTE:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_UINT8:
           deser >> *(uint8_t *)field;
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_CHAR:
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT8:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_CHAR:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_INT8:
           deser >> *(char *)field;
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_FLOAT32:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_FLOAT32:
           deser >> *(float *)field;
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_FLOAT64:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_FLOAT64:
           deser >> *(double *)field;
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT16:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_INT16:
           deser >> *(int16_t *)field;
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT16:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_UINT16:
           deser >> *(uint16_t *)field;
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT32:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_INT32:
           deser >> *(int32_t *)field;
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT32:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_UINT32:
           deser >> *(uint32_t *)field;
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT64:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_INT64:
           deser >> *(int64_t *)field;
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT64:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_UINT64:
           deser >> *(uint64_t *)field;
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_STRING:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_STRING:
           {
-            StringHelper<MembersType>::assign(deser, field, call_new);
+            TypeSupportHelper<MembersType>::assign(deser, field, call_new);
           }
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_MESSAGE:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_MESSAGE:
           {
             const MembersType * sub_members = (const MembersType *)member->members_->data;
             deserializeROSmessage(deser, sub_members, field, call_new);
@@ -701,45 +445,57 @@ bool TypeSupport<MembersType>::deserializeROSmessage(
       }
     } else {
       switch (member->type_id_) {
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_BOOL:
-          deserialize_array<bool>(member, field, deser, call_new);
+        case rosidl_typesupport_introspection_c__ROS_TYPE_BOOL:
+          TypeSupportHelper<MembersType>::template deserialize_array<bool>(member, field, deser,
+            call_new);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_BYTE:
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT8:
-          deserialize_array<uint8_t>(member, field, deser, call_new);
+        case rosidl_typesupport_introspection_c__ROS_TYPE_BYTE:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_UINT8:
+          TypeSupportHelper<MembersType>::template deserialize_array<uint8_t>(member, field, deser,
+            call_new);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_CHAR:
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT8:
-          deserialize_array<char>(member, field, deser, call_new);
+        case rosidl_typesupport_introspection_c__ROS_TYPE_CHAR:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_INT8:
+          TypeSupportHelper<MembersType>::template deserialize_array<char>(member, field, deser,
+            call_new);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_FLOAT32:
-          deserialize_array<float>(member, field, deser, call_new);
+        case rosidl_typesupport_introspection_c__ROS_TYPE_FLOAT32:
+          TypeSupportHelper<MembersType>::template deserialize_array<float>(member, field, deser,
+            call_new);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_FLOAT64:
-          deserialize_array<double>(member, field, deser, call_new);
+        case rosidl_typesupport_introspection_c__ROS_TYPE_FLOAT64:
+          TypeSupportHelper<MembersType>::template deserialize_array<double>(member, field, deser,
+            call_new);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT16:
-          deserialize_array<int16_t>(member, field, deser, call_new);
+        case rosidl_typesupport_introspection_c__ROS_TYPE_INT16:
+          TypeSupportHelper<MembersType>::template deserialize_array<int16_t>(member, field, deser,
+            call_new);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT16:
-          deserialize_array<uint16_t>(member, field, deser, call_new);
+        case rosidl_typesupport_introspection_c__ROS_TYPE_UINT16:
+          TypeSupportHelper<MembersType>::template deserialize_array<uint16_t>(member, field, deser,
+            call_new);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT32:
-          deserialize_array<int32_t>(member, field, deser, call_new);
+        case rosidl_typesupport_introspection_c__ROS_TYPE_INT32:
+          TypeSupportHelper<MembersType>::template deserialize_array<int32_t>(member, field, deser,
+            call_new);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT32:
-          deserialize_array<uint32_t>(member, field, deser, call_new);
+        case rosidl_typesupport_introspection_c__ROS_TYPE_UINT32:
+          TypeSupportHelper<MembersType>::template deserialize_array<uint32_t>(member, field, deser,
+            call_new);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT64:
-          deserialize_array<int64_t>(member, field, deser, call_new);
+        case rosidl_typesupport_introspection_c__ROS_TYPE_INT64:
+          TypeSupportHelper<MembersType>::template deserialize_array<int64_t>(member, field, deser,
+            call_new);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT64:
-          deserialize_array<uint64_t>(member, field, deser, call_new);
+        case rosidl_typesupport_introspection_c__ROS_TYPE_UINT64:
+          TypeSupportHelper<MembersType>::template deserialize_array<uint64_t>(member, field, deser,
+            call_new);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_STRING:
-          deserialize_array<std::string>(member, field, deser, call_new);
+        case rosidl_typesupport_introspection_c__ROS_TYPE_STRING:
+          TypeSupportHelper<MembersType>::template deserialize_array<std::string>(member, field,
+            deser, call_new);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_MESSAGE:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_MESSAGE:
           {
             const MembersType * sub_members = (const MembersType *)member->members_->data;
             void * subros_message = nullptr;
@@ -753,7 +509,7 @@ bool TypeSupport<MembersType>::deserializeROSmessage(
               subros_message = field;
               array_size = member->array_size_;
             } else {
-              array_size = get_submessage_array_deserialize(
+              array_size = TypeSupportHelper<MembersType>::get_submessage_array_deserialize(
                 member, deser, field, subros_message,
                 call_new, sub_members_size, max_align, space);
               recall_new = true;
@@ -789,33 +545,33 @@ size_t TypeSupport<MembersType>::calculateMaxSerializedSize(
 
     if (!member->is_array_) {
       switch (member->type_id_) {
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_BOOL:
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_BYTE:
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT8:
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_CHAR:
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT8:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_BOOL:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_BYTE:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_UINT8:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_CHAR:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_INT8:
           current_alignment += 1;
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT16:
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT16:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_INT16:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_UINT16:
           current_alignment += 2 + eprosima::fastcdr::Cdr::alignment(current_alignment, 2);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_FLOAT32:
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT32:
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT32:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_FLOAT32:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_INT32:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_UINT32:
           current_alignment += 4 + eprosima::fastcdr::Cdr::alignment(current_alignment, 4);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_FLOAT64:
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT64:
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT64:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_FLOAT64:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_INT64:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_UINT64:
           current_alignment += 8 + eprosima::fastcdr::Cdr::alignment(current_alignment, 8);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_STRING:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_STRING:
           current_alignment += 4 +
             eprosima::fastcdr::Cdr::alignment(current_alignment,
               4) + (member->string_upper_bound_ ? member->string_upper_bound_ + 1 : 257);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_MESSAGE:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_MESSAGE:
           {
             const MembersType * sub_members = (const MembersType *)member->members_->data;
             current_alignment += calculateMaxSerializedSize(sub_members, current_alignment);
@@ -835,31 +591,31 @@ size_t TypeSupport<MembersType>::calculateMaxSerializedSize(
       }
 
       switch (member->type_id_) {
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_BOOL:
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_BYTE:
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT8:
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_CHAR:
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT8:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_BOOL:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_BYTE:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_UINT8:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_CHAR:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_INT8:
           current_alignment += array_size;
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT16:
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT16:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_INT16:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_UINT16:
           current_alignment += array_size * 2 + eprosima::fastcdr::Cdr::alignment(current_alignment,
               2);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_FLOAT32:
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT32:
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT32:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_FLOAT32:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_INT32:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_UINT32:
           current_alignment += array_size * 4 + eprosima::fastcdr::Cdr::alignment(current_alignment,
               4);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_FLOAT64:
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT64:
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT64:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_FLOAT64:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_INT64:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_UINT64:
           current_alignment += array_size * 8 + eprosima::fastcdr::Cdr::alignment(current_alignment,
               8);
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_STRING:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_STRING:
           {
             for (size_t index = 0; index < array_size; ++index) {
               current_alignment += 4 +
@@ -868,7 +624,7 @@ size_t TypeSupport<MembersType>::calculateMaxSerializedSize(
             }
           }
           break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_MESSAGE:
+        case rosidl_typesupport_introspection_c__ROS_TYPE_MESSAGE:
           {
             const MembersType * sub_members = (const MembersType *)member->members_->data;
             for (size_t index = 0; index < array_size; ++index) {
@@ -965,6 +721,9 @@ std::function<uint32_t()> TypeSupport<MembersType>::getSerializedSizeProvider(vo
   return [ser]()->uint32_t {return static_cast<uint32_t>(ser->getSerializedDataLength()); };
 }
 
-}  // namespace rmw_fastrtps_cpp
+}  // namespace rmw_fastrtps_common
+
+#include "TypeSupport_impl_c.h"
+#include "TypeSupport_impl_cpp.h"
 
 #endif  // RMW_FASTRTPS_CPP__TYPESUPPORT_IMPL_H_

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport_impl_c.h
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport_impl_c.h
@@ -1,0 +1,283 @@
+// Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RMW_FASTRTPS_CPP__TYPESUPPORT_IMPL_C_H_
+#define RMW_FASTRTPS_CPP__TYPESUPPORT_IMPL_C_H_
+
+#include <fastcdr/FastBuffer.h>
+#include <fastcdr/Cdr.h>
+#include <cassert>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+#include "rmw_fastrtps_cpp/macros.hpp"
+#include "rosidl_typesupport_introspection_c/field_types.h"
+
+#include "rosidl_typesupport_introspection_c/message_introspection.h"
+#include "rosidl_typesupport_introspection_c/service_introspection.h"
+
+#include "rosidl_generator_c/primitives_array_functions.h"
+
+namespace rmw_fastrtps_common
+{
+
+template<typename T>
+struct GenericCArray;
+
+// multiple definitions of ambiguous primitive types
+SPECIALIZE_GENERIC_C_ARRAY(bool, bool)
+SPECIALIZE_GENERIC_C_ARRAY(byte, uint8_t)
+SPECIALIZE_GENERIC_C_ARRAY(char, char)
+SPECIALIZE_GENERIC_C_ARRAY(float32, float)
+SPECIALIZE_GENERIC_C_ARRAY(float64, double)
+SPECIALIZE_GENERIC_C_ARRAY(int8, int8_t)
+SPECIALIZE_GENERIC_C_ARRAY(int16, int16_t)
+SPECIALIZE_GENERIC_C_ARRAY(uint16, uint16_t)
+SPECIALIZE_GENERIC_C_ARRAY(int32, int32_t)
+SPECIALIZE_GENERIC_C_ARRAY(uint32, uint32_t)
+SPECIALIZE_GENERIC_C_ARRAY(int64, int64_t)
+SPECIALIZE_GENERIC_C_ARRAY(uint64, uint64_t)
+
+typedef struct rosidl_generator_c__void__Array
+{
+  void * data;
+  /// The number of valid items in data
+  size_t size;
+  /// The number of allocated items in data
+  size_t capacity;
+} rosidl_generator_c__void__Array;
+
+bool
+rosidl_generator_c__void__Array__init(
+  rosidl_generator_c__void__Array * array, size_t size, size_t member_size)
+{
+  if (!array) {
+    return false;
+  }
+  void * data = NULL;
+  if (size) {
+    data = (void *)calloc(size, member_size);
+    if (!data) {
+      return false;
+    }
+  }
+  array->data = data;
+  array->size = size;
+  array->capacity = size;
+  return true;
+}
+
+void
+rosidl_generator_c__void__Array__fini(rosidl_generator_c__void__Array * array)
+{
+  if (!array) {
+    return;
+  }
+  if (array->data) {
+    // ensure that data and capacity values are consistent
+    assert(array->capacity > 0);
+    // finalize all array elements
+    free(array->data);
+    array->data = NULL;
+    array->size = 0;
+    array->capacity = 0;
+  } else {
+    // ensure that data, size, and capacity values are consistent
+    assert(0 == array->size);
+    assert(0 == array->capacity);
+  }
+}
+
+// For C introspection typesupport we create intermediate instances of std::string so that
+// eprosima::fastcdr::Cdr can handle the string properly.
+template<>
+struct TypeSupportHelper<rosidl_typesupport_introspection_c__MessageMembers>
+{
+  using string_type = rosidl_generator_c__String;
+
+  static constexpr size_t string_alignment = alignof(string_type);
+
+  static constexpr size_t string_size = sizeof(string_type);
+
+  static std::string convert_to_std_string(void * data)
+  {
+    auto c_string = static_cast<rosidl_generator_c__String *>(data);
+    if (!c_string) {
+      fprintf(stderr, "Failed to cast data as rosidl_generator_c__String\n");
+      return "";
+    }
+    if (!c_string->data) {
+      fprintf(stderr, "rosidl_generator_c_String had invalid data\n");
+      return "";
+    }
+    return std::string(c_string->data);
+  }
+
+  static std::string convert_to_std_string(rosidl_generator_c__String & data)
+  {
+    return std::string(data.data);
+  }
+
+  static void assign(eprosima::fastcdr::Cdr & deser, void * field, bool)
+  {
+    std::string str;
+    deser >> str;
+    rosidl_generator_c__String * c_str = static_cast<rosidl_generator_c__String *>(field);
+    rosidl_generator_c__String__assign(c_str, str.c_str());
+  }
+
+  // C specialization
+  template<typename T,
+  typename std::enable_if<!std::is_same<T, std::string>::value>::type * = nullptr>
+  static void serialize_array(
+    const rosidl_typesupport_introspection_c__MessageMember * member,
+    void * field,
+    eprosima::fastcdr::Cdr & ser)
+  {
+    if (member->array_size_ && !member->is_upper_bound_) {
+      ser.serializeArray(static_cast<T *>(field), member->array_size_);
+    } else {
+      auto & data = *reinterpret_cast<typename GenericCArray<T>::type *>(field);
+      ser.serializeSequence(static_cast<T *>(data.data), data.size);
+    }
+  }
+
+  template<typename T,
+  typename std::enable_if<std::is_same<T, std::string>::value>::type * = nullptr>
+  static void serialize_array(
+    const rosidl_typesupport_introspection_c__MessageMember * member,
+    void * field,
+    eprosima::fastcdr::Cdr & ser)
+  {
+    using CTypeSupportHelper =
+        TypeSupportHelper<rosidl_typesupport_introspection_c__MessageMembers>;
+    // First, cast field to rosidl_generator_c
+    // Then convert to a std::string using TypeSupportHelper and serialize the std::string
+    if (member->array_size_ && !member->is_upper_bound_) {
+      // tmpstring is defined here and not below to avoid
+      // memory allocation in every iteration of the for loop
+      std::string tmpstring;
+      auto string_field = (rosidl_generator_c__String *) field;
+      for (size_t i = 0; i < member->array_size_; ++i) {
+        tmpstring = string_field[i].data;
+        ser.serialize(tmpstring);
+      }
+    } else {
+      auto & string_array_field = *reinterpret_cast<rosidl_generator_c__String__Array *>(field);
+      std::vector<std::string> cpp_string_vector;
+      for (size_t i = 0; i < string_array_field.size; ++i) {
+        cpp_string_vector.push_back(
+          CTypeSupportHelper::convert_to_std_string(string_array_field.data[i]));
+      }
+      ser << cpp_string_vector;
+    }
+  }
+
+  template<typename T,
+  typename std::enable_if<!std::is_same<T, std::string>::value>::type * = nullptr>
+  static void deserialize_array(
+    const rosidl_typesupport_introspection_c__MessageMember * member,
+    void * field,
+    eprosima::fastcdr::Cdr & deser,
+    bool call_new)
+  {
+    (void)call_new;
+    if (member->array_size_ && !member->is_upper_bound_) {
+      deser.deserializeArray(static_cast<T *>(field), member->array_size_);
+    } else {
+      auto & data = *reinterpret_cast<typename GenericCArray<T>::type *>(field);
+      int32_t dsize = 0;
+      deser >> dsize;
+      GenericCArray<T>::init(&data, dsize);
+      deser.deserializeArray(static_cast<T *>(data.data), dsize);
+    }
+  }
+
+  template<typename T,
+  typename std::enable_if<std::is_same<T, std::string>::value>::type * = nullptr>
+  static void deserialize_array(
+    const rosidl_typesupport_introspection_c__MessageMember * member,
+    void * field,
+    eprosima::fastcdr::Cdr & deser,
+    bool call_new)
+  {
+    (void)call_new;
+    if (member->array_size_ && !member->is_upper_bound_) {
+      auto deser_field = (rosidl_generator_c__String *)field;
+      // tmpstring is defined here and not below to avoid
+      // memory allocation in every iteration of the for loop
+      std::string tmpstring;
+      for (size_t i = 0; i < member->array_size_; ++i) {
+        deser.deserialize(tmpstring);
+        if (!rosidl_generator_c__String__assign(&deser_field[i], tmpstring.c_str())) {
+          throw std::runtime_error("unable to assign rosidl_generator_c__String");
+        }
+      }
+    } else {
+      std::vector<std::string> cpp_string_vector;
+      deser >> cpp_string_vector;
+
+      auto & string_array_field = *reinterpret_cast<rosidl_generator_c__String__Array *>(field);
+      if (!rosidl_generator_c__String__Array__init(&string_array_field, cpp_string_vector.size())) {
+        throw std::runtime_error("unable to initialize rosidl_generator_c__String array");
+      }
+
+      for (size_t i = 0; i < cpp_string_vector.size(); ++i) {
+        if (!rosidl_generator_c__String__assign(&string_array_field.data[i],
+          cpp_string_vector[i].c_str()))
+        {
+          throw std::runtime_error("unable to assign rosidl_generator_c__String");
+        }
+      }
+    }
+  }
+
+  static size_t get_array_size_and_assign_field(
+    const rosidl_typesupport_introspection_c__MessageMember * member,
+    void * field,
+    void * & subros_message,
+    size_t, size_t, size_t)
+  {
+    rosidl_generator_c__void__Array * tmparray = (rosidl_generator_c__void__Array *) field;
+    if (member->is_upper_bound_ && tmparray->size > member->array_size_) {
+      throw std::runtime_error("vector overcomes the maximum length");
+    }
+    subros_message = reinterpret_cast<void *>(tmparray->data);
+    return tmparray->size;
+  }
+
+  static size_t get_submessage_array_deserialize(
+    const rosidl_typesupport_introspection_c__MessageMember * member,
+    eprosima::fastcdr::Cdr & deser,
+    void * field,
+    void * & subros_message,
+    bool,
+    size_t sub_members_size,
+    size_t, size_t)
+  {
+    (void)member;
+    // Deserialize length
+    uint32_t vsize = 0;
+    deser >> vsize;
+    rosidl_generator_c__void__Array * tmparray = (rosidl_generator_c__void__Array *)field;
+    rosidl_generator_c__void__Array__init(tmparray, vsize, sub_members_size);
+    subros_message = reinterpret_cast<void *>(tmparray->data);
+    return vsize;
+  }
+};
+
+}  // namespace rmw_fastrtps_common
+
+#endif  // RMW_FASTRTPS_CPP__TYPESUPPORT_IMPL_C_H_

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport_impl_cpp.h
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport_impl_cpp.h
@@ -1,0 +1,135 @@
+// Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RMW_FASTRTPS_CPP__TYPESUPPORT_IMPL_CPP_H_
+#define RMW_FASTRTPS_CPP__TYPESUPPORT_IMPL_CPP_H_
+
+#include <fastcdr/FastBuffer.h>
+#include <fastcdr/Cdr.h>
+#include <cassert>
+#include <string>
+#include <vector>
+
+#include "rmw_fastrtps_cpp/macros.hpp"
+#include "rosidl_typesupport_introspection_c/field_types.h"
+
+#include "rosidl_typesupport_introspection_cpp/message_introspection.hpp"
+#include "rosidl_typesupport_introspection_cpp/service_introspection.hpp"
+
+namespace rmw_fastrtps_common
+{
+
+// For C++ introspection typesupport we just reuse the same std::string transparently.
+template<>
+struct TypeSupportHelper<rosidl_typesupport_introspection_cpp::MessageMembers>
+{
+  using string_type = std::string;
+
+  static constexpr size_t string_alignment = alignof(string_type);
+
+  static constexpr size_t string_size = sizeof(string_type);
+
+  static std::string & convert_to_std_string(void * data)
+  {
+    return *(static_cast<std::string *>(data));
+  }
+
+  static void assign(eprosima::fastcdr::Cdr & deser, void * field, bool call_new)
+  {
+    std::string & str = *(std::string *)field;
+    if (call_new) {
+      new(&str) std::string;
+    }
+    deser >> str;
+  }
+
+  // C++ specialization
+  template<typename T>
+  static void serialize_array(
+    const rosidl_typesupport_introspection_cpp::MessageMember * member,
+    void * field,
+    eprosima::fastcdr::Cdr & ser)
+  {
+    if (member->array_size_ && !member->is_upper_bound_) {
+      ser.serializeArray(static_cast<T *>(field), member->array_size_);
+    } else {
+      std::vector<T> & data = *reinterpret_cast<std::vector<T> *>(field);
+      ser << data;
+    }
+  }
+
+  template<typename T>
+  static void deserialize_array(
+    const rosidl_typesupport_introspection_cpp::MessageMember * member,
+    void * field,
+    eprosima::fastcdr::Cdr & deser,
+    bool call_new)
+  {
+    if (member->array_size_ && !member->is_upper_bound_) {
+      deser.deserializeArray(static_cast<T *>(field), member->array_size_);
+    } else {
+      std::vector<T> & vector = *reinterpret_cast<std::vector<T> *>(field);
+      if (call_new) {
+        new(&vector) std::vector<T>;
+      }
+      deser >> vector;
+    }
+  }
+
+  static size_t get_array_size_and_assign_field(
+    const rosidl_typesupport_introspection_cpp::MessageMember * member,
+    void * field,
+    void * & subros_message,
+    size_t sub_members_size,
+    size_t max_align,
+    size_t space)
+  {
+    std::vector<unsigned char> * vector = reinterpret_cast<std::vector<unsigned char> *>(field);
+    void * ptr = (void *)sub_members_size;
+    size_t vsize = vector->size() / (size_t)align_(max_align, 0, ptr, space);
+    if (member->is_upper_bound_ && vsize > member->array_size_) {
+      throw std::runtime_error("vector overcomes the maximum length");
+    }
+    subros_message = reinterpret_cast<void *>(vector->data());
+    return vsize;
+  }
+
+  static size_t get_submessage_array_deserialize(
+    const rosidl_typesupport_introspection_cpp::MessageMember * member,
+    eprosima::fastcdr::Cdr & deser,
+    void * field,
+    void * & subros_message,
+    bool call_new,
+    size_t sub_members_size,
+    size_t max_align,
+    size_t space)
+  {
+    (void)member;
+    uint32_t vsize = 0;
+    // Deserialize length
+    deser >> vsize;
+    std::vector<unsigned char> * vector = reinterpret_cast<std::vector<unsigned char> *>(field);
+    if (call_new) {
+      new(vector) std::vector<unsigned char>;
+    }
+    void * ptr = (void *)sub_members_size;
+    vector->resize(vsize * (size_t)align_(max_align, 0, ptr, space));
+    subros_message = reinterpret_cast<void *>(vector->data());
+    return vsize;
+  }
+};
+
+}  // namespace rmw_fastrtps_common
+
+#endif  // RMW_FASTRTPS_CPP__TYPESUPPORT_IMPL_CPP_H_

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/common_functions.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/common_functions.hpp
@@ -1,0 +1,76 @@
+// Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RMW_FASTRTPS_CPP__COMMON_FUNCTIONS_HPP_
+#define RMW_FASTRTPS_CPP__COMMON_FUNCTIONS_HPP_
+
+#include <string>
+
+#include "rmw/rmw.h"
+
+#include "fastcdr/Cdr.h"
+#include "fastrtps/Domain.h"
+#include "fastrtps/participant/Participant.h"
+
+namespace rmw_fastrtps_impl
+{
+const rosidl_message_type_support_t * _get_message_typesupport_handle(
+  const rosidl_message_type_support_t * type_supports);
+
+const rosidl_service_type_support_t * _get_service_typesupport_handle(
+  const rosidl_service_type_support_t * type_supports);
+
+std::string
+_create_type_name(
+  const void * untyped_members,
+  const std::string & sep,
+  const char * typesupport);
+
+const void * get_request_ptr(const void * untyped_service_members, const char * typesupport);
+
+const void * get_response_ptr(const void * untyped_service_members, const char * typesupport);
+void *
+_create_message_type_support(const void * untyped_members, const char * typesupport_identifier);
+
+void *
+_create_request_type_support(const void * untyped_members, const char * typesupport_identifier);
+
+void *
+_create_response_type_support(const void * untyped_members, const char * typesupport_identifier);
+
+void
+_register_type(
+  eprosima::fastrtps::Participant * participant, void * untyped_typesupport,
+  const char * typesupport_identifier);
+
+void
+_unregister_type(
+  eprosima::fastrtps::Participant * participant, void * untyped_typesupport,
+  const char * typesupport_identifier);
+
+void
+_delete_typesupport(void * untyped_typesupport, const char * typesupport_identifier);
+
+bool
+_serialize_ros_message(
+  const void * ros_message, eprosima::fastcdr::Cdr & ser, void * untyped_typesupport,
+  const char * typesupport_identifier);
+
+bool
+_deserialize_ros_message(
+  eprosima::fastcdr::FastBuffer * buffer, void * ros_message, void * untyped_typesupport,
+  const char * typesupport_identifier);
+}  // namespace rmw_fastrtps_impl
+
+#endif  // RMW_FASTRTPS_CPP__COMMON_FUNCTIONS_HPP_

--- a/rmw_fastrtps_cpp/src/functions.cpp
+++ b/rmw_fastrtps_cpp/src/functions.cpp
@@ -27,8 +27,6 @@
 #include "rmw/error_handling.h"
 #include "rmw/sanity_checks.h"
 #include "rmw/impl/cpp/macros.hpp"
-#include "rmw_fastrtps_cpp/MessageTypeSupport.h"
-#include "rmw_fastrtps_cpp/ServiceTypeSupport.h"
 
 #include "fastrtps/Domain.h"
 #include "fastrtps/participant/Participant.h"
@@ -50,271 +48,10 @@
 #include "fastrtps/rtps/reader/ReaderListener.h"
 #include "fastrtps/rtps/builtin/discovery/endpoint/EDPSimple.h"
 
-#include "rosidl_typesupport_introspection_cpp/field_types.hpp"
-#include "rosidl_typesupport_introspection_cpp/identifier.hpp"
-#include "rosidl_typesupport_introspection_cpp/message_introspection.hpp"
-#include "rosidl_typesupport_introspection_cpp/service_introspection.hpp"
-#include "rosidl_typesupport_introspection_cpp/visibility_control.h"
+#include "rmw_fastrtps_cpp/MessageTypeSupport.h"
+#include "rmw_fastrtps_cpp/ServiceTypeSupport.h"
 
-#include "rosidl_typesupport_introspection_c/field_types.h"
-#include "rosidl_typesupport_introspection_c/identifier.h"
-#include "rosidl_typesupport_introspection_c/message_introspection.h"
-#include "rosidl_typesupport_introspection_c/service_introspection.h"
-#include "rosidl_typesupport_introspection_c/visibility_control.h"
-
-using MessageTypeSupport_c =
-    rmw_fastrtps_cpp::MessageTypeSupport<rosidl_typesupport_introspection_c__MessageMembers>;
-using MessageTypeSupport_cpp =
-    rmw_fastrtps_cpp::MessageTypeSupport<rosidl_typesupport_introspection_cpp::MessageMembers>;
-using TypeSupport_c =
-    rmw_fastrtps_cpp::TypeSupport<rosidl_typesupport_introspection_c__MessageMembers>;
-using TypeSupport_cpp =
-    rmw_fastrtps_cpp::TypeSupport<rosidl_typesupport_introspection_cpp::MessageMembers>;
-
-using RequestTypeSupport_c = rmw_fastrtps_cpp::RequestTypeSupport<
-    rosidl_typesupport_introspection_c__ServiceMembers,
-    rosidl_typesupport_introspection_c__MessageMembers
-    >;
-using RequestTypeSupport_cpp = rmw_fastrtps_cpp::RequestTypeSupport<
-    rosidl_typesupport_introspection_cpp::ServiceMembers,
-    rosidl_typesupport_introspection_cpp::MessageMembers
-    >;
-
-using ResponseTypeSupport_c = rmw_fastrtps_cpp::ResponseTypeSupport<
-    rosidl_typesupport_introspection_c__ServiceMembers,
-    rosidl_typesupport_introspection_c__MessageMembers
-    >;
-using ResponseTypeSupport_cpp = rmw_fastrtps_cpp::ResponseTypeSupport<
-    rosidl_typesupport_introspection_cpp::ServiceMembers,
-    rosidl_typesupport_introspection_cpp::MessageMembers
-    >;
-
-bool using_introspection_c_typesupport(const char * typesupport_identifier)
-{
-  return typesupport_identifier == rosidl_typesupport_introspection_c__identifier;
-}
-
-bool using_introspection_cpp_typesupport(const char * typesupport_identifier)
-{
-  return typesupport_identifier ==
-         rosidl_typesupport_introspection_cpp::typesupport_identifier;
-}
-
-template<typename MembersType>
-ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_LOCAL
-inline std::string
-_create_type_name(
-  const void * untyped_members,
-  const std::string & sep)
-{
-  auto members = static_cast<const MembersType *>(untyped_members);
-  if (!members) {
-    RMW_SET_ERROR_MSG("members handle is null");
-    return "";
-  }
-  return
-    std::string(members->package_name_) + "::" + sep + "::dds_::" + members->message_name_ + "_";
-}
-
-ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_LOCAL
-inline std::string
-_create_type_name(
-  const void * untyped_members,
-  const std::string & sep,
-  const char * typesupport)
-{
-  if (using_introspection_c_typesupport(typesupport)) {
-    return _create_type_name<rosidl_typesupport_introspection_c__MessageMembers>(
-      untyped_members, sep);
-  } else if (using_introspection_cpp_typesupport(typesupport)) {
-    return _create_type_name<rosidl_typesupport_introspection_cpp::MessageMembers>(
-      untyped_members, sep);
-  }
-  RMW_SET_ERROR_MSG("Unknown typesupport identifier");
-  return "";
-}
-
-template<typename ServiceType>
-const void * get_request_ptr(const void * untyped_service_members)
-{
-  auto service_members = static_cast<const ServiceType *>(untyped_service_members);
-  if (!service_members) {
-    RMW_SET_ERROR_MSG("service members handle is null");
-    return NULL;
-  }
-  return service_members->request_members_;
-}
-
-const void * get_request_ptr(const void * untyped_service_members, const char * typesupport)
-{
-  if (using_introspection_c_typesupport(typesupport)) {
-    return get_request_ptr<rosidl_typesupport_introspection_c__ServiceMembers>(
-      untyped_service_members);
-  } else if (using_introspection_cpp_typesupport(typesupport)) {
-    return get_request_ptr<rosidl_typesupport_introspection_cpp::ServiceMembers>(
-      untyped_service_members);
-  }
-  RMW_SET_ERROR_MSG("Unknown typesupport identifier");
-  return NULL;
-}
-
-template<typename ServiceType>
-const void * get_response_ptr(const void * untyped_service_members)
-{
-  auto service_members = static_cast<const ServiceType *>(untyped_service_members);
-  if (!service_members) {
-    RMW_SET_ERROR_MSG("service members handle is null");
-    return NULL;
-  }
-  return service_members->response_members_;
-}
-
-const void * get_response_ptr(const void * untyped_service_members, const char * typesupport)
-{
-  if (using_introspection_c_typesupport(typesupport)) {
-    return get_response_ptr<rosidl_typesupport_introspection_c__ServiceMembers>(
-      untyped_service_members);
-  } else if (using_introspection_cpp_typesupport(typesupport)) {
-    return get_response_ptr<rosidl_typesupport_introspection_cpp::ServiceMembers>(
-      untyped_service_members);
-  }
-  RMW_SET_ERROR_MSG("Unknown typesupport identifier");
-  return NULL;
-}
-
-void *
-_create_message_type_support(const void * untyped_members, const char * typesupport_identifier)
-{
-  if (using_introspection_c_typesupport(typesupport_identifier)) {
-    auto members = static_cast<const rosidl_typesupport_introspection_c__MessageMembers *>(
-      untyped_members);
-    return new MessageTypeSupport_c(members);
-  } else if (using_introspection_cpp_typesupport(typesupport_identifier)) {
-    auto members = static_cast<const rosidl_typesupport_introspection_cpp::MessageMembers *>(
-      untyped_members);
-    return new MessageTypeSupport_cpp(members);
-  }
-  RMW_SET_ERROR_MSG("Unknown typesupport identifier");
-  return nullptr;
-}
-
-void *
-_create_request_type_support(const void * untyped_members, const char * typesupport_identifier)
-{
-  if (using_introspection_c_typesupport(typesupport_identifier)) {
-    auto members = static_cast<const rosidl_typesupport_introspection_c__ServiceMembers *>(
-      untyped_members);
-    return new RequestTypeSupport_c(members);
-  } else if (using_introspection_cpp_typesupport(typesupport_identifier)) {
-    auto members = static_cast<const rosidl_typesupport_introspection_cpp::ServiceMembers *>(
-      untyped_members);
-    return new RequestTypeSupport_cpp(members);
-  }
-  RMW_SET_ERROR_MSG("Unknown typesupport identifier");
-  return nullptr;
-}
-
-void *
-_create_response_type_support(const void * untyped_members, const char * typesupport_identifier)
-{
-  if (using_introspection_c_typesupport(typesupport_identifier)) {
-    auto members = static_cast<const rosidl_typesupport_introspection_c__ServiceMembers *>(
-      untyped_members);
-    return new ResponseTypeSupport_c(members);
-  } else if (using_introspection_cpp_typesupport(typesupport_identifier)) {
-    auto members = static_cast<const rosidl_typesupport_introspection_cpp::ServiceMembers *>(
-      untyped_members);
-    return new ResponseTypeSupport_cpp(members);
-  }
-  RMW_SET_ERROR_MSG("Unknown typesupport identifier");
-  return nullptr;
-}
-
-void
-_register_type(
-  eprosima::fastrtps::Participant * participant, void * untyped_typesupport,
-  const char * typesupport_identifier)
-{
-  if (using_introspection_c_typesupport(typesupport_identifier)) {
-    auto typed_typesupport = static_cast<TypeSupport_c *>(untyped_typesupport);
-    Domain::registerType(participant, typed_typesupport);
-  } else if (using_introspection_cpp_typesupport(typesupport_identifier)) {
-    auto typed_typesupport = static_cast<TypeSupport_cpp *>(untyped_typesupport);
-    Domain::registerType(participant, typed_typesupport);
-  } else {
-    RMW_SET_ERROR_MSG("Unknown typesupport identifier");
-  }
-}
-
-void
-_unregister_type(
-  eprosima::fastrtps::Participant * participant, void * untyped_typesupport,
-  const char * typesupport_identifier)
-{
-  if (using_introspection_c_typesupport(typesupport_identifier)) {
-    auto typed_typesupport = static_cast<TypeSupport_c *>(untyped_typesupport);
-    if (Domain::unregisterType(participant, typed_typesupport->getName())) {
-      delete typed_typesupport;
-    }
-  } else if (using_introspection_cpp_typesupport(typesupport_identifier)) {
-    auto typed_typesupport = static_cast<TypeSupport_cpp *>(untyped_typesupport);
-    if (Domain::unregisterType(participant, typed_typesupport->getName())) {
-      delete typed_typesupport;
-    }
-  } else {
-    RMW_SET_ERROR_MSG("Unknown typesupport identifier");
-  }
-}
-
-void
-_delete_typesupport(void * untyped_typesupport, const char * typesupport_identifier)
-{
-  if (using_introspection_c_typesupport(typesupport_identifier)) {
-    auto typed_typesupport = static_cast<MessageTypeSupport_c *>(untyped_typesupport);
-    if (typed_typesupport != nullptr) {
-      delete typed_typesupport;
-    }
-  } else if (using_introspection_cpp_typesupport(typesupport_identifier)) {
-    auto typed_typesupport = static_cast<MessageTypeSupport_cpp *>(untyped_typesupport);
-    if (typed_typesupport != nullptr) {
-      delete typed_typesupport;
-    }
-  } else {
-    RMW_SET_ERROR_MSG("Unknown typesupport identifier");
-  }
-}
-
-bool
-_serialize_ros_message(
-  const void * ros_message, eprosima::fastcdr::Cdr & ser, void * untyped_typesupport,
-  const char * typesupport_identifier)
-{
-  if (using_introspection_c_typesupport(typesupport_identifier)) {
-    auto typed_typesupport = static_cast<MessageTypeSupport_c *>(untyped_typesupport);
-    return typed_typesupport->serializeROSmessage(ros_message, ser);
-  } else if (using_introspection_cpp_typesupport(typesupport_identifier)) {
-    auto typed_typesupport = static_cast<MessageTypeSupport_cpp *>(untyped_typesupport);
-    return typed_typesupport->serializeROSmessage(ros_message, ser);
-  }
-  RMW_SET_ERROR_MSG("Unknown typesupport identifier");
-  return false;
-}
-
-bool
-_deserialize_ros_message(
-  eprosima::fastcdr::FastBuffer * buffer, void * ros_message, void * untyped_typesupport,
-  const char * typesupport_identifier)
-{
-  if (using_introspection_c_typesupport(typesupport_identifier)) {
-    auto typed_typesupport = static_cast<TypeSupport_c *>(untyped_typesupport);
-    return typed_typesupport->deserializeROSmessage(buffer, ros_message);
-  } else if (using_introspection_cpp_typesupport(typesupport_identifier)) {
-    auto typed_typesupport = static_cast<TypeSupport_cpp *>(untyped_typesupport);
-    return typed_typesupport->deserializeROSmessage(buffer, ros_message);
-  }
-  RMW_SET_ERROR_MSG("Unknown typesupport identifier");
-  return false;
-}
+#include "rmw_fastrtps_cpp/common_functions.hpp"
 
 class ClientListener;
 
@@ -476,7 +213,8 @@ extern "C"
 {
 const char * const eprosima_fastrtps_identifier = "rmw_fastrtps_cpp";
 
-const char * rmw_get_implementation_identifier()
+const char *
+rmw_get_implementation_identifier()
 {
   return eprosima_fastrtps_identifier;
 }
@@ -657,7 +395,7 @@ rmw_node_t * rmw_create_node(const char * name, size_t domain_id)
     RMW_SET_ERROR_MSG("failed to allocate rmw_node_t");
     return NULL;
   }
-  node_handle->implementation_identifier = eprosima_fastrtps_identifier;
+  node_handle->implementation_identifier = rmw_get_implementation_identifier();
   node_impl->participant = participant;
   node_impl->graph_guard_condition = graph_guard_condition;
   node_handle->data = node_impl;
@@ -703,7 +441,7 @@ rmw_ret_t rmw_destroy_node(rmw_node_t * node)
     return RMW_RET_ERROR;
   }
 
-  if (node->implementation_identifier != eprosima_fastrtps_identifier) {
+  if (node->implementation_identifier != rmw_get_implementation_identifier()) {
     RMW_SET_ERROR_MSG("node handle not from this implementation");
     return RMW_RET_ERROR;
   }
@@ -761,7 +499,7 @@ rmw_publisher_t * rmw_create_publisher(const rmw_node_t * node,
   assert(topic_name);
   assert(qos_policies);
 
-  if (node->implementation_identifier != eprosima_fastrtps_identifier) {
+  if (node->implementation_identifier != rmw_get_implementation_identifier()) {
     RMW_SET_ERROR_MSG("node handle not from this implementation");
     return NULL;
   }
@@ -773,28 +511,26 @@ rmw_publisher_t * rmw_create_publisher(const rmw_node_t * node,
   }
 
   Participant * participant = impl->participant;
-  const rosidl_message_type_support_t * type_support = get_message_typesupport_handle(
-    type_supports, rosidl_typesupport_introspection_c__identifier);
+  const rosidl_message_type_support_t * type_support =
+    rmw_fastrtps_impl::_get_message_typesupport_handle(
+    type_supports);
   if (!type_support) {
-    type_support = get_message_typesupport_handle(
-      type_supports, rosidl_typesupport_introspection_cpp::typesupport_identifier);
-    if (!type_support) {
-      RMW_SET_ERROR_MSG("type support not from this implementation");
-      return NULL;
-    }
+    RMW_SET_ERROR_MSG("type support not from this implementation");
+    return NULL;
   }
 
   CustomPublisherInfo * info = new CustomPublisherInfo();
   info->typesupport_identifier_ = type_support->typesupport_identifier;
 
-  std::string type_name = _create_type_name(type_support->data, "msg",
+  std::string type_name = rmw_fastrtps_impl::_create_type_name(type_support->data, "msg",
       info->typesupport_identifier_);
   if (!Domain::getRegisteredType(participant, type_name.c_str(),
     reinterpret_cast<TopicDataType **>(&info->type_support_)))
   {
-    info->type_support_ = _create_message_type_support(type_support->data,
+    info->type_support_ = rmw_fastrtps_impl::_create_message_type_support(type_support->data,
         info->typesupport_identifier_);
-    _register_type(participant, info->type_support_, info->typesupport_identifier_);
+    rmw_fastrtps_impl::_register_type(participant, info->type_support_,
+      info->typesupport_identifier_);
   }
 
   PublisherAttributes publisherParam;
@@ -823,10 +559,10 @@ rmw_publisher_t * rmw_create_publisher(const rmw_node_t * node,
     goto fail;
   }
 
-  info->publisher_gid.implementation_identifier = eprosima_fastrtps_identifier;
+  info->publisher_gid.implementation_identifier = rmw_get_implementation_identifier();
   static_assert(
     sizeof(eprosima::fastrtps::rtps::GUID_t) <= RMW_GID_STORAGE_SIZE,
-    "RMW_GID_STORAGE_SIZE insufficient to store the rmw_fastrtps_cpp GID implementation."
+    "RMW_GID_STORAGE_SIZE insufficient to store the rmw_fastrtps_common GID implementation."
   );
 
   memset(info->publisher_gid.data, 0, RMW_GID_STORAGE_SIZE);
@@ -834,7 +570,7 @@ rmw_publisher_t * rmw_create_publisher(const rmw_node_t * node,
   memcpy(info->publisher_gid.data, guid, sizeof(eprosima::fastrtps::rtps::GUID_t));
 
   rmw_publisher = new rmw_publisher_t;
-  rmw_publisher->implementation_identifier = eprosima_fastrtps_identifier;
+  rmw_publisher->implementation_identifier = rmw_get_implementation_identifier();
   rmw_publisher->data = info;
   rmw_publisher->topic_name = reinterpret_cast<const char *>(new char[strlen(topic_name) + 1]);
   memcpy(const_cast<char *>(rmw_publisher->topic_name), topic_name, strlen(topic_name) + 1);
@@ -842,7 +578,7 @@ rmw_publisher_t * rmw_create_publisher(const rmw_node_t * node,
 
 fail:
   if (info != nullptr) {
-    _delete_typesupport(info->type_support_, info->typesupport_identifier_);
+    rmw_fastrtps_impl::_delete_typesupport(info->type_support_, info->typesupport_identifier_);
     delete info;
   }
 
@@ -856,7 +592,7 @@ rmw_ret_t rmw_destroy_publisher(rmw_node_t * node, rmw_publisher_t * publisher)
     return RMW_RET_ERROR;
   }
 
-  if (node->implementation_identifier != eprosima_fastrtps_identifier) {
+  if (node->implementation_identifier != rmw_get_implementation_identifier()) {
     RMW_SET_ERROR_MSG("publisher handle not from this implementation");
     return RMW_RET_ERROR;
   }
@@ -866,7 +602,7 @@ rmw_ret_t rmw_destroy_publisher(rmw_node_t * node, rmw_publisher_t * publisher)
     return RMW_RET_ERROR;
   }
 
-  if (publisher->implementation_identifier != eprosima_fastrtps_identifier) {
+  if (publisher->implementation_identifier != rmw_get_implementation_identifier()) {
     RMW_SET_ERROR_MSG("publisher handle not from this implementation");
     return RMW_RET_ERROR;
   }
@@ -884,7 +620,8 @@ rmw_ret_t rmw_destroy_publisher(rmw_node_t * node, rmw_publisher_t * publisher)
       }
 
       Participant * participant = impl->participant;
-      _unregister_type(participant, info->type_support_, info->typesupport_identifier_);
+      rmw_fastrtps_impl::_unregister_type(participant, info->type_support_,
+        info->typesupport_identifier_);
     }
     delete info;
   }
@@ -900,7 +637,7 @@ rmw_ret_t rmw_publish(const rmw_publisher_t * publisher, const void * ros_messag
   assert(ros_message);
   rmw_ret_t returnedValue = RMW_RET_ERROR;
 
-  if (publisher->implementation_identifier != eprosima_fastrtps_identifier) {
+  if (publisher->implementation_identifier != rmw_get_implementation_identifier()) {
     RMW_SET_ERROR_MSG("publisher handle not from this implementation");
     return RMW_RET_ERROR;
   }
@@ -911,7 +648,7 @@ rmw_ret_t rmw_publish(const rmw_publisher_t * publisher, const void * ros_messag
   eprosima::fastcdr::FastBuffer buffer;
   eprosima::fastcdr::Cdr ser(buffer);
 
-  if (_serialize_ros_message(ros_message, ser, info->type_support_,
+  if (rmw_fastrtps_impl::_serialize_ros_message(ros_message, ser, info->type_support_,
     info->typesupport_identifier_))
   {
     if (info->publisher_->write(&ser)) {
@@ -1018,7 +755,7 @@ rmw_subscription_t * rmw_create_subscription(const rmw_node_t * node,
   assert(topic_name);
   assert(qos_policies);
 
-  if (node->implementation_identifier != eprosima_fastrtps_identifier) {
+  if (node->implementation_identifier != rmw_get_implementation_identifier()) {
     RMW_SET_ERROR_MSG("node handle not from this implementation");
     return NULL;
   }
@@ -1030,29 +767,27 @@ rmw_subscription_t * rmw_create_subscription(const rmw_node_t * node,
   }
 
   Participant * participant = impl->participant;
-  const rosidl_message_type_support_t * type_support = get_message_typesupport_handle(
-    type_supports, rosidl_typesupport_introspection_c__identifier);
+  const rosidl_message_type_support_t * type_support =
+    rmw_fastrtps_impl::_get_message_typesupport_handle(
+    type_supports);
   if (!type_support) {
-    type_support = get_message_typesupport_handle(
-      type_supports, rosidl_typesupport_introspection_cpp::typesupport_identifier);
-    if (!type_support) {
-      RMW_SET_ERROR_MSG("type support not from this implementation");
-      return NULL;
-    }
+    RMW_SET_ERROR_MSG("type support not from this implementation");
+    return NULL;
   }
 
   CustomSubscriberInfo * info = new CustomSubscriberInfo();
   info->typesupport_identifier_ = type_support->typesupport_identifier;
 
-  std::string type_name = _create_type_name(
+  std::string type_name = rmw_fastrtps_impl::_create_type_name(
     type_support->data, "msg", info->typesupport_identifier_);
 
   if (!Domain::getRegisteredType(participant, type_name.c_str(),
     reinterpret_cast<TopicDataType **>(&info->type_support_)))
   {
-    info->type_support_ = _create_message_type_support(type_support->data,
+    info->type_support_ = rmw_fastrtps_impl::_create_message_type_support(type_support->data,
         info->typesupport_identifier_);
-    _register_type(participant, info->type_support_, info->typesupport_identifier_);
+    rmw_fastrtps_impl::_register_type(participant, info->type_support_,
+      info->typesupport_identifier_);
   }
 
   SubscriberAttributes subscriberParam;
@@ -1074,7 +809,7 @@ rmw_subscription_t * rmw_create_subscription(const rmw_node_t * node,
   }
 
   subscription = new rmw_subscription_t;
-  subscription->implementation_identifier = eprosima_fastrtps_identifier;
+  subscription->implementation_identifier = rmw_get_implementation_identifier();
   subscription->data = info;
   subscription->topic_name = reinterpret_cast<const char *>(new char[strlen(topic_name) + 1]);
   memcpy(const_cast<char *>(subscription->topic_name), topic_name, strlen(topic_name) + 1);
@@ -1084,7 +819,7 @@ fail:
 
   if (info != nullptr) {
     if (info->type_support_ != nullptr) {
-      _delete_typesupport(info->type_support_, info->typesupport_identifier_);
+      rmw_fastrtps_impl::_delete_typesupport(info->type_support_, info->typesupport_identifier_);
     }
     delete info;
   }
@@ -1099,7 +834,7 @@ rmw_ret_t rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subsc
     return RMW_RET_ERROR;
   }
 
-  if (node->implementation_identifier != eprosima_fastrtps_identifier) {
+  if (node->implementation_identifier != rmw_get_implementation_identifier()) {
     RMW_SET_ERROR_MSG("node handle not from this implementation");
     return RMW_RET_ERROR;
   }
@@ -1109,7 +844,7 @@ rmw_ret_t rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subsc
     return RMW_RET_ERROR;
   }
 
-  if (subscription->implementation_identifier != eprosima_fastrtps_identifier) {
+  if (subscription->implementation_identifier != rmw_get_implementation_identifier()) {
     RMW_SET_ERROR_MSG("node handle not from this implementation");
     return RMW_RET_ERROR;
   }
@@ -1131,7 +866,8 @@ rmw_ret_t rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subsc
       }
 
       Participant * participant = impl->participant;
-      _unregister_type(participant, info->type_support_, info->typesupport_identifier_);
+      rmw_fastrtps_impl::_unregister_type(participant, info->type_support_,
+        info->typesupport_identifier_);
     }
     delete info;
   }
@@ -1149,7 +885,7 @@ rmw_ret_t rmw_take(const rmw_subscription_t * subscription, void * ros_message, 
 
   *taken = false;
 
-  if (subscription->implementation_identifier != eprosima_fastrtps_identifier) {
+  if (subscription->implementation_identifier != rmw_get_implementation_identifier()) {
     RMW_SET_ERROR_MSG("publisher handle not from this implementation");
     return RMW_RET_ERROR;
   }
@@ -1164,7 +900,7 @@ rmw_ret_t rmw_take(const rmw_subscription_t * subscription, void * ros_message, 
     info->listener_->data_taken();
 
     if (sinfo.sampleKind == ALIVE) {
-      _deserialize_ros_message(&buffer, ros_message, info->type_support_,
+      rmw_fastrtps_impl::_deserialize_ros_message(&buffer, ros_message, info->type_support_,
         info->typesupport_identifier_);
       *taken = true;
     }
@@ -1190,7 +926,7 @@ rmw_ret_t rmw_take_with_info(
 
   *taken = false;
 
-  if (subscription->implementation_identifier != eprosima_fastrtps_identifier) {
+  if (subscription->implementation_identifier != rmw_get_implementation_identifier()) {
     RMW_SET_ERROR_MSG("publisher handle not from this implementation");
     return RMW_RET_ERROR;
   }
@@ -1205,10 +941,10 @@ rmw_ret_t rmw_take_with_info(
     info->listener_->data_taken();
 
     if (sinfo.sampleKind == ALIVE) {
-      _deserialize_ros_message(&buffer, ros_message, info->type_support_,
+      rmw_fastrtps_impl::_deserialize_ros_message(&buffer, ros_message, info->type_support_,
         info->typesupport_identifier_);
       rmw_gid_t * sender_gid = &message_info->publisher_gid;
-      sender_gid->implementation_identifier = eprosima_fastrtps_identifier;
+      sender_gid->implementation_identifier = rmw_get_implementation_identifier();
       memset(sender_gid->data, 0, RMW_GID_STORAGE_SIZE);
       memcpy(sender_gid->data, &sinfo.sample_identity.writer_guid(),
         sizeof(eprosima::fastrtps::rtps::GUID_t));
@@ -1276,7 +1012,7 @@ private:
 rmw_guard_condition_t * rmw_create_guard_condition()
 {
   rmw_guard_condition_t * guard_condition_handle = new rmw_guard_condition_t;
-  guard_condition_handle->implementation_identifier = eprosima_fastrtps_identifier;
+  guard_condition_handle->implementation_identifier = rmw_get_implementation_identifier();
   guard_condition_handle->data = new GuardCondition();
   return guard_condition_handle;
 }
@@ -1297,7 +1033,7 @@ rmw_ret_t rmw_trigger_guard_condition(const rmw_guard_condition_t * guard_condit
 {
   assert(guard_condition_handle);
 
-  if (guard_condition_handle->implementation_identifier != eprosima_fastrtps_identifier) {
+  if (guard_condition_handle->implementation_identifier != rmw_get_implementation_identifier()) {
     RMW_SET_ERROR_MSG("guard condition handle not from this implementation");
     return RMW_RET_ERROR;
   }
@@ -1319,7 +1055,7 @@ rmw_create_waitset(size_t max_conditions)
     RMW_SET_ERROR_MSG("failed to allocate waitset");
     goto fail;
   }
-  waitset->implementation_identifier = eprosima_fastrtps_identifier;
+  waitset->implementation_identifier = rmw_get_implementation_identifier();
   waitset->data = rmw_allocate(sizeof(CustomWaitsetInfo));
   // This should default-construct the fields of CustomWaitsetInfo
   waitset_info = static_cast<CustomWaitsetInfo *>(waitset->data);
@@ -1352,7 +1088,7 @@ rmw_destroy_waitset(rmw_waitset_t * waitset)
   }
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
     waitset handle,
-    waitset->implementation_identifier, eprosima_fastrtps_identifier,
+    waitset->implementation_identifier, rmw_get_implementation_identifier(),
     return RMW_RET_ERROR)
 
   auto result = RMW_RET_OK;
@@ -1498,7 +1234,7 @@ rmw_client_t * rmw_create_client(const rmw_node_t * node,
   assert(service_name);
   assert(qos_policies);
 
-  if (node->implementation_identifier != eprosima_fastrtps_identifier) {
+  if (node->implementation_identifier != rmw_get_implementation_identifier()) {
     RMW_SET_ERROR_MSG("node handle not from this implementation");
     return NULL;
   }
@@ -1510,16 +1246,12 @@ rmw_client_t * rmw_create_client(const rmw_node_t * node,
   }
 
   Participant * participant = impl->participant;
-
-  const rosidl_service_type_support_t * type_support = get_service_typesupport_handle(
-    type_supports, rosidl_typesupport_introspection_c__identifier);
+  const rosidl_service_type_support_t * type_support =
+    rmw_fastrtps_impl::_get_service_typesupport_handle(
+    type_supports);
   if (!type_support) {
-    type_support = get_service_typesupport_handle(
-      type_supports, rosidl_typesupport_introspection_cpp::typesupport_identifier);
-    if (!type_support) {
-      RMW_SET_ERROR_MSG("type support not from this implementation");
-      return NULL;
-    }
+    RMW_SET_ERROR_MSG("type support not from this implementation");
+    return NULL;
   }
 
   info = new CustomClientInfo();
@@ -1530,29 +1262,35 @@ rmw_client_t * rmw_create_client(const rmw_node_t * node,
   const void * untyped_response_members;
 
   untyped_request_members =
-    get_request_ptr(type_support->data, info->typesupport_identifier_);
-  untyped_response_members = get_response_ptr(type_support->data,
+    rmw_fastrtps_impl::get_request_ptr(type_support->data, info->typesupport_identifier_);
+  untyped_response_members = rmw_fastrtps_impl::get_response_ptr(type_support->data,
       info->typesupport_identifier_);
 
-  std::string request_type_name = _create_type_name(untyped_request_members, "srv",
+  std::string request_type_name = rmw_fastrtps_impl::_create_type_name(untyped_request_members,
+      "srv",
       info->typesupport_identifier_);
-  std::string response_type_name = _create_type_name(untyped_response_members, "srv",
+  std::string response_type_name = rmw_fastrtps_impl::_create_type_name(untyped_response_members,
+      "srv",
       info->typesupport_identifier_);
 
   if (!Domain::getRegisteredType(participant, request_type_name.c_str(),
     reinterpret_cast<TopicDataType **>(&info->request_type_support_)))
   {
-    info->request_type_support_ = _create_request_type_support(type_support->data,
-        info->typesupport_identifier_);
-    _register_type(participant, info->request_type_support_, info->typesupport_identifier_);
+    info->request_type_support_ = rmw_fastrtps_impl::_create_request_type_support(
+      type_support->data,
+      info->typesupport_identifier_);
+    rmw_fastrtps_impl::_register_type(participant, info->request_type_support_,
+      info->typesupport_identifier_);
   }
 
   if (!Domain::getRegisteredType(participant, response_type_name.c_str(),
     reinterpret_cast<TopicDataType **>(&info->response_type_support_)))
   {
-    info->response_type_support_ = _create_response_type_support(type_support->data,
-        info->typesupport_identifier_);
-    _register_type(participant, info->response_type_support_, info->typesupport_identifier_);
+    info->response_type_support_ = rmw_fastrtps_impl::_create_response_type_support(
+      type_support->data,
+      info->typesupport_identifier_);
+    rmw_fastrtps_impl::_register_type(participant, info->response_type_support_,
+      info->typesupport_identifier_);
   }
 
   SubscriberAttributes subscriberParam;
@@ -1596,7 +1334,7 @@ rmw_client_t * rmw_create_client(const rmw_node_t * node,
   info->writer_guid_ = info->request_publisher_->getGuid();
 
   client = new rmw_client_t;
-  client->implementation_identifier = eprosima_fastrtps_identifier;
+  client->implementation_identifier = rmw_get_implementation_identifier();
   client->data = info;
   client->service_name = reinterpret_cast<const char *>(rmw_allocate(strlen(service_name) + 1));
   if (!client->service_name) {
@@ -1624,11 +1362,13 @@ fail:
 
     if (impl) {
       if (info->request_type_support_ != nullptr) {
-        _unregister_type(participant, info->request_type_support_, info->typesupport_identifier_);
+        rmw_fastrtps_impl::_unregister_type(participant, info->request_type_support_,
+          info->typesupport_identifier_);
       }
 
       if (info->response_type_support_ != nullptr) {
-        _unregister_type(participant, info->response_type_support_, info->typesupport_identifier_);
+        rmw_fastrtps_impl::_unregister_type(participant, info->response_type_support_,
+          info->typesupport_identifier_);
       }
     } else {
       fprintf(stderr,
@@ -1651,7 +1391,7 @@ rmw_ret_t rmw_send_request(const rmw_client_t * client,
 
   rmw_ret_t returnedValue = RMW_RET_ERROR;
 
-  if (client->implementation_identifier != eprosima_fastrtps_identifier) {
+  if (client->implementation_identifier != rmw_get_implementation_identifier()) {
     RMW_SET_ERROR_MSG("node handle not from this implementation");
     return RMW_RET_ERROR;
   }
@@ -1662,7 +1402,7 @@ rmw_ret_t rmw_send_request(const rmw_client_t * client,
   eprosima::fastcdr::FastBuffer buffer;
   eprosima::fastcdr::Cdr ser(buffer);
 
-  if (_serialize_ros_message(ros_request, ser, info->request_type_support_,
+  if (rmw_fastrtps_impl::_serialize_ros_message(ros_request, ser, info->request_type_support_,
     info->typesupport_identifier_))
   {
     eprosima::fastrtps::rtps::WriteParams wparams;
@@ -1693,7 +1433,7 @@ rmw_ret_t rmw_take_request(const rmw_service_t * service,
 
   *taken = false;
 
-  if (service->implementation_identifier != eprosima_fastrtps_identifier) {
+  if (service->implementation_identifier != rmw_get_implementation_identifier()) {
     RMW_SET_ERROR_MSG("service handle not from this implementation");
     return RMW_RET_ERROR;
   }
@@ -1704,7 +1444,8 @@ rmw_ret_t rmw_take_request(const rmw_service_t * service,
   CustomServiceRequest request = info->listener_->getRequest();
 
   if (request.buffer_ != nullptr) {
-    _deserialize_ros_message(request.buffer_, ros_request, info->request_type_support_,
+    rmw_fastrtps_impl::_deserialize_ros_message(request.buffer_, ros_request,
+      info->request_type_support_,
       info->typesupport_identifier_);
 
     // Get header
@@ -1733,7 +1474,7 @@ rmw_ret_t rmw_take_response(const rmw_client_t * client,
 
   *taken = false;
 
-  if (client->implementation_identifier != eprosima_fastrtps_identifier) {
+  if (client->implementation_identifier != rmw_get_implementation_identifier()) {
     RMW_SET_ERROR_MSG("service handle not from this implementation");
     return RMW_RET_ERROR;
   }
@@ -1744,7 +1485,8 @@ rmw_ret_t rmw_take_response(const rmw_client_t * client,
   CustomClientResponse response = info->listener_->getResponse();
 
   if (response.buffer_ != nullptr) {
-    _deserialize_ros_message(response.buffer_, ros_response, info->response_type_support_,
+    rmw_fastrtps_impl::_deserialize_ros_message(response.buffer_, ros_response,
+      info->response_type_support_,
       info->typesupport_identifier_);
 
     request_header->sequence_number = ((int64_t)response.sample_identity_.sequence_number().high) <<
@@ -1768,7 +1510,7 @@ rmw_ret_t rmw_send_response(const rmw_service_t * service,
 
   rmw_ret_t returnedValue = RMW_RET_ERROR;
 
-  if (service->implementation_identifier != eprosima_fastrtps_identifier) {
+  if (service->implementation_identifier != rmw_get_implementation_identifier()) {
     RMW_SET_ERROR_MSG("service handle not from this implementation");
     return RMW_RET_ERROR;
   }
@@ -1779,7 +1521,7 @@ rmw_ret_t rmw_send_response(const rmw_service_t * service,
   eprosima::fastcdr::FastBuffer buffer;
   eprosima::fastcdr::Cdr ser(buffer);
 
-  _serialize_ros_message(ros_response, ser, info->response_type_support_,
+  rmw_fastrtps_impl::_serialize_ros_message(ros_response, ser, info->response_type_support_,
     info->typesupport_identifier_);
   eprosima::fastrtps::rtps::WriteParams wparams;
   memcpy(&wparams.related_sample_identity().writer_guid(), request_header->writer_guid,
@@ -1810,7 +1552,7 @@ rmw_service_t * rmw_create_service(const rmw_node_t * node,
   assert(service_name);
   assert(qos_policies);
 
-  if (node->implementation_identifier != eprosima_fastrtps_identifier) {
+  if (node->implementation_identifier != rmw_get_implementation_identifier()) {
     RMW_SET_ERROR_MSG("node handle not from this implementation");
     return NULL;
   }
@@ -1822,15 +1564,12 @@ rmw_service_t * rmw_create_service(const rmw_node_t * node,
   }
 
   Participant * participant = impl->participant;
-  const rosidl_service_type_support_t * type_support = get_service_typesupport_handle(
-    type_supports, rosidl_typesupport_introspection_c__identifier);
+  const rosidl_service_type_support_t * type_support =
+    rmw_fastrtps_impl::_get_service_typesupport_handle(
+    type_supports);
   if (!type_support) {
-    type_support = get_service_typesupport_handle(
-      type_supports, rosidl_typesupport_introspection_cpp::typesupport_identifier);
-    if (!type_support) {
-      RMW_SET_ERROR_MSG("type support not from this implementation");
-      return NULL;
-    }
+    RMW_SET_ERROR_MSG("type support not from this implementation");
+    return NULL;
   }
 
   info = new CustomServiceInfo();
@@ -1841,29 +1580,35 @@ rmw_service_t * rmw_create_service(const rmw_node_t * node,
   const void * untyped_response_members;
 
   untyped_request_members =
-    get_request_ptr(type_support->data, info->typesupport_identifier_);
-  untyped_response_members = get_response_ptr(type_support->data,
+    rmw_fastrtps_impl::get_request_ptr(type_support->data, info->typesupport_identifier_);
+  untyped_response_members = rmw_fastrtps_impl::get_response_ptr(type_support->data,
       info->typesupport_identifier_);
 
-  std::string request_type_name = _create_type_name(untyped_request_members, "srv",
+  std::string request_type_name = rmw_fastrtps_impl::_create_type_name(untyped_request_members,
+      "srv",
       info->typesupport_identifier_);
-  std::string response_type_name = _create_type_name(untyped_response_members, "srv",
+  std::string response_type_name = rmw_fastrtps_impl::_create_type_name(untyped_response_members,
+      "srv",
       info->typesupport_identifier_);
 
   if (!Domain::getRegisteredType(participant, request_type_name.c_str(),
     reinterpret_cast<TopicDataType **>(&info->request_type_support_)))
   {
-    info->request_type_support_ = _create_request_type_support(type_support->data,
-        info->typesupport_identifier_);
-    _register_type(participant, info->request_type_support_, info->typesupport_identifier_);
+    info->request_type_support_ = rmw_fastrtps_impl::_create_request_type_support(
+      type_support->data,
+      info->typesupport_identifier_);
+    rmw_fastrtps_impl::_register_type(participant, info->request_type_support_,
+      info->typesupport_identifier_);
   }
 
   if (!Domain::getRegisteredType(participant, response_type_name.c_str(),
     reinterpret_cast<TopicDataType **>(&info->response_type_support_)))
   {
-    info->response_type_support_ = _create_response_type_support(type_support->data,
-        info->typesupport_identifier_);
-    _register_type(participant, info->response_type_support_, info->typesupport_identifier_);
+    info->response_type_support_ = rmw_fastrtps_impl::_create_response_type_support(
+      type_support->data,
+      info->typesupport_identifier_);
+    rmw_fastrtps_impl::_register_type(participant, info->response_type_support_,
+      info->typesupport_identifier_);
   }
 
   SubscriberAttributes subscriberParam;
@@ -1905,7 +1650,7 @@ rmw_service_t * rmw_create_service(const rmw_node_t * node,
   }
 
   service = new rmw_service_t;
-  service->implementation_identifier = eprosima_fastrtps_identifier;
+  service->implementation_identifier = rmw_get_implementation_identifier();
   service->data = info;
   service->service_name = reinterpret_cast<const char *>(
     rmw_allocate(strlen(service_name) + 1));
@@ -1933,11 +1678,13 @@ fail:
     }
 
     if (info->request_type_support_ != nullptr) {
-      _unregister_type(participant, info->request_type_support_, info->typesupport_identifier_);
+      rmw_fastrtps_impl::_unregister_type(participant, info->request_type_support_,
+        info->typesupport_identifier_);
     }
 
     if (info->response_type_support_ != nullptr) {
-      _unregister_type(participant, info->response_type_support_, info->typesupport_identifier_);
+      rmw_fastrtps_impl::_unregister_type(participant, info->response_type_support_,
+        info->typesupport_identifier_);
     }
 
     delete info;
@@ -1953,7 +1700,7 @@ rmw_ret_t rmw_destroy_service(rmw_node_t * node, rmw_service_t * service)
     RMW_SET_ERROR_MSG("service handle is null");
     return RMW_RET_ERROR;
   }
-  if (service->implementation_identifier != eprosima_fastrtps_identifier) {
+  if (service->implementation_identifier != rmw_get_implementation_identifier()) {
     RMW_SET_ERROR_MSG("publisher handle not from this implementation");
     return RMW_RET_ERROR;
   }
@@ -1971,11 +1718,11 @@ rmw_ret_t rmw_destroy_service(rmw_node_t * node, rmw_service_t * service)
     }
 
     if (info->request_type_support_ != nullptr) {
-      _unregister_type(info->participant_, info->request_type_support_,
+      rmw_fastrtps_impl::_unregister_type(info->participant_, info->request_type_support_,
         info->typesupport_identifier_);
     }
     if (info->response_type_support_ != nullptr) {
-      _unregister_type(info->participant_, info->response_type_support_,
+      rmw_fastrtps_impl::_unregister_type(info->participant_, info->response_type_support_,
         info->typesupport_identifier_);
     }
     delete info;
@@ -1992,7 +1739,7 @@ rmw_ret_t rmw_destroy_client(rmw_node_t * node, rmw_client_t * client)
     RMW_SET_ERROR_MSG("client handle is null");
     return RMW_RET_ERROR;
   }
-  if (client->implementation_identifier != eprosima_fastrtps_identifier) {
+  if (client->implementation_identifier != rmw_get_implementation_identifier()) {
     RMW_SET_ERROR_MSG("publisher handle not from this implementation");
     return RMW_RET_ERROR;
   }
@@ -2009,11 +1756,11 @@ rmw_ret_t rmw_destroy_client(rmw_node_t * node, rmw_client_t * client)
       delete info->listener_;
     }
     if (info->request_type_support_ != nullptr) {
-      _unregister_type(info->participant_, info->request_type_support_,
+      rmw_fastrtps_impl::_unregister_type(info->participant_, info->request_type_support_,
         info->typesupport_identifier_);
     }
     if (info->response_type_support_ != nullptr) {
-      _unregister_type(info->participant_, info->response_type_support_,
+      rmw_fastrtps_impl::_unregister_type(info->participant_, info->response_type_support_,
         info->typesupport_identifier_);
     }
     delete info;
@@ -2246,7 +1993,7 @@ rmw_get_topic_names_and_types(
   }
 
   // Get participant pointer from node
-  if (node->implementation_identifier != eprosima_fastrtps_identifier) {
+  if (node->implementation_identifier != rmw_get_implementation_identifier()) {
     RMW_SET_ERROR_MSG("node handle not from this implementation");
     return RMW_RET_ERROR;
   }
@@ -2422,7 +2169,7 @@ rmw_count_publishers(
     return RMW_RET_ERROR;
   }
   // Get participant pointer from node
-  if (node->implementation_identifier != eprosima_fastrtps_identifier) {
+  if (node->implementation_identifier != rmw_get_implementation_identifier()) {
     RMW_SET_ERROR_MSG("node handle not from this implementation");
     return RMW_RET_ERROR;
   }
@@ -2462,7 +2209,7 @@ rmw_count_subscribers(
     return RMW_RET_ERROR;
   }
   // Get participant pointer from node
-  if (node->implementation_identifier != eprosima_fastrtps_identifier) {
+  if (node->implementation_identifier != rmw_get_implementation_identifier()) {
     RMW_SET_ERROR_MSG("node handle not from this implementation");
     return RMW_RET_ERROR;
   }
@@ -2503,7 +2250,7 @@ rmw_service_server_is_available(
 
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
     node handle,
-    node->implementation_identifier, eprosima_fastrtps_identifier,
+    node->implementation_identifier, rmw_get_implementation_identifier(),
     return RMW_RET_ERROR);
 
   if (!client) {
@@ -2577,7 +2324,7 @@ rmw_get_gid_for_publisher(const rmw_publisher_t * publisher, rmw_gid_t * gid)
     return RMW_RET_ERROR;
   }
 
-  if (publisher->implementation_identifier != eprosima_fastrtps_identifier) {
+  if (publisher->implementation_identifier != rmw_get_implementation_identifier()) {
     RMW_SET_ERROR_MSG("publisher handle not from this implementation");
     return RMW_RET_ERROR;
   }
@@ -2606,7 +2353,7 @@ rmw_compare_gids_equal(const rmw_gid_t * gid1, const rmw_gid_t * gid2, bool * re
     return RMW_RET_ERROR;
   }
 
-  if (gid1->implementation_identifier != eprosima_fastrtps_identifier) {
+  if (gid1->implementation_identifier != rmw_get_implementation_identifier()) {
     RMW_SET_ERROR_MSG("guid1 handle not from this implementation");
     return RMW_RET_ERROR;
   }
@@ -2616,7 +2363,7 @@ rmw_compare_gids_equal(const rmw_gid_t * gid1, const rmw_gid_t * gid2, bool * re
     return RMW_RET_ERROR;
   }
 
-  if (gid2->implementation_identifier != eprosima_fastrtps_identifier) {
+  if (gid2->implementation_identifier != rmw_get_implementation_identifier()) {
     RMW_SET_ERROR_MSG("gid1 handle not from this implementation");
     return RMW_RET_ERROR;
   }

--- a/rmw_fastrtps_cpp/src/functions_impl_cpp.cpp
+++ b/rmw_fastrtps_cpp/src/functions_impl_cpp.cpp
@@ -1,0 +1,286 @@
+// Copyright 2016 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+
+#include "rmw/rmw.h"
+#include "rmw/error_handling.h"
+
+#include "rosidl_typesupport_introspection_c/field_types.h"
+#include "rosidl_typesupport_introspection_c/identifier.h"
+#include "rosidl_typesupport_introspection_c/message_introspection.h"
+#include "rosidl_typesupport_introspection_c/service_introspection.h"
+
+#include "rosidl_typesupport_introspection_cpp/identifier.hpp"
+#include "rosidl_typesupport_introspection_cpp/message_introspection.hpp"
+#include "rosidl_typesupport_introspection_cpp/service_introspection.hpp"
+
+#include "rmw_fastrtps_cpp/MessageTypeSupport.h"
+#include "rmw_fastrtps_cpp/ServiceTypeSupport.h"
+#include "rmw_fastrtps_cpp/TypeSupport_impl.h"
+
+#include "rmw_fastrtps_cpp/common_functions.hpp"
+
+#include "fastcdr/Cdr.h"
+#include "fastrtps/Domain.h"
+#include "fastrtps/participant/Participant.h"
+
+namespace rmw_fastrtps_impl
+{
+using MessageTypeSupport_c =
+    rmw_fastrtps_common::MessageTypeSupport<rosidl_typesupport_introspection_c__MessageMembers>;
+using MessageTypeSupport_cpp =
+    rmw_fastrtps_common::MessageTypeSupport<rosidl_typesupport_introspection_cpp::MessageMembers>;
+using TypeSupport_c =
+    rmw_fastrtps_common::TypeSupport<rosidl_typesupport_introspection_c__MessageMembers>;
+using TypeSupport_cpp =
+    rmw_fastrtps_common::TypeSupport<rosidl_typesupport_introspection_cpp::MessageMembers>;
+
+using RequestTypeSupport_c = rmw_fastrtps_common::RequestTypeSupport<
+    rosidl_typesupport_introspection_c__ServiceMembers,
+    rosidl_typesupport_introspection_c__MessageMembers
+    >;
+using RequestTypeSupport_cpp = rmw_fastrtps_common::RequestTypeSupport<
+    rosidl_typesupport_introspection_cpp::ServiceMembers,
+    rosidl_typesupport_introspection_cpp::MessageMembers
+    >;
+
+using ResponseTypeSupport_c = rmw_fastrtps_common::ResponseTypeSupport<
+    rosidl_typesupport_introspection_c__ServiceMembers,
+    rosidl_typesupport_introspection_c__MessageMembers
+    >;
+using ResponseTypeSupport_cpp = rmw_fastrtps_common::ResponseTypeSupport<
+    rosidl_typesupport_introspection_cpp::ServiceMembers,
+    rosidl_typesupport_introspection_cpp::MessageMembers
+    >;
+
+bool using_introspection_c_typesupport(const char * typesupport_identifier)
+{
+  return typesupport_identifier == rosidl_typesupport_introspection_c__identifier;
+}
+
+bool using_introspection_cpp_typesupport(const char * typesupport_identifier)
+{
+  return typesupport_identifier ==
+         rosidl_typesupport_introspection_cpp::typesupport_identifier;
+}
+
+const rosidl_message_type_support_t * _get_message_typesupport_handle(
+  const rosidl_message_type_support_t * type_supports)
+{
+  const rosidl_message_type_support_t * type_support = get_message_typesupport_handle(
+    type_supports, rosidl_typesupport_introspection_c__identifier);
+  if (!type_support) {
+    type_support = get_message_typesupport_handle(
+      type_supports, rosidl_typesupport_introspection_cpp::typesupport_identifier);
+  }
+  return type_support;
+}
+
+const rosidl_service_type_support_t * _get_service_typesupport_handle(
+  const rosidl_service_type_support_t * type_supports)
+{
+  const rosidl_service_type_support_t * type_support = get_service_typesupport_handle(
+    type_supports, rosidl_typesupport_introspection_c__identifier);
+  if (!type_support) {
+    type_support = get_service_typesupport_handle(
+      type_supports, rosidl_typesupport_introspection_cpp::typesupport_identifier);
+  }
+  return type_support;
+}
+
+ROSIDL_TYPESUPPORT_INTROSPECTION_CPP_LOCAL
+std::string
+_create_type_name(
+  const void * untyped_members,
+  const std::string & sep,
+  const char * typesupport)
+{
+  if (using_introspection_c_typesupport(typesupport)) {
+    return rmw_fastrtps_common::_create_type_name<
+      rosidl_typesupport_introspection_c__MessageMembers
+    >(untyped_members, sep);
+  } else if (using_introspection_cpp_typesupport(typesupport)) {
+    return rmw_fastrtps_common::_create_type_name<
+      rosidl_typesupport_introspection_cpp::MessageMembers
+    >(untyped_members, sep);
+  }
+  RMW_SET_ERROR_MSG("Unknown typesupport identifier");
+  return "";
+}
+
+const void * get_request_ptr(const void * untyped_service_members, const char * typesupport)
+{
+  if (using_introspection_c_typesupport(typesupport)) {
+    return rmw_fastrtps_common::get_request_ptr<
+      rosidl_typesupport_introspection_c__ServiceMembers
+    >(untyped_service_members);
+  } else if (using_introspection_cpp_typesupport(typesupport)) {
+    return rmw_fastrtps_common::get_request_ptr<
+      rosidl_typesupport_introspection_cpp::ServiceMembers
+    >(untyped_service_members);
+  }
+  RMW_SET_ERROR_MSG("Unknown typesupport identifier");
+  return NULL;
+}
+
+const void * get_response_ptr(const void * untyped_service_members, const char * typesupport)
+{
+  if (using_introspection_c_typesupport(typesupport)) {
+    return rmw_fastrtps_common::get_response_ptr<
+      rosidl_typesupport_introspection_c__ServiceMembers
+    >(untyped_service_members);
+  } else if (using_introspection_cpp_typesupport(typesupport)) {
+    return rmw_fastrtps_common::get_response_ptr<
+      rosidl_typesupport_introspection_cpp::ServiceMembers
+    >(untyped_service_members);
+  }
+  RMW_SET_ERROR_MSG("Unknown typesupport identifier");
+  return NULL;
+}
+
+void *
+_create_message_type_support(const void * untyped_members, const char * typesupport_identifier)
+{
+  if (using_introspection_c_typesupport(typesupport_identifier)) {
+    auto members = static_cast<const rosidl_typesupport_introspection_c__MessageMembers *>(
+      untyped_members);
+    return new MessageTypeSupport_c(members);
+  } else if (using_introspection_cpp_typesupport(typesupport_identifier)) {
+    auto members = static_cast<const rosidl_typesupport_introspection_cpp::MessageMembers *>(
+      untyped_members);
+    return new MessageTypeSupport_cpp(members);
+  }
+  RMW_SET_ERROR_MSG("Unknown typesupport identifier");
+  return nullptr;
+}
+
+void *
+_create_request_type_support(const void * untyped_members, const char * typesupport_identifier)
+{
+  if (using_introspection_c_typesupport(typesupport_identifier)) {
+    auto members = static_cast<const rosidl_typesupport_introspection_c__ServiceMembers *>(
+      untyped_members);
+    return new RequestTypeSupport_c(members);
+  } else if (using_introspection_cpp_typesupport(typesupport_identifier)) {
+    auto members = static_cast<const rosidl_typesupport_introspection_cpp::ServiceMembers *>(
+      untyped_members);
+    return new RequestTypeSupport_cpp(members);
+  }
+  RMW_SET_ERROR_MSG("Unknown typesupport identifier");
+  return nullptr;
+}
+
+void *
+_create_response_type_support(const void * untyped_members, const char * typesupport_identifier)
+{
+  if (using_introspection_c_typesupport(typesupport_identifier)) {
+    auto members = static_cast<const rosidl_typesupport_introspection_c__ServiceMembers *>(
+      untyped_members);
+    return new ResponseTypeSupport_c(members);
+  } else if (using_introspection_cpp_typesupport(typesupport_identifier)) {
+    auto members = static_cast<const rosidl_typesupport_introspection_cpp::ServiceMembers *>(
+      untyped_members);
+    return new ResponseTypeSupport_cpp(members);
+  }
+  RMW_SET_ERROR_MSG("Unknown typesupport identifier");
+  return nullptr;
+}
+
+void
+_register_type(
+  eprosima::fastrtps::Participant * participant, void * untyped_typesupport,
+  const char * typesupport_identifier)
+{
+  if (using_introspection_c_typesupport(typesupport_identifier)) {
+    auto typed_typesupport = static_cast<TypeSupport_c *>(untyped_typesupport);
+    eprosima::fastrtps::Domain::registerType(participant, typed_typesupport);
+  } else if (using_introspection_cpp_typesupport(typesupport_identifier)) {
+    auto typed_typesupport = static_cast<TypeSupport_cpp *>(untyped_typesupport);
+    eprosima::fastrtps::Domain::registerType(participant, typed_typesupport);
+  } else {
+    RMW_SET_ERROR_MSG("Unknown typesupport identifier");
+  }
+}
+
+void
+_unregister_type(
+  eprosima::fastrtps::Participant * participant, void * untyped_typesupport,
+  const char * typesupport_identifier)
+{
+  if (using_introspection_c_typesupport(typesupport_identifier)) {
+    auto typed_typesupport = static_cast<TypeSupport_c *>(untyped_typesupport);
+    if (eprosima::fastrtps::Domain::unregisterType(participant, typed_typesupport->getName())) {
+      delete typed_typesupport;
+    }
+  } else if (using_introspection_cpp_typesupport(typesupport_identifier)) {
+    auto typed_typesupport = static_cast<TypeSupport_cpp *>(untyped_typesupport);
+    if (eprosima::fastrtps::Domain::unregisterType(participant, typed_typesupport->getName())) {
+      delete typed_typesupport;
+    }
+  } else {
+    RMW_SET_ERROR_MSG("Unknown typesupport identifier");
+  }
+}
+
+void
+_delete_typesupport(void * untyped_typesupport, const char * typesupport_identifier)
+{
+  if (using_introspection_c_typesupport(typesupport_identifier)) {
+    auto typed_typesupport = static_cast<MessageTypeSupport_c *>(untyped_typesupport);
+    if (typed_typesupport != nullptr) {
+      delete typed_typesupport;
+    }
+  } else if (using_introspection_cpp_typesupport(typesupport_identifier)) {
+    auto typed_typesupport = static_cast<MessageTypeSupport_cpp *>(untyped_typesupport);
+    if (typed_typesupport != nullptr) {
+      delete typed_typesupport;
+    }
+  } else {
+    RMW_SET_ERROR_MSG("Unknown typesupport identifier");
+  }
+}
+
+bool
+_serialize_ros_message(
+  const void * ros_message, eprosima::fastcdr::Cdr & ser, void * untyped_typesupport,
+  const char * typesupport_identifier)
+{
+  if (using_introspection_c_typesupport(typesupport_identifier)) {
+    auto typed_typesupport = static_cast<MessageTypeSupport_c *>(untyped_typesupport);
+    return typed_typesupport->serializeROSmessage(ros_message, ser);
+  } else if (using_introspection_cpp_typesupport(typesupport_identifier)) {
+    auto typed_typesupport = static_cast<MessageTypeSupport_cpp *>(untyped_typesupport);
+    return typed_typesupport->serializeROSmessage(ros_message, ser);
+  }
+  RMW_SET_ERROR_MSG("Unknown typesupport identifier");
+  return false;
+}
+
+bool
+_deserialize_ros_message(
+  eprosima::fastcdr::FastBuffer * buffer, void * ros_message, void * untyped_typesupport,
+  const char * typesupport_identifier)
+{
+  if (using_introspection_c_typesupport(typesupport_identifier)) {
+    auto typed_typesupport = static_cast<TypeSupport_c *>(untyped_typesupport);
+    return typed_typesupport->deserializeROSmessage(buffer, ros_message);
+  } else if (using_introspection_cpp_typesupport(typesupport_identifier)) {
+    auto typed_typesupport = static_cast<TypeSupport_cpp *>(untyped_typesupport);
+    return typed_typesupport->deserializeROSmessage(buffer, ros_message);
+  }
+  RMW_SET_ERROR_MSG("Unknown typesupport identifier");
+  return false;
+}
+}  // namespace rmw_fastrtps_impl


### PR DESCRIPTION
This moves the C and C++ specializations each to separate units, keeping the common code in one place.

The changes in this PR improve readability, so the general design of the code is abstracted from the C and C++ specializations.

Depends on #75 
Connect to #75 