### PR TITLE
fix unnecessary wake ups

### DIFF
--- a/rmw_fastrtps_cpp/src/functions.cpp
+++ b/rmw_fastrtps_cpp/src/functions.cpp
@@ -366,11 +366,17 @@ public:
       memcpy(tempMsg.buffer, change->serializedPayload.data, tempMsg.length);
       if (proxyData.readFromCDRMessage(&tempMsg)) {
         mapmutex.lock();
-        topicNtypes[proxyData.topicName()].insert(proxyData.typeName());
-        rmw_ret_t ret = rmw_trigger_guard_condition(graph_guard_condition_);
-        if (ret != RMW_RET_OK) {
-          fprintf(stderr, "failed to trigger graph guard condition: %s\n",
-            rmw_get_error_string_safe());
+        auto it = topicNtypes.find(proxyData.topicName());
+        if (
+          it == topicNtypes.end() ||
+          it->second.find(proxyData.typeName()) == it->second.end())
+        {
+          topicNtypes[proxyData.topicName()].insert(proxyData.typeName());
+          rmw_ret_t ret = rmw_trigger_guard_condition(graph_guard_condition_);
+          if (ret != RMW_RET_OK) {
+            fprintf(stderr, "failed to trigger graph guard condition: %s\n",
+              rmw_get_error_string_safe());
+          }
         }
         mapmutex.unlock();
       }

--- a/rmw_fastrtps_cpp/src/functions.cpp
+++ b/rmw_fastrtps_cpp/src/functions.cpp
@@ -445,7 +445,7 @@ public:
     conditionVariable_ = conditionVariable;
   }
 
-  void dettachCondition()
+  void detachCondition()
   {
     std::lock_guard<std::mutex> lock(internalMutex_);
     conditionMutex_ = NULL;
@@ -1016,7 +1016,7 @@ public:
     conditionVariable_ = conditionVariable;
   }
 
-  void dettachCondition()
+  void detachCondition()
   {
     std::lock_guard<std::mutex> lock(internalMutex_);
     conditionMutex_ = NULL;
@@ -1288,7 +1288,7 @@ public:
     conditionVariable_ = conditionVariable;
   }
 
-  void dettachCondition()
+  void detachCondition()
   {
     std::lock_guard<std::mutex> lock(internalMutex_);
     conditionMutex_ = NULL;
@@ -1507,7 +1507,7 @@ public:
     conditionVariable_ = conditionVariable;
   }
 
-  void dettachCondition()
+  void detachCondition()
   {
     std::lock_guard<std::mutex> lock(internalMutex_);
     conditionMutex_ = NULL;
@@ -2227,7 +2227,7 @@ rmw_ret_t rmw_wait(rmw_subscriptions_t * subscriptions,
       subscriptions->subscribers[i] = 0;
     }
     lock.unlock();
-    custom_subscriber_info->listener_->dettachCondition();
+    custom_subscriber_info->listener_->detachCondition();
     lock.lock();
   }
 
@@ -2238,7 +2238,7 @@ rmw_ret_t rmw_wait(rmw_subscriptions_t * subscriptions,
       clients->clients[i] = 0;
     }
     lock.unlock();
-    custom_client_info->listener_->dettachCondition();
+    custom_client_info->listener_->detachCondition();
     lock.lock();
   }
 
@@ -2249,7 +2249,7 @@ rmw_ret_t rmw_wait(rmw_subscriptions_t * subscriptions,
       services->services[i] = 0;
     }
     lock.unlock();
-    custom_service_info->listener_->dettachCondition();
+    custom_service_info->listener_->detachCondition();
     lock.lock();
   }
 
@@ -2261,7 +2261,7 @@ rmw_ret_t rmw_wait(rmw_subscriptions_t * subscriptions,
         guard_conditions->guard_conditions[i] = 0;
       }
       lock.unlock();
-      guard_condition->dettachCondition();
+      guard_condition->detachCondition();
       lock.lock();
     }
   }


### PR DESCRIPTION
As a result of #51 the guard condition was constantly been triggered since `onNewCacheChangeAdded` is being invoked repeatedly for the same topic / type.

[![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2598)](http://ci.ros2.org/job/ci_linux/2598/) using `--retest-until-fail 20` (all failing tests are also present in the corresponding nighlty)

Ready for review.