### PR TITLE
Fix the issues to dereference to nullptr

### DIFF
--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -209,34 +209,36 @@ rmw_create_client(
   return rmw_client;
 
 fail:
-  if (info->request_publisher_ != nullptr) {
-    Domain::removePublisher(info->request_publisher_);
-  }
-
-  if (info->response_subscriber_ != nullptr) {
-    Domain::removeSubscriber(info->response_subscriber_);
-  }
-
-  if (info->listener_ != nullptr) {
-    delete info->listener_;
-  }
-
-  if (impl) {
-    if (info->request_type_support_ != nullptr) {
-      _unregister_type(participant, info->request_type_support_, info->typesupport_identifier_);
+  if (info != nullptr) {
+    if (info->request_publisher_ != nullptr) {
+      Domain::removePublisher(info->request_publisher_);
     }
 
-    if (info->response_type_support_ != nullptr) {
-      _unregister_type(participant, info->response_type_support_, info->typesupport_identifier_);
+    if (info->response_subscriber_ != nullptr) {
+      Domain::removeSubscriber(info->response_subscriber_);
     }
-  } else {
-    RCUTILS_LOG_ERROR_NAMED(
-      "rmw_fastrtps_cpp",
-      "leaking type support objects because node impl is null")
-  }
 
-  delete info;
-  info = nullptr;
+    if (info->listener_ != nullptr) {
+      delete info->listener_;
+    }
+
+    if (impl) {
+      if (info->request_type_support_ != nullptr) {
+        _unregister_type(participant, info->request_type_support_, info->typesupport_identifier_);
+      }
+
+      if (info->response_type_support_ != nullptr) {
+        _unregister_type(participant, info->response_type_support_, info->typesupport_identifier_);
+      }
+    } else {
+      RCUTILS_LOG_ERROR_NAMED(
+        "rmw_fastrtps_cpp",
+        "leaking type support objects because node impl is null")
+    }
+
+    delete info;
+    info = nullptr;
+  }
 
   if (nullptr != rmw_client) {
     if (rmw_client->service_name != nullptr) {


### PR DESCRIPTION
_Issue_: the `info` in `fail` is always non-nullptr
_issue_: no checking to memory allocation of `rmw_client`, which
       may leads to free `nullptr` in the following code:

`  rmw_client_free(rmw_client);`

_Issue_: uninteded memory free from `rmw_client->service_name`:

```
  if (rmw_client->service_name != nullptr) {
    rmw_free(const_cast<char *>(rmw_client->service_name));
    rmw_client->service_name = nullptr;
  }
```

when the code goes to `fail` before it's actually allocated here:

```
  rmw_client->service_name = reinterpret_cast<const char *>(
    rmw_allocate(strlen(service_name) + 1));
```

Signed-off-by: Ethan Gao <ethan.gao@linux.intel.com>