### PR TITLE
Expose more native handles

### DIFF
--- a/rmw_fastrtps_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_cpp/CMakeLists.txt
@@ -52,7 +52,11 @@ include_directories(include)
 add_library(rmw_fastrtps_cpp
   src/client_service_common.cpp
   src/demangle.cpp
+  src/get_client.cpp
   src/get_participant.cpp
+  src/get_publisher.cpp
+  src/get_service.cpp
+  src/get_subscriber.cpp
   src/identifier.cpp
   src/namespace_prefix.cpp
   src/qos.cpp

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/custom_publisher_info.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/custom_publisher_info.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef TYPES__CUSTOM_PUBLISHER_INFO_HPP_
-#define TYPES__CUSTOM_PUBLISHER_INFO_HPP_
+#ifndef RMW_FASTRTPS_CPP__CUSTOM_PUBLISHER_INFO_HPP_
+#define RMW_FASTRTPS_CPP__CUSTOM_PUBLISHER_INFO_HPP_
 
 #include "fastrtps/publisher/Publisher.h"
 
@@ -27,4 +27,4 @@ typedef struct CustomPublisherInfo
   const char * typesupport_identifier_;
 } CustomPublisherInfo;
 
-#endif  // TYPES__CUSTOM_PUBLISHER_INFO_HPP_
+#endif  // RMW_FASTRTPS_CPP__CUSTOM_PUBLISHER_INFO_HPP_

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/custom_subscriber_info.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/custom_subscriber_info.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef TYPES__CUSTOM_SUBSCRIBER_INFO_HPP_
-#define TYPES__CUSTOM_SUBSCRIBER_INFO_HPP_
+#ifndef RMW_FASTRTPS_CPP__CUSTOM_SUBSCRIBER_INFO_HPP_
+#define RMW_FASTRTPS_CPP__CUSTOM_SUBSCRIBER_INFO_HPP_
 
 #include <condition_variable>
 #include <mutex>
@@ -109,4 +109,4 @@ private:
   std::condition_variable * conditionVariable_;
 };
 
-#endif  // TYPES__CUSTOM_SUBSCRIBER_INFO_HPP_
+#endif  // RMW_FASTRTPS_CPP__CUSTOM_SUBSCRIBER_INFO_HPP_

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/get_client.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/get_client.hpp
@@ -1,0 +1,50 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RMW_FASTRTPS_CPP__GET_CLIENT_HPP_
+#define RMW_FASTRTPS_CPP__GET_CLIENT_HPP_
+
+#include "fastrtps/publisher/Publisher.h"
+#include "fastrtps/subscriber/Subscriber.h"
+#include "rmw/rmw.h"
+#include "rmw_fastrtps_cpp/visibility_control.h"
+
+namespace rmw_fastrtps_cpp
+{
+
+/// Return a native FastRTPS publisher handle for the request.
+/**
+ * The function returns `NULL` when either the client handle is `NULL` or
+ * when the client handle is from a different rmw implementation.
+ *
+ * \return native FastRTPS publisher handle if successful, otherwise `NULL`
+ */
+RMW_FASTRTPS_CPP_PUBLIC
+eprosima::fastrtps::Publisher *
+get_request_publisher(rmw_client_t * client);
+
+/// Return a native FastRTPS subscriber handle for the response.
+/**
+ * The function returns `NULL` when either the client handle is `NULL` or
+ * when the client handle is from a different rmw implementation.
+ *
+ * \return native FastRTPS subscriber handle if successful, otherwise `NULL`
+ */
+RMW_FASTRTPS_CPP_PUBLIC
+eprosima::fastrtps::Subscriber *
+get_response_subscriber(rmw_client_t * client);
+
+}  // namespace rmw_fastrtps_cpp
+
+#endif  // RMW_FASTRTPS_CPP__GET_CLIENT_HPP_

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/get_publisher.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/get_publisher.hpp
@@ -12,27 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RMW_FASTRTPS_CPP__GET_PARTICIPANT_HPP_
-#define RMW_FASTRTPS_CPP__GET_PARTICIPANT_HPP_
+#ifndef RMW_FASTRTPS_CPP__GET_PUBLISHER_HPP_
+#define RMW_FASTRTPS_CPP__GET_PUBLISHER_HPP_
 
