### PR TITLE
Release the condition mutex while detaching condition variable

### DIFF
--- a/rmw_fastrtps_cpp/src/rmw_wait.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_wait.cpp
@@ -185,7 +185,6 @@ rmw_wait(
   // We're done with the condition variable now, but there's still a chance that something it was
   // attached to will trigger and deadlock trying to lock the condition mutex.
   // To avoid that we release it explicitly ASAP.
-  conditionVariable = NULL;
   lock.unlock();
 
   for (size_t i = 0; i < subscriptions->subscriber_count; ++i) {


### PR DESCRIPTION
Otherwise if something triggers while we're detaching, it will deadlock waiting for the condition mutex

In particular, for the local_parameter tests in test_rclcpp, triggering of the graph guard condition can happen while detaching conditions.

I haven't seen an explanation for why the mutex was being unlocked while calling `detachCondition`. it was added in https://github.com/ros2/rmw_fastrtps/commit/4da558f6fcec1cc63fbd6b4b3dc4fee83b879913#diff-8225b098f1ec4debcdcee03d65ae95d5R1579 but from what I can see the condition mutex is not used by any `detachCondition`. Perhaps that was just a way to prevent it from happening _most_ of the time.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3037)](http://ci.ros2.org/job/ci_linux/3037/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=440)](http://ci.ros2.org/job/ci_linux-aarch64/440/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2442)](http://ci.ros2.org/job/ci_osx/2442/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3120)](http://ci.ros2.org/job/ci_windows/3120/)