### PR TITLE
move export of FastRTPS libraries to extra file to avoid hardcoded absolute paths

### DIFF
--- a/rmw_fastrtps_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_cpp/CMakeLists.txt
@@ -65,7 +65,7 @@ ament_target_dependencies(rmw_fastrtps_cpp
 
 configure_rmw_library(rmw_fastrtps_cpp)
 
-ament_export_libraries(rmw_fastrtps_cpp ${FastRTPS_LIBRARIES})
+ament_export_libraries(rmw_fastrtps_cpp)
 if(NOT WIN32 AND NOT ANDROID)
   ament_export_libraries(pthread)
 endif()
@@ -79,7 +79,9 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_package()
+ament_package(
+  CONFIG_EXTRAS "rmw_fastrtps_cpp-extras.cmake"
+)
 
 install(
   DIRECTORY include/

--- a/rmw_fastrtps_cpp/rmw_fastrtps_cpp-extras.cmake
+++ b/rmw_fastrtps_cpp/rmw_fastrtps_cpp-extras.cmake
@@ -1,0 +1,22 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# copied from rmw_fastrtps_cpp/rmw_fastrtps_cpp-extras.cmake
+
+find_package(fastrtps_cmake_module REQUIRED)
+find_package(fastcdr REQUIRED CONFIG)
+find_package(fastrtps REQUIRED CONFIG)
+find_package(FastRTPS REQUIRED MODULE)
+
+list(APPEND rmw_fastrtps_cpp_LIBRARIES ${FastRTPS_LIBRARIES})


### PR DESCRIPTION
This was exporting absolute library paths which made the generated CMake config files not relocatable. ~~Since the export isn't necessary this patch just removes it.~~

* ~~Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2834)](http://ci.ros2.org/job/ci_linux/2834/)~~
* ~~Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=338)](http://ci.ros2.org/job/ci_linux-aarch64/338/) (aborted since parallel build hung)~~
* ~~macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2290)](http://ci.ros2.org/job/ci_osx/2290/)~~
* ~~Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2970)](http://ci.ros2.org/job/ci_windows/2970/)~~

Ready for review.