-#include "fastrtps/participant/Participant.h"
+#include "fastrtps/publisher/Publisher.h"
 #include "rmw/rmw.h"
 #include "rmw_fastrtps_cpp/visibility_control.h"
 
 namespace rmw_fastrtps_cpp
 {
 
-/// Return a native FastRTPS participant handle.
+/// Return a native FastRTPS publisher handle.
 /**
- * The function returns `NULL` when either the node handle is `NULL` or when the
- * node handle is from a different rmw implementation.
+ * The function returns `NULL` when either the publisher handle is `NULL` or
+ * when the publisher handle is from a different rmw implementation.
  *
- * \return native FastRTPS participant handle if successful, otherwise `NULL`
+ * \return native FastRTPS publisher handle if successful, otherwise `NULL`
  */
 RMW_FASTRTPS_CPP_PUBLIC
-eprosima::fastrtps::Participant *
-get_participant(rmw_node_t * node);
+eprosima::fastrtps::Publisher *
+get_publisher(rmw_publisher_t * publisher);
 
 }  // namespace rmw_fastrtps_cpp
 
-#endif  // RMW_FASTRTPS_CPP__GET_PARTICIPANT_HPP_
+#endif  // RMW_FASTRTPS_CPP__GET_PUBLISHER_HPP_

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/get_service.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/get_service.hpp
@@ -1,0 +1,50 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RMW_FASTRTPS_CPP__GET_SERVICE_HPP_
+#define RMW_FASTRTPS_CPP__GET_SERVICE_HPP_
+
+#include "fastrtps/publisher/Publisher.h"
+#include "fastrtps/subscriber/Subscriber.h"
+#include "rmw/rmw.h"
+#include "rmw_fastrtps_cpp/visibility_control.h"
+
+namespace rmw_fastrtps_cpp
+{
+
+/// Return a native FastRTPS subscriber handle for the request.
+/**
+ * The function returns `NULL` when either the service handle is `NULL` or
+ * when the service handle is from a different rmw implementation.
+ *
+ * \return native FastRTPS subscriber handle if successful, otherwise `NULL`
+ */
+RMW_FASTRTPS_CPP_PUBLIC
+eprosima::fastrtps::Subscriber *
+get_request_subscriber(rmw_service_t * service);
+
+/// Return a native FastRTPS publisher handle for the response.
+/**
+ * The function returns `NULL` when either the service handle is `NULL` or
+ * when the service handle is from a different rmw implementation.
+ *
+ * \return native FastRTPS publisher handle if successful, otherwise `NULL`
+ */
+RMW_FASTRTPS_CPP_PUBLIC
+eprosima::fastrtps::Publisher *
+get_response_publisher(rmw_service_t * service);
+
+}  // namespace rmw_fastrtps_cpp
+
+#endif  // RMW_FASTRTPS_CPP__GET_SERVICE_HPP_

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/get_subscriber.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/get_subscriber.hpp
@@ -12,27 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RMW_FASTRTPS_CPP__GET_PARTICIPANT_HPP_
-#define RMW_FASTRTPS_CPP__GET_PARTICIPANT_HPP_
+#ifndef RMW_FASTRTPS_CPP__GET_SUBSCRIBER_HPP_
+#define RMW_FASTRTPS_CPP__GET_SUBSCRIBER_HPP_
 
-#include "fastrtps/participant/Participant.h"
+#include "fastrtps/subscriber/Subscriber.h"
 #include "rmw/rmw.h"
 #include "rmw_fastrtps_cpp/visibility_control.h"
 
 namespace rmw_fastrtps_cpp
 {
 
-/// Return a native FastRTPS participant handle.
+/// Return a native FastRTPS subscriber handle.
 /**
- * The function returns `NULL` when either the node handle is `NULL` or when the
- * node handle is from a different rmw implementation.
+ * The function returns `NULL` when either the subscription handle is `NULL` or
+ * when the subscription handle is from a different rmw implementation.
  *
- * \return native FastRTPS participant handle if successful, otherwise `NULL`
+ * \return native FastRTPS subscriber handle if successful, otherwise `NULL`
  */
 RMW_FASTRTPS_CPP_PUBLIC
-eprosima::fastrtps::Participant *
-get_participant(rmw_node_t * node);
+eprosima::fastrtps::Subscriber *
+get_subscriber(rmw_subscription_t * subscription);
 
 }  // namespace rmw_fastrtps_cpp
 
