### PR TITLE
fix memory leak

### DIFF
--- a/rmw_fastrtps_cpp/src/functions.cpp
+++ b/rmw_fastrtps_cpp/src/functions.cpp
@@ -437,7 +437,7 @@ public:
   {
     ReaderProxyData proxyData;
     if (change->kind == ALIVE) {
-      CDRMessage_t tempMsg;
+      CDRMessage_t tempMsg(0);
       tempMsg.wraps = true;
       tempMsg.msg_endian = change->serializedPayload.encapsulation ==
         PL_CDR_BE ? BIGEND : LITTLEEND;
@@ -507,7 +507,7 @@ public:
   {
     WriterProxyData proxyData;
     if (change->kind == ALIVE) {
-      CDRMessage_t tempMsg;
+      CDRMessage_t tempMsg(0);
       tempMsg.wraps = true;
       tempMsg.msg_endian = change->serializedPayload.encapsulation ==
         PL_CDR_BE ? BIGEND : LITTLEEND;


### PR DESCRIPTION
When calling the constructor without any arguments the pointer of the allocated buffer is later overwritten and therefore leaked: https://github.com/eProsima/Fast-RTPS/blob/f16b8f365c44aa76066b35004e84e9a352949d8c/include/fastrtps/rtps/common/CDRMessage_t.h#L53

Calling the constructor with the size argument `0` ensures that no memory is being allocated within the constructor.