### PR TITLE
remove obsolete stuff from CMake module

### DIFF
--- a/fastrtps_cmake_module/cmake/Modules/FindFastRTPS.cmake
+++ b/fastrtps_cmake_module/cmake/Modules/FindFastRTPS.cmake
@@ -16,22 +16,10 @@
 #
 # CMake module for finding eProsima FastRTPS.
 #
-# Input variables:
-#
-# - FASTRTPSHOME (optional): When specified, header files and libraries
-#   will be searched for in `${FASTRTPSHOME}/include`
-#   and `${FASTRTPSHOME}/lib` respectively.
-#
 # Output variables:
 #
 # - FastRTPS_FOUND: flag indicating if the package was found
 # - FastRTPS_INCLUDE_DIR: Paths to the header files
-# - FastRTPS_HOME: Root directory for the eProsima FastRTPS install. Might be
-#   not set.
-# - FastRTPS_LIBRARIES: Name to the C++ libraries including the path
-# - FastRTPS_LIBRARY_DIRS: Paths to the libraries
-# - FastRTPS_LIBRARY_DIR: Path to libraries; guaranteed to be a single path
-# - FastRTPS_DEFINITIONS: Definitions to be passed on
 #
 # Example usage:
 #
@@ -45,24 +33,8 @@
 
 set(FastRTPS_FOUND FALSE)
 
-# -----------------------------------------
-# Detect environment variable
-# -----------------------------------------
-if($ENV{FASTRPCHOME})
-    set(FastRTPS_HOME $ENV{FASTRPCHOME})
-endif()
-
-# -----------------------------------------
-# Search for eProsima FastRTPS include DIR
-# -----------------------------------------
-set(_fastrtps_INCLUDE_SEARCH_DIRS "")
-
-if(FastRTPS_HOME)
-    list(APPEND _fastrtps_INCLUDE_SEARCH_DIRS ${FastRTPS_HOME}/include)
-endif()
-
 find_path(FastRTPS_INCLUDE_DIR
-    NAMES fastrtps/)
+  NAMES fastrtps/)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(FastRTPS


### PR DESCRIPTION
Replaces #91. Fixes #90.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2613)](http://ci.ros2.org/job/ci_linux/2613/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=186)](http://ci.ros2.org/job/ci_linux-aarch64/186/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2069)](http://ci.ros2.org/job/ci_osx/2069/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2726)](http://ci.ros2.org/job/ci_windows/2726/)