### PR TITLE
Remove unnecessary dependency on rosidl_generator_cpp

### DIFF
--- a/rmw_fastrtps_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_cpp/CMakeLists.txt
@@ -36,14 +36,12 @@ find_package(FastRTPS REQUIRED MODULE)
 
 find_package(rmw REQUIRED)
 find_package(rosidl_generator_c REQUIRED)
-find_package(rosidl_generator_cpp REQUIRED)
 find_package(rosidl_typesupport_introspection_c REQUIRED)
 find_package(rosidl_typesupport_introspection_cpp REQUIRED)
 
 ament_export_dependencies(rcutils)
 ament_export_dependencies(rmw)
 ament_export_dependencies(rosidl_generator_c)
-ament_export_dependencies(rosidl_generator_cpp)
 ament_export_dependencies(rosidl_typesupport_introspection_c)
 ament_export_dependencies(rosidl_typesupport_introspection_cpp)
 
@@ -94,7 +92,7 @@ ament_target_dependencies(rmw_fastrtps_cpp
   "rosidl_typesupport_introspection_cpp"
   "rmw"
   "rosidl_generator_c"
-  "rosidl_generator_cpp")
+)
 
 configure_rmw_library(rmw_fastrtps_cpp)
 

--- a/rmw_fastrtps_cpp/package.xml
+++ b/rmw_fastrtps_cpp/package.xml
@@ -18,7 +18,6 @@
   <build_depend>rcutils</build_depend>
   <build_depend>rmw</build_depend>
   <build_depend>rosidl_generator_c</build_depend>
-  <build_depend>rosidl_generator_cpp</build_depend>
   <build_depend>rosidl_typesupport_introspection_c</build_depend>
   <build_depend>rosidl_typesupport_introspection_cpp</build_depend>
 
@@ -28,7 +27,6 @@
   <build_export_depend>rcutils</build_export_depend>
   <build_export_depend>rmw</build_export_depend>
   <build_export_depend>rosidl_generator_c</build_export_depend>
-  <build_export_depend>rosidl_generator_cpp</build_export_depend>
   <build_export_depend>rosidl_typesupport_introspection_c</build_export_depend>
   <build_export_depend>rosidl_typesupport_introspection_cpp</build_export_depend>
 


### PR DESCRIPTION
In https://github.com/ros2/rmw_fastrtps/issues/159 we realised this isn't actually used

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3364)](http://ci.ros2.org/job/ci_linux/3364/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=619)](http://ci.ros2.org/job/ci_linux-aarch64/619/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2697)](http://ci.ros2.org/job/ci_osx/2697/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3421)](http://ci.ros2.org/job/ci_windows/3421/)