### PR TITLE
Fix rmw_fastrtps dead code

### DIFF
--- a/rmw_fastrtps_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publisher.cpp
@@ -170,7 +170,7 @@ rmw_create_publisher(
   rmw_publisher->topic_name = reinterpret_cast<char *>(rmw_allocate(strlen(topic_name) + 1));
 
   if (!rmw_publisher->topic_name) {
-    RMW_SET_ERROR_MSG("failed to allocate memory for publiser node name");
+    RMW_SET_ERROR_MSG("failed to allocate memory for publiser topic name");
     goto fail;
   }
 

--- a/rmw_fastrtps_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publisher.cpp
@@ -170,7 +170,7 @@ rmw_create_publisher(
   rmw_publisher->topic_name = reinterpret_cast<char *>(rmw_allocate(strlen(topic_name) + 1));
 
   if (!rmw_publisher->topic_name) {
-    RMW_SET_ERROR_MSG("failed to allocate memory for publiser topic name");
+    RMW_SET_ERROR_MSG("failed to allocate memory for publisher topic name");
     goto fail;
   }
 

--- a/rmw_fastrtps_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publisher.cpp
@@ -177,10 +177,6 @@ fail:
     delete info;
   }
 
-  if (rmw_publisher) {
-    rmw_publisher_free(rmw_publisher);
-  }
-
   return NULL;
 }
 

--- a/rmw_fastrtps_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publisher.cpp
@@ -168,6 +168,12 @@ rmw_create_publisher(
   rmw_publisher->implementation_identifier = eprosima_fastrtps_identifier;
   rmw_publisher->data = info;
   rmw_publisher->topic_name = reinterpret_cast<char *>(rmw_allocate(strlen(topic_name) + 1));
+
+  if (!rmw_publisher->topic_name) {
+    RMW_SET_ERROR_MSG("failed to allocate memory for publiser node name");
+    goto fail;
+  }
+
   memcpy(const_cast<char *>(rmw_publisher->topic_name), topic_name, strlen(topic_name) + 1);
   return rmw_publisher;
 

--- a/rmw_fastrtps_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_subscription.cpp
@@ -152,7 +152,7 @@ rmw_create_subscription(
     reinterpret_cast<const char *>(rmw_allocate(strlen(topic_name) + 1));
 
   if (!rmw_subscription->topic_name) {
-    RMW_SET_ERROR_MSG("failed to allocate memory for subscription node name");
+    RMW_SET_ERROR_MSG("failed to allocate memory for subscription topic name");
     goto fail;
   }
 

--- a/rmw_fastrtps_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_subscription.cpp
@@ -150,6 +150,12 @@ rmw_create_subscription(
   rmw_subscription->data = info;
   rmw_subscription->topic_name =
     reinterpret_cast<const char *>(rmw_allocate(strlen(topic_name) + 1));
+
+  if (!rmw_subscription->topic_name) {
+    RMW_SET_ERROR_MSG("failed to allocate memory for subscription node name");
+    goto fail;
+  }
+
   memcpy(const_cast<char *>(rmw_subscription->topic_name), topic_name, strlen(topic_name) + 1);
   return rmw_subscription;
 

--- a/rmw_fastrtps_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_subscription.cpp
@@ -162,10 +162,6 @@ fail:
     delete info;
   }
 
-  if (rmw_subscription) {
-    rmw_subscription_free(rmw_subscription);
-  }
-
   return NULL;
 }
 


### PR DESCRIPTION
Dead code in API `rmw_create_subscription()`
becasue the condition "`rmw_subscription`" cannot be true in the
"`fail`" clauses, the execution cannot reach this statement:

`rmw_subscription_free(rmw_subscription);
`

finally, the "`rmw_subscribtion`" is free by
`rmw_destroy_subscription()` when it's not a nullptr

Dead code in API rmw_create_publisher()
because the condition "`rmw_publisher`" cannot be true in the
"`fail`" clauses, the execution cannot reach this statement:

`rmw_publisher_free(rmw_publisher);
`

finally, the "`rmw_publisher`" is free by
`rmw_destroy_publisher()` when it's not a nullptr

Signed-off-by: Ethan Gao <ethan.gao@linux.intel.com>