### PR TITLE
Topic names

### DIFF
--- a/rmw_fastrtps_cpp/src/functions.cpp
+++ b/rmw_fastrtps_cpp/src/functions.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <array>
 #include <cassert>
 #include <condition_variable>
 #include <limits>
@@ -551,21 +552,13 @@ inline
 std::string
 _filter_ros_prefix(const std::string & topic_name)
 {
-  if (topic_name.find(std::string(ros_topic_prefix) + "/") == 0) {
-    return topic_name.substr(
-      strlen(ros_topic_prefix),
-      topic_name.size() - strlen(ros_topic_prefix));
-  } else if (topic_name.find(std::string(ros_service_requester_prefix) + "/") == 0) {
-    return topic_name.substr(
-      strlen(ros_service_requester_prefix),
-      topic_name.size() - strlen(ros_service_requester_prefix));
-  } else if (topic_name.find(std::string(ros_service_response_prefix) + "/") == 0) {
-    return topic_name.substr(
-      strlen(ros_service_response_prefix),
-      topic_name.size() - strlen(ros_service_response_prefix));
-  } else {
-    return topic_name;
+  auto prefixes = {ros_topic_prefix, ros_service_requester_prefix, ros_service_response_prefix};
+  for (auto prefix : prefixes) {
+    if (topic_name.rfind(std::string(prefix) + "/") == 0) {
+      return topic_name.substr(strlen(ros_topic_prefix));
+    }
   }
+  return topic_name;
 }
 
 extern "C"

--- a/rmw_fastrtps_cpp/src/functions.cpp
+++ b/rmw_fastrtps_cpp/src/functions.cpp
@@ -2522,7 +2522,15 @@ rmw_get_topic_names_and_types(
   slave_target->mapmutex.lock();
   for (auto it : slave_target->topicNtypes) {
     for (auto & itt : it.second) {
-      unfiltered_topics[it.first].insert(itt);
+      // truncate the ROS specific prefix
+      auto topic_fqdn = it.first;
+      if ( (it.first.find(std::string(ros_topic_prefix) + "/") == 0)
+        || (it.first.find(std::string(ros_service_requester_prefix) + "/") == 0)
+        || (it.first.find(std::string(ros_service_response_prefix) + "/") == 0)) {
+        topic_fqdn = it.first.substr(2, it.first.size() - 2);
+      }
+      //topics[topic_fqdn] = *it.second.begin();}
+      unfiltered_topics[topic_fqdn].insert(itt);
     }
   }
   slave_target->mapmutex.unlock();
@@ -2537,7 +2545,8 @@ rmw_get_topic_names_and_types(
   // Filter duplicates
   std::map<std::string, std::string> topics;
   for (auto & it : unfiltered_topics) {
-    if (it.second.size() == 1) {topics[it.first] = *it.second.begin();}
+    if (it.second.size() == 1) {
+      topics[it.first] = *it.second.begin();}
   }
   std::string substring = "::msg::dds_::";
   for (auto & it : topics) {
@@ -2667,7 +2676,16 @@ rmw_count_publishers(
   slave_target->mapmutex.lock();
   for (auto it : slave_target->topicNtypes) {
     for (auto & itt : it.second) {
-      unfiltered_topics[it.first].insert(itt);
+      // truncate the ROS specific prefix
+      auto topic_fqdn = it.first;
+      if ( (it.first.find(std::string(ros_topic_prefix) + "/") == 0)
+        || (it.first.find(std::string(ros_service_requester_prefix) + "/") == 0)
+        || (it.first.find(std::string(ros_service_response_prefix) + "/") == 0)) {
+        topic_fqdn = it.first.substr(2, it.first.size() - 2);
+      }
+      //topics[topic_fqdn] = *it.second.begin();}
+      unfiltered_topics[topic_fqdn].insert(itt);
+      //unfiltered_topics[it.first].insert(itt);
     }
   }
   slave_target->mapmutex.unlock();
@@ -2716,7 +2734,16 @@ rmw_count_subscribers(
   slave_target->mapmutex.lock();
   for (auto it : slave_target->topicNtypes) {
     for (auto & itt : it.second) {
-      unfiltered_topics[it.first].insert(itt);
+      // truncate the ROS specific prefix
+      auto topic_fqdn = it.first;
+      if ( (it.first.find(std::string(ros_topic_prefix) + "/") == 0)
+        || (it.first.find(std::string(ros_service_requester_prefix) + "/") == 0)
+        || (it.first.find(std::string(ros_service_response_prefix) + "/") == 0)) {
+        topic_fqdn = it.first.substr(2, it.first.size() - 2);
+      }
+      //topics[topic_fqdn] = *it.second.begin();}
+      unfiltered_topics[topic_fqdn].insert(itt);
+      //unfiltered_topics[it.first].insert(itt);
     }
   }
   slave_target->mapmutex.unlock();

--- a/rmw_fastrtps_cpp/src/functions.cpp
+++ b/rmw_fastrtps_cpp/src/functions.cpp
@@ -71,13 +71,11 @@
 
 extern "C"
 {
-
 // static for internal linkage
 static const char * const eprosima_fastrtps_identifier = "rmw_fastrtps_cpp";
 static const char * const ros_topic_prefix = "rt";
 static const char * const ros_service_requester_prefix = "rq";
 static const char * const ros_service_response_prefix = "rr";
-
 }  // extern "C"
 
 using MessageTypeSupport_c =
@@ -1818,6 +1816,7 @@ rmw_client_t * rmw_create_client(const rmw_node_t * node,
 
   info->writer_guid_ = info->request_publisher_->getGuid();
 
+  fprintf(stderr, "Original service lcient topic %s\n", service_name);
   rmw_client = rmw_client_allocate();
   rmw_client->implementation_identifier = eprosima_fastrtps_identifier;
   rmw_client->data = info;
@@ -2167,6 +2166,7 @@ rmw_service_t * rmw_create_service(const rmw_node_t * node,
     goto fail;
   }
 
+  fprintf(stderr, "Original service server topic %s\n", service_name);
   rmw_service = rmw_service_allocate();
   rmw_service->implementation_identifier = eprosima_fastrtps_identifier;
   rmw_service->data = info;
@@ -2812,6 +2812,7 @@ rmw_service_server_is_available(
     return RMW_RET_ERROR;
   }
   auto pub_fqdn = pub_partitions[0] + "/" + pub_topic_name;
+  pub_fqdn = _filter_ros_prefix(pub_fqdn);
 
   auto sub_topic_name =
     client_info->response_subscriber_->getAttributes().topic.getTopicName();
@@ -2824,6 +2825,7 @@ rmw_service_server_is_available(
     return RMW_RET_ERROR;
   }
   auto sub_fqdn = sub_partitions[0] + "/" + sub_topic_name;
+  sub_fqdn = _filter_ros_prefix(sub_fqdn);
 
   *is_available = false;
   size_t number_of_request_subscribers = 0;
@@ -2869,7 +2871,6 @@ rmw_node_get_graph_guard_condition(const rmw_node_t * node)
   }
   return impl->graph_guard_condition;
 }
-
 
 rmw_ret_t
 rmw_get_gid_for_publisher(const rmw_publisher_t * publisher, rmw_gid_t * gid)

--- a/rmw_fastrtps_cpp/src/functions.cpp
+++ b/rmw_fastrtps_cpp/src/functions.cpp
@@ -553,17 +553,16 @@ _filter_ros_prefix(const std::string & topic_name)
 {
   if (topic_name.find(std::string(ros_topic_prefix) + "/") == 0) {
     return topic_name.substr(
-        strlen(ros_topic_prefix),
-        topic_name.size() - strlen(ros_topic_prefix));
-  }
-  else if (topic_name.find(std::string(ros_service_requester_prefix) + "/") == 0) {
+      strlen(ros_topic_prefix),
+      topic_name.size() - strlen(ros_topic_prefix));
+  } else if (topic_name.find(std::string(ros_service_requester_prefix) + "/") == 0) {
     return topic_name.substr(
-        strlen(ros_service_requester_prefix),
-        topic_name.size() - strlen(ros_service_requester_prefix));
+      strlen(ros_service_requester_prefix),
+      topic_name.size() - strlen(ros_service_requester_prefix));
   } else if (topic_name.find(std::string(ros_service_response_prefix) + "/") == 0) {
     return topic_name.substr(
-        strlen(ros_service_response_prefix),
-        topic_name.size() - strlen(ros_service_response_prefix));
+      strlen(ros_service_response_prefix),
+      topic_name.size() - strlen(ros_service_response_prefix));
   } else {
     return topic_name;
   }

--- a/rmw_fastrtps_cpp/src/functions.cpp
+++ b/rmw_fastrtps_cpp/src/functions.cpp
@@ -554,7 +554,7 @@ _filter_ros_prefix(const std::string & topic_name)
 {
   auto prefixes = {ros_topic_prefix, ros_service_requester_prefix, ros_service_response_prefix};
   for (auto prefix : prefixes) {
-    if (topic_name.rfind(std::string(prefix) + "/") == 0) {
+    if (topic_name.rfind(std::string(prefix) + "/", 0) == 0) {
       return topic_name.substr(strlen(ros_topic_prefix));
     }
   }

--- a/rmw_fastrtps_cpp/src/functions.cpp
+++ b/rmw_fastrtps_cpp/src/functions.cpp
@@ -1816,7 +1816,6 @@ rmw_client_t * rmw_create_client(const rmw_node_t * node,
 
   info->writer_guid_ = info->request_publisher_->getGuid();
 
-  fprintf(stderr, "Original service lcient topic %s\n", service_name);
   rmw_client = rmw_client_allocate();
   rmw_client->implementation_identifier = eprosima_fastrtps_identifier;
   rmw_client->data = info;
@@ -2166,7 +2165,6 @@ rmw_service_t * rmw_create_service(const rmw_node_t * node,
     goto fail;
   }
 
-  fprintf(stderr, "Original service server topic %s\n", service_name);
   rmw_service = rmw_service_allocate();
   rmw_service->implementation_identifier = eprosima_fastrtps_identifier;
   rmw_service->data = info;


### PR DESCRIPTION
this should fix the inconsistency with `rclcpp::Node::count_subscribers` and `rclcpp::Node::count_publishers` as well as `get_topic_names_and_types`.

The function truncates the internal topic fqdn in the form of `rt/my_namespace/my_topic` into `/my_namespace/my_topic`

@clalancette Could you please review this and report whether this solves your issue?