### PR TITLE
Added CDR encapsulation

### DIFF
--- a/rmw_fastrtps_cpp/src/functions.cpp
+++ b/rmw_fastrtps_cpp/src/functions.cpp
@@ -1042,7 +1042,8 @@ rmw_ret_t rmw_publish(const rmw_publisher_t * publisher, const void * ros_messag
   assert(info);
 
   eprosima::fastcdr::FastBuffer buffer;
-  eprosima::fastcdr::Cdr ser(buffer);
+  eprosima::fastcdr::Cdr ser(buffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+    eprosima::fastcdr::Cdr::DDS_CDR);
 
   if (_serialize_ros_message(ros_message, ser, info->type_support_,
     info->typesupport_identifier_))
@@ -1808,7 +1809,8 @@ rmw_ret_t rmw_send_request(const rmw_client_t * client,
   assert(info);
 
   eprosima::fastcdr::FastBuffer buffer;
-  eprosima::fastcdr::Cdr ser(buffer);
+  eprosima::fastcdr::Cdr ser(buffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+    eprosima::fastcdr::Cdr::DDS_CDR);
 
   if (_serialize_ros_message(ros_request, ser, info->request_type_support_,
     info->typesupport_identifier_))
@@ -1925,7 +1927,8 @@ rmw_ret_t rmw_send_response(const rmw_service_t * service,
   assert(info);
 
   eprosima::fastcdr::FastBuffer buffer;
-  eprosima::fastcdr::Cdr ser(buffer);
+  eprosima::fastcdr::Cdr ser(buffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+    eprosima::fastcdr::Cdr::DDS_CDR);
 
   _serialize_ros_message(ros_response, ser, info->response_type_support_,
     info->typesupport_identifier_);


### PR DESCRIPTION
In future version of Fast RTPS, CDR encapsulation has to be done outside of the fastrtps library. This PR implements the CDR encapsulation on rmw_fastrtps_cpp.