### PR TITLE
Fix Compiler Warning

### DIFF
--- a/rmw_fastrtps_cpp/src/functions.cpp
+++ b/rmw_fastrtps_cpp/src/functions.cpp
@@ -838,7 +838,7 @@ rmw_node_t * create_node(
 
   try {
     node_impl = new CustomParticipantInfo();
-  } catch (std::bad_alloc) {
+  } catch (std::bad_alloc &) {
     RMW_SET_ERROR_MSG("failed to allocate node impl struct");
     goto fail;
   }


### PR DESCRIPTION
In newer versions of GCC, a compiler warning appears when you catch a polymorphic type by value.

```
Scanning dependencies of target rmw_fastrtps_cpp
[ 50%] Building CXX object CMakeFiles/rmw_fastrtps_cpp.dir/src/functions.cpp.o
/home/allenh1/ros2_ws/src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/src/functions.cpp: In function ‘rmw_node_t* create_node(const char*, const char*, eprosima::fastrtps::ParticipantAttributes)’:
/home/allenh1/ros2_ws/src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/src/functions.cpp:841:17: warning: catching polymorphic type ‘class std::bad_alloc’ by value [-Wcatch-value=]
   } catch (std::bad_alloc) {
                 ^~~~~~~~~
```

The fix is to catch a reference (or a pointer). I personally don't understand why it is _bad_ to catch a polymorphic type by value (I guess it could be bad if your constructor is explicit?), though, if anyone knows why this is a _bad thing_, I would appreciate some insight.