### PR TITLE
fix usage of deleted memory introduced in #97

### DIFF
--- a/rmw_fastrtps_cpp/src/functions.cpp
+++ b/rmw_fastrtps_cpp/src/functions.cpp
@@ -769,12 +769,12 @@ rmw_ret_t rmw_destroy_node(rmw_node_t * node)
   node->namespace_ = nullptr;
   free(static_cast<void *>(node));
 
-  delete impl;
-
   if (RMW_RET_OK != rmw_destroy_guard_condition(impl->graph_guard_condition)) {
     RMW_SET_ERROR_MSG("failed to destroy graph guard condition");
     result_ret = RMW_RET_ERROR;
   }
+
+  delete impl;
 
   Domain::removeParticipant(participant);
 


### PR DESCRIPTION
The problematic `delete` line was moved above the block which destroys the guard condition in https://github.com/ros2/rmw_fastrtps/commit/181265638dac5253d45816a1d3bb652603244e7f#diff-8225b098f1ec4debcdcee03d65ae95d5R771

Before: http://ci.ros2.org/job/ci_windows/2693/testReport/
After: http://ci.ros2.org/job/ci_windows/2694/testReport/

Fixes ros2/build_cop#19