### PR TITLE
expose native participant

### DIFF
--- a/rmw_fastrtps_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_cpp/CMakeLists.txt
@@ -52,6 +52,7 @@ include_directories(include)
 add_library(rmw_fastrtps_cpp
   src/client_service_common.cpp
   src/demangle.cpp
+  src/get_participant.cpp
   src/identifier.cpp
   src/namespace_prefix.cpp
   src/qos.cpp
@@ -94,6 +95,12 @@ ament_target_dependencies(rmw_fastrtps_cpp
 
 configure_rmw_library(rmw_fastrtps_cpp)
 
+# Causes the visibility macros to use dllexport rather than dllimport,
+# which is appropriate when building the dll but not consuming it.
+target_compile_definitions(${PROJECT_NAME}
+PRIVATE "RMW_FASTRTPS_CPP_BUILDING_LIBRARY")
+
+ament_export_include_directories(include)
 ament_export_libraries(rmw_fastrtps_cpp)
 if(NOT WIN32 AND NOT ANDROID)
   ament_export_libraries(pthread)

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/custom_participant_info.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/custom_participant_info.hpp
@@ -12,9 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef IDENTIFIER_HPP_
-#define IDENTIFIER_HPP_
+#ifndef RMW_FASTRTPS_CPP__CUSTOM_PARTICIPANT_INFO_HPP_
+#define RMW_FASTRTPS_CPP__CUSTOM_PARTICIPANT_INFO_HPP_
 
-extern const char * const eprosima_fastrtps_identifier;
+#include "fastrtps/participant/Participant.h"
 
-#endif  // IDENTIFIER_HPP_
+#include "rmw/rmw.h"
+
+#include "rmw_fastrtps_cpp/reader_info.hpp"
+#include "rmw_fastrtps_cpp/writer_info.hpp"
+
+typedef struct CustomParticipantInfo
+{
+  eprosima::fastrtps::Participant * participant;
+  ReaderInfo * secondarySubListener;
+  WriterInfo * secondaryPubListener;
+  rmw_guard_condition_t * graph_guard_condition;
+} CustomParticipantInfo;
+
+#endif  // RMW_FASTRTPS_CPP__CUSTOM_PARTICIPANT_INFO_HPP_

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/get_participant.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/get_participant.hpp
@@ -1,0 +1,38 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RMW_FASTRTPS_CPP__GET_PARTICIPANT_HPP_
+#define RMW_FASTRTPS_CPP__GET_PARTICIPANT_HPP_
+
+#include "fastrtps/participant/Participant.h"
+#include "rmw/rmw.h"
+#include "rmw_fastrtps_cpp/visibility_control.h"
+
+namespace rmw_fastrtps_cpp
+{
+
+/// Return a native FastRTPS participant handle.
+/**
+ * The function return `NULL` when either the node handle is `NULL` or when the
+ * node handle is from a different rmw implementation.
+ *
+ * \return native FastRTPS participant handle if successful, otherwise `NULL`
+ */
+RMW_FASTRTPS_CPP_PUBLIC
+eprosima::fastrtps::Participant *
+get_participant(rmw_node_t * node);
+
+}  // namespace rmw_fastrtps_cpp
+
+#endif  // RMW_FASTRTPS_CPP__GET_PARTICIPANT_HPP_

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/identifier.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/identifier.hpp
@@ -12,22 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef TYPES__CUSTOM_PARTICIPANT_INFO_HPP_
-#define TYPES__CUSTOM_PARTICIPANT_INFO_HPP_
+#ifndef RMW_FASTRTPS_CPP__IDENTIFIER_HPP_
+#define RMW_FASTRTPS_CPP__IDENTIFIER_HPP_
 
-#include "fastrtps/participant/Participant.h"
+extern const char * const eprosima_fastrtps_identifier;
 
-#include "rmw/rmw.h"
-
-#include "reader_info.hpp"
-#include "writer_info.hpp"
-
-typedef struct CustomParticipantInfo
-{
-  eprosima::fastrtps::Participant * participant;
-  ReaderInfo * secondarySubListener;
-  WriterInfo * secondaryPubListener;
-  rmw_guard_condition_t * graph_guard_condition;
-} CustomParticipantInfo;
-
-#endif  // TYPES__CUSTOM_PARTICIPANT_INFO_HPP_
+#endif  // RMW_FASTRTPS_CPP__IDENTIFIER_HPP_

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/reader_info.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/reader_info.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef TYPES__WRITER_INFO_HPP_
-#define TYPES__WRITER_INFO_HPP_
+#ifndef RMW_FASTRTPS_CPP__READER_INFO_HPP_
+#define RMW_FASTRTPS_CPP__READER_INFO_HPP_
 
 #include <cassert>
 #include <map>
@@ -23,18 +23,20 @@
 #include <string>
 #include <vector>
 
-#include "fastrtps/participant/Participant.h"
-#include "fastrtps/rtps/builtin/data/WriterProxyData.h"
-#include "fastrtps/rtps/reader/RTPSReader.h"
-
 #include "rcutils/logging_macros.h"
 
+#include "rmw/error_handling.h"
 #include "rmw/rmw.h"
 
-class WriterInfo : public eprosima::fastrtps::ReaderListener
+#include "fastrtps/participant/Participant.h"
+#include "fastrtps/rtps/builtin/data/ReaderProxyData.h"
+#include "fastrtps/rtps/reader/ReaderListener.h"
+#include "fastrtps/rtps/reader/RTPSReader.h"
+
+class ReaderInfo : public eprosima::fastrtps::ReaderListener
 {
 public:
-  WriterInfo(
+  ReaderInfo(
     eprosima::fastrtps::Participant * participant,
     rmw_guard_condition_t * graph_guard_condition)
   : participant_(participant),
@@ -46,9 +48,9 @@ public:
     eprosima::fastrtps::rtps::RTPSReader *,
     const eprosima::fastrtps::CacheChange_t * const change)
   {
-    eprosima::fastrtps::rtps::WriterProxyData proxyData;
+    eprosima::fastrtps::rtps::ReaderProxyData proxyData;
     if (change->kind == ALIVE) {
-      eprosima::fastrtps::CDRMessage_t tempMsg(0);
+      CDRMessage_t tempMsg(0);
       tempMsg.wraps = true;
       tempMsg.msg_endian = change->serializedPayload.encapsulation ==
         PL_CDR_BE ? BIGEND : LITTLEEND;
@@ -59,9 +61,9 @@ public:
         return;
       }
     } else {
-      eprosima::fastrtps::rtps::GUID_t writerGuid;
-      iHandle2GUID(writerGuid, change->instanceHandle);
-      if (!participant_->get_remote_writer_info(writerGuid, proxyData)) {
+      eprosima::fastrtps::rtps::GUID_t readerGuid;
+      iHandle2GUID(readerGuid, change->instanceHandle);
+      if (!participant_->get_remote_reader_info(readerGuid, proxyData)) {
         return;
       }
     }
@@ -112,4 +114,4 @@ public:
   rmw_guard_condition_t * graph_guard_condition_;
 };
 
-#endif  // TYPES__WRITER_INFO_HPP_
+#endif  // RMW_FASTRTPS_CPP__READER_INFO_HPP_

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/visibility_control.h
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/visibility_control.h
@@ -1,0 +1,56 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* This header must be included by all rclcpp headers which declare symbols
+ * which are defined in the rclcpp library. When not building the rclcpp
+ * library, i.e. when using the headers in other package's code, the contents
+ * of this header change the visibility of certain symbols which the rclcpp
+ * library cannot have, but the consuming code must have inorder to link.
+ */
+
+#ifndef RMW_FASTRTPS_CPP__VISIBILITY_CONTROL_H_
+#define RMW_FASTRTPS_CPP__VISIBILITY_CONTROL_H_
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define RMW_FASTRTPS_CPP_EXPORT __attribute__ ((dllexport))
+    #define RMW_FASTRTPS_CPP_IMPORT __attribute__ ((dllimport))
+  #else
+    #define RMW_FASTRTPS_CPP_EXPORT __declspec(dllexport)
+    #define RMW_FASTRTPS_CPP_IMPORT __declspec(dllimport)
+  #endif
+  #ifdef RMW_FASTRTPS_CPP_BUILDING_LIBRARY
+    #define RMW_FASTRTPS_CPP_PUBLIC RMW_FASTRTPS_CPP_EXPORT
+  #else
+    #define RMW_FASTRTPS_CPP_PUBLIC RMW_FASTRTPS_CPP_IMPORT
+  #endif
+  #define RMW_FASTRTPS_CPP_PUBLIC_TYPE RMW_FASTRTPS_CPP_PUBLIC
+  #define RMW_FASTRTPS_CPP_LOCAL
+#else
+  #define RMW_FASTRTPS_CPP_EXPORT __attribute__ ((visibility("default")))
+  #define RMW_FASTRTPS_CPP_IMPORT
+  #if __GNUC__ >= 4
+    #define RMW_FASTRTPS_CPP_PUBLIC __attribute__ ((visibility("default")))
+    #define RMW_FASTRTPS_CPP_LOCAL  __attribute__ ((visibility("hidden")))
+  #else
+    #define RMW_FASTRTPS_CPP_PUBLIC
+    #define RMW_FASTRTPS_CPP_LOCAL
+  #endif
+  #define RMW_FASTRTPS_CPP_PUBLIC_TYPE
+#endif
+
+#endif  // RMW_FASTRTPS_CPP__VISIBILITY_CONTROL_H_

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/writer_info.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/writer_info.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef TYPES__READER_INFO_HPP_
-#define TYPES__READER_INFO_HPP_
+#ifndef RMW_FASTRTPS_CPP__WRITER_INFO_HPP_
+#define RMW_FASTRTPS_CPP__WRITER_INFO_HPP_
 
 #include <cassert>
 #include <map>
@@ -23,20 +23,18 @@
 #include <string>
 #include <vector>
 
-#include "rcutils/logging_macros.h"
-
-#include "rmw/error_handling.h"
-#include "rmw/rmw.h"
-
 #include "fastrtps/participant/Participant.h"
-#include "fastrtps/rtps/builtin/data/ReaderProxyData.h"
-#include "fastrtps/rtps/reader/ReaderListener.h"
+#include "fastrtps/rtps/builtin/data/WriterProxyData.h"
 #include "fastrtps/rtps/reader/RTPSReader.h"
 
-class ReaderInfo : public eprosima::fastrtps::ReaderListener
+#include "rcutils/logging_macros.h"
+
+#include "rmw/rmw.h"
+
+class WriterInfo : public eprosima::fastrtps::ReaderListener
 {
 public:
-  ReaderInfo(
+  WriterInfo(
     eprosima::fastrtps::Participant * participant,
     rmw_guard_condition_t * graph_guard_condition)
   : participant_(participant),
@@ -48,9 +46,9 @@ public:
     eprosima::fastrtps::rtps::RTPSReader *,
     const eprosima::fastrtps::CacheChange_t * const change)
   {
-    eprosima::fastrtps::rtps::ReaderProxyData proxyData;
+    eprosima::fastrtps::rtps::WriterProxyData proxyData;
     if (change->kind == ALIVE) {
-      CDRMessage_t tempMsg(0);
+      eprosima::fastrtps::CDRMessage_t tempMsg(0);
       tempMsg.wraps = true;
       tempMsg.msg_endian = change->serializedPayload.encapsulation ==
         PL_CDR_BE ? BIGEND : LITTLEEND;
@@ -61,9 +59,9 @@ public:
         return;
       }
     } else {
-      eprosima::fastrtps::rtps::GUID_t readerGuid;
-      iHandle2GUID(readerGuid, change->instanceHandle);
-      if (!participant_->get_remote_reader_info(readerGuid, proxyData)) {
+      eprosima::fastrtps::rtps::GUID_t writerGuid;
+      iHandle2GUID(writerGuid, change->instanceHandle);
+      if (!participant_->get_remote_writer_info(writerGuid, proxyData)) {
         return;
       }
     }
@@ -114,4 +112,4 @@ public:
   rmw_guard_condition_t * graph_guard_condition_;
 };
 
-#endif  // TYPES__READER_INFO_HPP_
+#endif  // RMW_FASTRTPS_CPP__WRITER_INFO_HPP_

--- a/rmw_fastrtps_cpp/rmw_fastrtps_cpp-extras.cmake
+++ b/rmw_fastrtps_cpp/rmw_fastrtps_cpp-extras.cmake
@@ -19,4 +19,5 @@ find_package(fastcdr REQUIRED CONFIG)
 find_package(fastrtps REQUIRED CONFIG)
 find_package(FastRTPS REQUIRED MODULE)
 
+list(APPEND rmw_fastrtps_cpp_INCLUDE_DIRS ${FastRTPS_INCLUDE_DIR})
 list(APPEND rmw_fastrtps_cpp_LIBRARIES ${FastRTPS_LIBRARIES})

--- a/rmw_fastrtps_cpp/src/get_participant.cpp
+++ b/rmw_fastrtps_cpp/src/get_participant.cpp
@@ -1,0 +1,36 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rmw_fastrtps_cpp/get_participant.hpp"
+
+#include "rmw_fastrtps_cpp/custom_participant_info.hpp"
+#include "rmw_fastrtps_cpp/identifier.hpp"
+
+namespace rmw_fastrtps_cpp
+{
+
+eprosima::fastrtps::Participant *
+get_participant(rmw_node_t * node)
+{
+  if (!node) {
+    return NULL;
+  }
+  if (node->implementation_identifier != eprosima_fastrtps_identifier) {
+    return NULL;
+  }
+  CustomParticipantInfo * impl = static_cast<CustomParticipantInfo *>(node->data);
+  return impl->participant;
+}
+
+}  // namespace rmw_fastrtps_cpp

--- a/rmw_fastrtps_cpp/src/identifier.cpp
+++ b/rmw_fastrtps_cpp/src/identifier.cpp
@@ -12,6 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "identifier.hpp"
+#include "rmw_fastrtps_cpp/identifier.hpp"
 
 const char * const eprosima_fastrtps_identifier = "rmw_fastrtps_cpp";

--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -25,11 +25,11 @@
 
 #include "assign_partitions.hpp"
 #include "client_service_common.hpp"
-#include "identifier.hpp"
+#include "rmw_fastrtps_cpp/identifier.hpp"
 #include "namespace_prefix.hpp"
 #include "qos.hpp"
 #include "type_support_common.hpp"
-#include "types/custom_participant_info.hpp"
+#include "rmw_fastrtps_cpp/custom_participant_info.hpp"
 #include "types/custom_client_info.hpp"
 
 extern "C"

--- a/rmw_fastrtps_cpp/src/rmw_compare_gids_equal.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_compare_gids_equal.cpp
@@ -18,7 +18,7 @@
 #include "rmw/error_handling.h"
 #include "rmw/types.h"
 
-#include "identifier.hpp"
+#include "rmw_fastrtps_cpp/identifier.hpp"
 
 extern "C"
 {

--- a/rmw_fastrtps_cpp/src/rmw_count.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_count.cpp
@@ -22,9 +22,9 @@
 #include "rmw/rmw.h"
 #include "rmw/types.h"
 
-#include "identifier.hpp"
+#include "rmw_fastrtps_cpp/identifier.hpp"
 #include "demangle.hpp"
-#include "types/custom_participant_info.hpp"
+#include "rmw_fastrtps_cpp/custom_participant_info.hpp"
 
 extern "C"
 {

--- a/rmw_fastrtps_cpp/src/rmw_get_gid_for_publisher.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_get_gid_for_publisher.cpp
@@ -16,7 +16,7 @@
 #include "rmw/rmw.h"
 #include "rmw/types.h"
 
-#include "identifier.hpp"
+#include "rmw_fastrtps_cpp/identifier.hpp"
 #include "types/custom_publisher_info.hpp"
 
 extern "C"

--- a/rmw_fastrtps_cpp/src/rmw_get_implementation_identifier.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_get_implementation_identifier.cpp
@@ -14,7 +14,7 @@
 
 #include "rmw/rmw.h"
 
-#include "identifier.hpp"
+#include "rmw_fastrtps_cpp/identifier.hpp"
 
 extern "C"
 {

--- a/rmw_fastrtps_cpp/src/rmw_guard_condition.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_guard_condition.cpp
@@ -15,7 +15,7 @@
 #include "rmw/error_handling.h"
 #include "rmw/rmw.h"
 
-#include "identifier.hpp"
+#include "rmw_fastrtps_cpp/identifier.hpp"
 #include "types/guard_condition.hpp"
 
 extern "C"

--- a/rmw_fastrtps_cpp/src/rmw_node.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_node.cpp
@@ -42,8 +42,8 @@
 #include "fastrtps/rtps/reader/ReaderListener.h"
 #include "fastrtps/rtps/builtin/discovery/endpoint/EDPSimple.h"
 
-#include "identifier.hpp"
-#include "types/custom_participant_info.hpp"
+#include "rmw_fastrtps_cpp/identifier.hpp"
+#include "rmw_fastrtps_cpp/custom_participant_info.hpp"
 
 extern "C"
 {

--- a/rmw_fastrtps_cpp/src/rmw_node_names.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_node_names.cpp
@@ -26,8 +26,8 @@
 
 #include "fastrtps/Domain.h"
 
-#include "identifier.hpp"
-#include "types/custom_participant_info.hpp"
+#include "rmw_fastrtps_cpp/identifier.hpp"
+#include "rmw_fastrtps_cpp/custom_participant_info.hpp"
 
 extern "C"
 {

--- a/rmw_fastrtps_cpp/src/rmw_publish.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publish.cpp
@@ -19,7 +19,7 @@
 #include "rmw/error_handling.h"
 #include "rmw/rmw.h"
 
-#include "identifier.hpp"
+#include "rmw_fastrtps_cpp/identifier.hpp"
 #include "ros_message_serialization.hpp"
 #include "types/custom_publisher_info.hpp"
 

--- a/rmw_fastrtps_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publisher.cpp
@@ -19,10 +19,10 @@
 #include "rmw/rmw.h"
 
 #include "assign_partitions.hpp"
-#include "identifier.hpp"
+#include "rmw_fastrtps_cpp/identifier.hpp"
 #include "namespace_prefix.hpp"
 #include "qos.hpp"
-#include "types/custom_participant_info.hpp"
+#include "rmw_fastrtps_cpp/custom_participant_info.hpp"
 #include "types/custom_publisher_info.hpp"
 #include "type_support_common.hpp"
 

--- a/rmw_fastrtps_cpp/src/rmw_request.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_request.cpp
@@ -23,7 +23,7 @@
 #include "rmw/rmw.h"
 #include "rmw/types.h"
 
-#include "identifier.hpp"
+#include "rmw_fastrtps_cpp/identifier.hpp"
 #include "ros_message_serialization.hpp"
 #include "types/custom_client_info.hpp"
 #include "types/custom_service_info.hpp"

--- a/rmw_fastrtps_cpp/src/rmw_response.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_response.cpp
@@ -21,7 +21,7 @@
 #include "rmw/error_handling.h"
 #include "rmw/rmw.h"
 
-#include "identifier.hpp"
+#include "rmw_fastrtps_cpp/identifier.hpp"
 #include "ros_message_serialization.hpp"
 #include "types/custom_client_info.hpp"
 #include "types/custom_service_info.hpp"

--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -35,11 +35,11 @@
 
 #include "assign_partitions.hpp"
 #include "client_service_common.hpp"
-#include "identifier.hpp"
+#include "rmw_fastrtps_cpp/identifier.hpp"
 #include "namespace_prefix.hpp"
 #include "qos.hpp"
 #include "type_support_common.hpp"
-#include "types/custom_participant_info.hpp"
+#include "rmw_fastrtps_cpp/custom_participant_info.hpp"
 #include "types/custom_service_info.hpp"
 
 extern "C"

--- a/rmw_fastrtps_cpp/src/rmw_service_names_and_types.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service_names_and_types.cpp
@@ -25,9 +25,9 @@
 #include "rmw/names_and_types.h"
 #include "rmw/rmw.h"
 
-#include "identifier.hpp"
+#include "rmw_fastrtps_cpp/identifier.hpp"
 #include "demangle.hpp"
-#include "types/custom_participant_info.hpp"
+#include "rmw_fastrtps_cpp/custom_participant_info.hpp"
 
 extern "C"
 {

--- a/rmw_fastrtps_cpp/src/rmw_service_server_is_available.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service_server_is_available.cpp
@@ -25,7 +25,7 @@
 #include "rmw/types.h"
 
 #include "demangle.hpp"
-#include "identifier.hpp"
+#include "rmw_fastrtps_cpp/identifier.hpp"
 #include "types/custom_client_info.hpp"
 
 extern "C"

--- a/rmw_fastrtps_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_subscription.cpp
@@ -23,10 +23,10 @@
 #include "fastrtps/subscriber/Subscriber.h"
 
 #include "assign_partitions.hpp"
-#include "identifier.hpp"
+#include "rmw_fastrtps_cpp/identifier.hpp"
 #include "namespace_prefix.hpp"
 #include "qos.hpp"
-#include "types/custom_participant_info.hpp"
+#include "rmw_fastrtps_cpp/custom_participant_info.hpp"
 #include "types/custom_subscriber_info.hpp"
 #include "type_support_common.hpp"
 

--- a/rmw_fastrtps_cpp/src/rmw_take.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_take.cpp
@@ -21,7 +21,7 @@
 #include "fastrtps/attributes/SubscriberAttributes.h"
 
 #include "fastcdr/FastBuffer.h"
-#include "identifier.hpp"
+#include "rmw_fastrtps_cpp/identifier.hpp"
 #include "types/custom_subscriber_info.hpp"
 #include "ros_message_serialization.hpp"
 

--- a/rmw_fastrtps_cpp/src/rmw_topic_names_and_types.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_topic_names_and_types.cpp
@@ -31,9 +31,9 @@
 #include "rmw/rmw.h"
 
 #include "demangle.hpp"
-#include "identifier.hpp"
+#include "rmw_fastrtps_cpp/identifier.hpp"
 #include "namespace_prefix.hpp"
-#include "types/custom_participant_info.hpp"
+#include "rmw_fastrtps_cpp/custom_participant_info.hpp"
 
 extern "C"
 {

--- a/rmw_fastrtps_cpp/src/rmw_trigger_guard_condition.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_trigger_guard_condition.cpp
@@ -17,7 +17,7 @@
 #include "rmw/error_handling.h"
 #include "rmw/rmw.h"
 
-#include "identifier.hpp"
+#include "rmw_fastrtps_cpp/identifier.hpp"
 #include "types/guard_condition.hpp"
 
 extern "C"

--- a/rmw_fastrtps_cpp/src/rmw_waitset.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_waitset.cpp
@@ -17,7 +17,7 @@
 #include "rmw/rmw.h"
 #include "rmw/impl/cpp/macros.hpp"
 
-#include "identifier.hpp"
+#include "rmw_fastrtps_cpp/identifier.hpp"
 #include "types/custom_waitset_info.hpp"
 
 extern "C"

--- a/rmw_fastrtps_cpp/src/type_support_common.hpp
+++ b/rmw_fastrtps_cpp/src/type_support_common.hpp
@@ -27,7 +27,7 @@
 
 #include "rosidl_typesupport_introspection_c/visibility_control.h"
 
-#include "identifier.hpp"
+#include "rmw_fastrtps_cpp/identifier.hpp"
 
 using MessageTypeSupport_c =
     rmw_fastrtps_cpp::MessageTypeSupport<rosidl_typesupport_introspection_c__MessageMembers>;


### PR DESCRIPTION
This is an example how to expose native handles from a rmw implementation. It only exposes the `eprosima::fastrtps::Participant` but other handles could be supported in a similar fashion. The patch demonstrate how this is possible and that it can be achieved by each rmw implementation without requiring any changes in the `rmw` interface.

When the function is being used with a different rmw implementation at runtime `get_participant` returns `NULL`.

In order to try this feature I modified the `talker` in the `demo_nodes_cpp` package. The changes are straight forward. Only getting from the C++ `Node` to the `rmw_node_t` is not "very pretty":

* `package.xml`

```
<depend>rmw_fastrtps_cpp</depend>
```
* `CMakeLists.txt`

```
find_package(rmw_fastrtps_cpp REQUIRED)
...
ament_target_dependencies(talker "rmw_fastrtps_cpp")
```

* `talker.cpp`

```
#include "rmw_fastrtps_cpp/internal/get_participant.hpp"
...
// auto node = rclcpp::node::Node::make_shared("talker");
...
rcl_node_t * rcl_node = node->get_node_base_interface()->get_rcl_node_handle();
rmw_node_t * rmw_node = rcl_node_get_rmw_handle(rcl_node);
eprosima::fastrtps::Participant * p = rmw_fastrtps_cpp::get_participant(rmw_node);
```