-#endif  // RMW_FASTRTPS_CPP__GET_PARTICIPANT_HPP_
+#endif  // RMW_FASTRTPS_CPP__GET_SUBSCRIBER_HPP_

--- a/rmw_fastrtps_cpp/src/get_client.cpp
+++ b/rmw_fastrtps_cpp/src/get_client.cpp
@@ -1,0 +1,49 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rmw_fastrtps_cpp/get_client.hpp"
+
+#include "rmw_fastrtps_cpp/custom_client_info.hpp"
+#include "rmw_fastrtps_cpp/identifier.hpp"
+
+namespace rmw_fastrtps_cpp
+{
+
+eprosima::fastrtps::Publisher *
+get_request_publisher(rmw_client_t * client)
+{
+  if (!client) {
+    return NULL;
+  }
+  if (client->implementation_identifier != eprosima_fastrtps_identifier) {
+    return NULL;
+  }
+  CustomClientInfo * impl = static_cast<CustomClientInfo *>(client->data);
+  return impl->request_publisher_;
+}
+
+eprosima::fastrtps::Subscriber *
+get_response_subscriber(rmw_client_t * client)
+{
+  if (!client) {
+    return NULL;
+  }
+  if (client->implementation_identifier != eprosima_fastrtps_identifier) {
+    return NULL;
+  }
+  CustomClientInfo * impl = static_cast<CustomClientInfo *>(client->data);
+  return impl->response_subscriber_;
+}
+
+}  // namespace rmw_fastrtps_cpp

--- a/rmw_fastrtps_cpp/src/get_publisher.cpp
+++ b/rmw_fastrtps_cpp/src/get_publisher.cpp
@@ -12,27 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RMW_FASTRTPS_CPP__GET_PARTICIPANT_HPP_
-#define RMW_FASTRTPS_CPP__GET_PARTICIPANT_HPP_
+#include "rmw_fastrtps_cpp/get_publisher.hpp"
 
-#include "fastrtps/participant/Participant.h"
-#include "rmw/rmw.h"
-#include "rmw_fastrtps_cpp/visibility_control.h"
+#include "rmw_fastrtps_cpp/custom_publisher_info.hpp"
+#include "rmw_fastrtps_cpp/identifier.hpp"
 
 namespace rmw_fastrtps_cpp
 {
 
-/// Return a native FastRTPS participant handle.
-/**
- * The function returns `NULL` when either the node handle is `NULL` or when the
- * node handle is from a different rmw implementation.
- *
- * \return native FastRTPS participant handle if successful, otherwise `NULL`
- */
-RMW_FASTRTPS_CPP_PUBLIC
-eprosima::fastrtps::Participant *
-get_participant(rmw_node_t * node);
+eprosima::fastrtps::Publisher *
+get_publisher(rmw_publisher_t * publisher)
+{
+  if (!publisher) {
+    return NULL;
+  }
+  if (publisher->implementation_identifier != eprosima_fastrtps_identifier) {
+    return NULL;
+  }
+  CustomPublisherInfo * impl = static_cast<CustomPublisherInfo *>(publisher->data);
+  return impl->publisher_;
+}
 
 }  // namespace rmw_fastrtps_cpp
-
-#endif  // RMW_FASTRTPS_CPP__GET_PARTICIPANT_HPP_

