### PR TITLE
Drop duplicated rmw_init.cpp in rmw_fastrtps_cpp/CMakeLists.txt

### DIFF
--- a/rmw_fastrtps_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_cpp/CMakeLists.txt
@@ -60,7 +60,6 @@ add_library(rmw_fastrtps_cpp
   src/identifier.cpp
   src/namespace_prefix.cpp
   src/qos.cpp
-  src/rmw_init.cpp
   src/rmw_client.cpp
   src/rmw_compare_gids_equal.cpp
   src/rmw_count.cpp


### PR DESCRIPTION
src/rmw_init.cpp appear twice in add_library(rmw_fastrtps_cpp, ...). Drop the duplicated one.
