### PR TITLE
Move the hasData checks for non-blocking wait 'timeout' higher

### DIFF
--- a/rmw_fastrtps_cpp/src/rmw_wait.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_wait.cpp
@@ -194,6 +194,14 @@ rmw_wait(
   // after we check, it will be caught on the next call to this function).
   lock.unlock();
 
+  // Even if this was a non-blocking wait, signal a timeout if there's no data.
+  // This makes the return behavior consistent with rcl expectations for zero timeout value.
+  // Do this before detaching the listeners because the data gets cleared for guard conditions.
+  bool hasData = check_waitset_for_data(subscriptions, guard_conditions, services, clients);
+  if (!hasData && wait_timeout && wait_timeout->sec == 0 && wait_timeout->nsec == 0) {
+    timeout = true;
+  }
+
   for (size_t i = 0; i < subscriptions->subscriber_count; ++i) {
     void * data = subscriptions->subscribers[i];
     CustomSubscriberInfo * custom_subscriber_info = static_cast<CustomSubscriberInfo *>(data);
@@ -230,11 +238,6 @@ rmw_wait(
         guard_conditions->guard_conditions[i] = 0;
       }
     }
-  }
-  // Make timeout behavior consistent with rcl expectations for zero timeout value
-  bool hasData = check_waitset_for_data(subscriptions, guard_conditions, services, clients);
-  if (!hasData && wait_timeout && wait_timeout->sec == 0 && wait_timeout->nsec == 0) {
-    return RMW_RET_TIMEOUT;
   }
 
   return timeout ? RMW_RET_TIMEOUT : RMW_RET_OK;


### PR DESCRIPTION
Avoids the data having been already cleared for guard conditions

fixes the test added in ros2/rcl#169

CI of all repos including the new test added in ros2/rcl#169
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3354)](http://ci.ros2.org/job/ci_linux/3354/) (fixed the test: http://ci.ros2.org/job/ci_linux/3354/testReport/(root)/WaitSetTestFixture__rmw_fastrtps_cpp/zero_timeout_triggered_guard_condition/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=613)](http://ci.ros2.org/job/ci_linux-aarch64/613/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2691)](http://ci.ros2.org/job/ci_osx/2691/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3414)](http://ci.ros2.org/job/ci_windows/3414/)