### PR TITLE
Control shared/static linking via BUILD_SHARED_LIBS and ament_cmake_ros

### DIFF
--- a/rmw_fastrtps_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_cpp/CMakeLists.txt
@@ -20,7 +20,7 @@ if(NOT WIN32)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wextra -Wpedantic")
 endif()
 
-find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
 
 find_package(rcutils REQUIRED)
 
@@ -42,7 +42,7 @@ ament_export_dependencies(rosidl_typesupport_introspection_cpp)
 
 include_directories(include)
 
-add_library(rmw_fastrtps_cpp SHARED
+add_library(rmw_fastrtps_cpp
   src/functions.cpp
 )
 target_link_libraries(rmw_fastrtps_cpp

--- a/rmw_fastrtps_cpp/package.xml
+++ b/rmw_fastrtps_cpp/package.xml
@@ -7,7 +7,7 @@
   <maintainer email="ricardogonzalez@eprosima.com">Ricardo González</maintainer>
   <license>Apache License 2.0</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
   <buildtool_depend>fastrtps_cmake_module</buildtool_depend>
 
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>


### PR DESCRIPTION
This PR delegates the decision to build a shared or a static library to CMake's BUILD_SHARED_LIBS

Update:

Connects to https://github.com/ros2/ros2/issues/306