### PR TITLE
Revert "add missing mutex lock"

### DIFF
--- a/rmw_fastrtps_cpp/src/functions.cpp
+++ b/rmw_fastrtps_cpp/src/functions.cpp
@@ -14,7 +14,6 @@
 
 #include <algorithm>
 #include <array>
-#include <atomic>
 #include <cassert>
 #include <condition_variable>
 #include <limits>
@@ -580,7 +579,7 @@ class ClientListener : public SubscriberListener
 {
 public:
   explicit ClientListener(CustomClientInfo * info)
-  : info_(info), list_has_data_(false),
+  : info_(info),
     conditionMutex_(NULL), conditionVariable_(NULL) {}
 
 
@@ -607,7 +606,6 @@ public:
           } else {
             list.push_back(response);
           }
-          list_has_data_.store(true);
         }
       }
     }
@@ -623,13 +621,11 @@ public:
       if (!list.empty()) {
         response = list.front();
         list.pop_front();
-        list_has_data_.store(!list.empty());
       }
     } else {
       if (!list.empty()) {
         response = list.front();
         list.pop_front();
-        list_has_data_.store(!list.empty());
       }
     }
 
@@ -652,14 +648,13 @@ public:
 
   bool hasData()
   {
-    return list_has_data_.load();
+    return !list.empty();
   }
 
 private:
   CustomClientInfo * info_;
   std::mutex internalMutex_;
   std::list<CustomClientResponse> list;
-  std::atomic_bool list_has_data_;
   std::mutex * conditionMutex_;
   std::condition_variable * conditionVariable_;
 };
@@ -1815,8 +1810,7 @@ class ServiceListener : public SubscriberListener
 {
 public:
   explicit ServiceListener(CustomServiceInfo * info)
-  : info_(info), list_has_data_(false),
-    conditionMutex_(NULL), conditionVariable_(NULL)
+  : info_(info), conditionMutex_(NULL), conditionVariable_(NULL)
   {
     (void)info_;
   }
@@ -1844,7 +1838,6 @@ public:
         } else {
           list.push_back(request);
         }
-        list_has_data_.store(true);
       }
     }
   }
@@ -1859,13 +1852,11 @@ public:
       if (!list.empty()) {
         request = list.front();
         list.pop_front();
-        list_has_data_.store(!list.empty());
       }
     } else {
       if (!list.empty()) {
         request = list.front();
         list.pop_front();
-        list_has_data_.store(!list.empty());
       }
     }
 
@@ -1888,14 +1879,13 @@ public:
 
   bool hasData()
   {
-    return list_has_data_.load();
+    return !list.empty();
   }
 
 private:
   CustomServiceInfo * info_;
   std::mutex internalMutex_;
   std::list<CustomServiceRequest> list;
-  std::atomic_bool list_has_data_;
   std::mutex * conditionMutex_;
   std::condition_variable * conditionVariable_;
 };


### PR DESCRIPTION
Reverts ros2/rmw_fastrtps#132 to make #131 easier.

Will reapply this patch afterwards.