### PR TITLE
Cherry pick sros2 update for Fast-RTPS master support

### DIFF
--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport_impl.h
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport_impl.h
@@ -946,7 +946,8 @@ bool TypeSupport<MembersType>::serialize(
   eprosima::fastcdr::Cdr * ser = static_cast<eprosima::fastcdr::Cdr *>(data);
   if (payload->max_size >= ser->getSerializedDataLength()) {
     payload->length = static_cast<uint32_t>(ser->getSerializedDataLength());
-    payload->encapsulation = ser->endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+    payload->encapsulation = ser->endianness() ==
+      eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
     memcpy(payload->data, ser->getBufferPointer(), ser->getSerializedDataLength());
     return true;
   }

--- a/rmw_fastrtps_cpp/src/functions.cpp
+++ b/rmw_fastrtps_cpp/src/functions.cpp
@@ -948,7 +948,8 @@ rmw_ret_t rmw_publish(const rmw_publisher_t * publisher, const void * ros_messag
   assert(info);
 
   eprosima::fastcdr::FastBuffer buffer;
-  eprosima::fastcdr::Cdr ser(buffer);
+  eprosima::fastcdr::Cdr ser(buffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+    eprosima::fastcdr::Cdr::DDS_CDR);
 
   if (_serialize_ros_message(ros_message, ser, info->type_support_,
     info->typesupport_identifier_))
@@ -1699,7 +1700,8 @@ rmw_ret_t rmw_send_request(const rmw_client_t * client,
   assert(info);
 
   eprosima::fastcdr::FastBuffer buffer;
-  eprosima::fastcdr::Cdr ser(buffer);
+  eprosima::fastcdr::Cdr ser(buffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+    eprosima::fastcdr::Cdr::DDS_CDR);
 
   if (_serialize_ros_message(ros_request, ser, info->request_type_support_,
     info->typesupport_identifier_))
@@ -1816,7 +1818,8 @@ rmw_ret_t rmw_send_response(const rmw_service_t * service,
   assert(info);
 
   eprosima::fastcdr::FastBuffer buffer;
-  eprosima::fastcdr::Cdr ser(buffer);
+  eprosima::fastcdr::Cdr ser(buffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+    eprosima::fastcdr::Cdr::DDS_CDR);
 
   _serialize_ros_message(ros_response, ser, info->response_type_support_,
     info->typesupport_identifier_);


### PR DESCRIPTION
This cherry picks a330d0e from the sros2 branch (with a style fixup) at the suggestion of @mikaelarguedas in order to support the current master branch of eProsima/Fast-RTPS.

Combined with https://github.com/ros2/ros2/pull/332 this will enable the update of Fast-RTPS to upstream's master once some local CMake changes are accepted upstream.