--- a/rmw_fastrtps_cpp/src/get_service.cpp
+++ b/rmw_fastrtps_cpp/src/get_service.cpp
@@ -1,0 +1,49 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rmw_fastrtps_cpp/get_service.hpp"
+
+#include "rmw_fastrtps_cpp/custom_service_info.hpp"
+#include "rmw_fastrtps_cpp/identifier.hpp"
+
+namespace rmw_fastrtps_cpp
+{
+
+eprosima::fastrtps::Subscriber *
+get_request_subscriber(rmw_service_t * service)
+{
+  if (!service) {
+    return NULL;
+  }
+  if (service->implementation_identifier != eprosima_fastrtps_identifier) {
+    return NULL;
+  }
+  CustomServiceInfo * impl = static_cast<CustomServiceInfo *>(service->data);
+  return impl->request_subscriber_;
+}
+
+eprosima::fastrtps::Publisher *
+get_response_publisher(rmw_service_t * service)
+{
+  if (!service) {
+    return NULL;
+  }
+  if (service->implementation_identifier != eprosima_fastrtps_identifier) {
+    return NULL;
+  }
+  CustomServiceInfo * impl = static_cast<CustomServiceInfo *>(service->data);
+  return impl->response_publisher_;
+}
+
+}  // namespace rmw_fastrtps_cpp

--- a/rmw_fastrtps_cpp/src/get_subscriber.cpp
+++ b/rmw_fastrtps_cpp/src/get_subscriber.cpp
@@ -12,27 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RMW_FASTRTPS_CPP__GET_PARTICIPANT_HPP_
-#define RMW_FASTRTPS_CPP__GET_PARTICIPANT_HPP_
+#include "rmw_fastrtps_cpp/get_subscriber.hpp"
 
-#include "fastrtps/participant/Participant.h"
-#include "rmw/rmw.h"
-#include "rmw_fastrtps_cpp/visibility_control.h"
+#include "rmw_fastrtps_cpp/custom_subscriber_info.hpp"
+#include "rmw_fastrtps_cpp/identifier.hpp"
 
 namespace rmw_fastrtps_cpp
 {
 
-/// Return a native FastRTPS participant handle.
-/**
- * The function returns `NULL` when either the node handle is `NULL` or when the
- * node handle is from a different rmw implementation.
- *
- * \return native FastRTPS participant handle if successful, otherwise `NULL`
- */
-RMW_FASTRTPS_CPP_PUBLIC
-eprosima::fastrtps::Participant *
-get_participant(rmw_node_t * node);
+eprosima::fastrtps::Subscriber *
+get_subscriber(rmw_subscription_t * subscription)
+{
+  if (!subscription) {
+    return NULL;
+  }
+  if (subscription->implementation_identifier != eprosima_fastrtps_identifier) {
+    return NULL;
+  }
+  CustomSubscriberInfo * impl = static_cast<CustomSubscriberInfo *>(subscription->data);
+  return impl->subscriber_;
+}
 
 }  // namespace rmw_fastrtps_cpp
-
-#endif  // RMW_FASTRTPS_CPP__GET_PARTICIPANT_HPP_

--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -29,8 +29,8 @@
 #include "namespace_prefix.hpp"
 #include "qos.hpp"
 #include "type_support_common.hpp"
+#include "rmw_fastrtps_cpp/custom_client_info.hpp"
 #include "rmw_fastrtps_cpp/custom_participant_info.hpp"
-#include "types/custom_client_info.hpp"
 
 extern "C"
 {

--- a/rmw_fastrtps_cpp/src/rmw_get_gid_for_publisher.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_get_gid_for_publisher.cpp
@@ -16,8 +16,8 @@
 #include "rmw/rmw.h"
 #include "rmw/types.h"
 
+#include "rmw_fastrtps_cpp/custom_publisher_info.hpp"
 #include "rmw_fastrtps_cpp/identifier.hpp"
-#include "types/custom_publisher_info.hpp"
 
 extern "C"
 {

--- a/rmw_fastrtps_cpp/src/rmw_publish.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publish.cpp
@@ -19,9 +19,9 @@
 #include "rmw/error_handling.h"
 #include "rmw/rmw.h"
 
+#include "rmw_fastrtps_cpp/custom_publisher_info.hpp"
 #include "rmw_fastrtps_cpp/identifier.hpp"
 #include "ros_message_serialization.hpp"
-#include "types/custom_publisher_info.hpp"
 
 extern "C"
 {

--- a/rmw_fastrtps_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publisher.cpp
@@ -23,7 +23,7 @@
 #include "namespace_prefix.hpp"
 #include "qos.hpp"
 #include "rmw_fastrtps_cpp/custom_participant_info.hpp"
-#include "types/custom_publisher_info.hpp"
+#include "rmw_fastrtps_cpp/custom_publisher_info.hpp"
 #include "type_support_common.hpp"
 
 extern "C"

--- a/rmw_fastrtps_cpp/src/rmw_request.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_request.cpp
@@ -23,10 +23,10 @@
 #include "rmw/rmw.h"
 #include "rmw/types.h"
 
+#include "rmw_fastrtps_cpp/custom_client_info.hpp"
+#include "rmw_fastrtps_cpp/custom_service_info.hpp"
 #include "rmw_fastrtps_cpp/identifier.hpp"
 #include "ros_message_serialization.hpp"
-#include "types/custom_client_info.hpp"
-#include "types/custom_service_info.hpp"
 
 extern "C"
 {

--- a/rmw_fastrtps_cpp/src/rmw_response.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_response.cpp
@@ -21,10 +21,10 @@
 #include "rmw/error_handling.h"
 #include "rmw/rmw.h"
 
+#include "rmw_fastrtps_cpp/custom_client_info.hpp"
+#include "rmw_fastrtps_cpp/custom_service_info.hpp"
 #include "rmw_fastrtps_cpp/identifier.hpp"
 #include "ros_message_serialization.hpp"
-#include "types/custom_client_info.hpp"
-#include "types/custom_service_info.hpp"
 
 extern "C"
 {

--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -40,7 +40,7 @@
 #include "qos.hpp"
 #include "type_support_common.hpp"
 #include "rmw_fastrtps_cpp/custom_participant_info.hpp"
-#include "types/custom_service_info.hpp"
+#include "rmw_fastrtps_cpp/custom_service_info.hpp"
 
 extern "C"
 {

--- a/rmw_fastrtps_cpp/src/rmw_service_server_is_available.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service_server_is_available.cpp
@@ -25,8 +25,8 @@
 #include "rmw/types.h"
 
 #include "demangle.hpp"
+#include "rmw_fastrtps_cpp/custom_client_info.hpp"
 #include "rmw_fastrtps_cpp/identifier.hpp"
-#include "types/custom_client_info.hpp"
 
 extern "C"
 {

--- a/rmw_fastrtps_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_subscription.cpp
@@ -27,7 +27,7 @@
 #include "namespace_prefix.hpp"
 #include "qos.hpp"
 #include "rmw_fastrtps_cpp/custom_participant_info.hpp"
-#include "types/custom_subscriber_info.hpp"
+#include "rmw_fastrtps_cpp/custom_subscriber_info.hpp"
 #include "type_support_common.hpp"
 
 extern "C"

--- a/rmw_fastrtps_cpp/src/rmw_take.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_take.cpp
@@ -21,8 +21,8 @@
 #include "fastrtps/attributes/SubscriberAttributes.h"
 
 #include "fastcdr/FastBuffer.h"
+#include "rmw_fastrtps_cpp/custom_subscriber_info.hpp"
 #include "rmw_fastrtps_cpp/identifier.hpp"
-#include "types/custom_subscriber_info.hpp"
 #include "ros_message_serialization.hpp"
 
 extern "C"

--- a/rmw_fastrtps_cpp/src/rmw_wait.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_wait.cpp
@@ -17,9 +17,9 @@
 #include "rmw/error_handling.h"
 #include "rmw/rmw.h"
 
-#include "types/custom_client_info.hpp"
-#include "types/custom_service_info.hpp"
-#include "types/custom_subscriber_info.hpp"
+#include "rmw_fastrtps_cpp/custom_client_info.hpp"
+#include "rmw_fastrtps_cpp/custom_service_info.hpp"
+#include "rmw_fastrtps_cpp/custom_subscriber_info.hpp"
 #include "types/custom_waitset_info.hpp"
 #include "types/guard_condition.hpp"
 


### PR DESCRIPTION
Follow up of #145 additionally exposing the publishers and subscribers of topics as well as services.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3058)](http://ci.ros2.org/job/ci_linux/3058/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=451)](http://ci.ros2.org/job/ci_linux-aarch64/451/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2457)](http://ci.ros2.org/job/ci_osx/2457/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3129)](http://ci.ros2.org/job/ci_windows/3129/)