### PR TITLE
memory leak issue

### DIFF
--- a/rmw_fastrtps_cpp/src/rmw_node.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_node.cpp
@@ -171,18 +171,20 @@ get_security_file_paths(
   char * file_path = nullptr;
   for (size_t i = 0; i < num_files; i++) {
     file_path = rcutils_join_path(node_secure_root, file_names[i]);
-    if (file_path) {
-      if (!rcutils_is_readable(file_path)) {
-        free(file_path);
-        return false;
-      }
-
-      security_files_paths[i] = std::string(file_prefix + file_path);
-      free(file_path);
-    } else {
-        RMW_SET_ERROR_MSG("Failed to allocate memory to get security file path");
-        return false;
+    if (!file_path) {
+      RMW_SET_ERROR_MSG("Failed to allocate memory for security file path");
+      return false;
     }
+
+    if (rcutils_is_readable(file_path)) {
+      security_files_paths[i] = std::string(file_prefix + std::string(file_path));
+    } else {
+      RMW_SET_ERROR_MSG("No security file found");
+      free(file_path);
+      return false;
+    }
+
+    free(file_path);
   }
 
   return true;

--- a/rmw_fastrtps_cpp/src/rmw_node.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_node.cpp
@@ -166,24 +166,22 @@ get_security_file_paths(
   const char * file_names[3] = {"ca.cert.pem", "cert.pem", "key.pem"};
   size_t num_files = sizeof(file_names) / sizeof(char *);
 
-  const char * file_prefix = "file://";
+  std::string file_prefix("file://");
 
   for (size_t i = 0; i < num_files; i++) {
-    char * file_path = rcutils_join_path(node_secure_root, file_names[i]);
+    const char * file_path = rcutils_join_path(node_secure_root, file_names[i]);
     if (!file_path) {
-      RMW_SET_ERROR_MSG("Failed to allocate memory for security file path");
       return false;
     }
 
     if (rcutils_is_readable(file_path)) {
-      security_files_paths[i] = std::string(file_prefix) + std::string(file_path);
+      security_files_paths[i] = file_prefix + std::string(file_path);
     } else {
-      RMW_SET_ERROR_MSG("No security file found");
-      free(file_path);
+      free(const_cast<char *>(file_path));
       return false;
     }
 
-    free(file_path);
+    free(const_cast<char *>(file_path));
   }
 
   return true;

--- a/rmw_fastrtps_cpp/src/rmw_node.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_node.cpp
@@ -172,13 +172,12 @@ get_security_file_paths(
   for (size_t i = 0; i < num_files; i++) {
     file_path = rcutils_join_path(node_secure_root, file_names[i]);
     if (file_path) {
-      if (!rcutils_is_readable(std::string(file_path).c_str())) {
+      if (!rcutils_is_readable(file_path)) {
         free(file_path);
-        file_path = nullptr;
         return false;
       }
 
-      security_files_paths[i] = std::string(file_prefix + std::string(file_path));
+      security_files_paths[i] = std::string(file_prefix + file_path);
       free(file_path);
     } else {
         RMW_SET_ERROR_MSG("Failed to allocate memory to get security file path");
@@ -186,7 +185,6 @@ get_security_file_paths(
     }
   }
 
-  file_path = nullptr;
   return true;
 }
 

--- a/rmw_fastrtps_cpp/src/rmw_node.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_node.cpp
@@ -168,16 +168,15 @@ get_security_file_paths(
 
   const char * file_prefix = "file://";
 
-  char * file_path = nullptr;
   for (size_t i = 0; i < num_files; i++) {
-    file_path = rcutils_join_path(node_secure_root, file_names[i]);
+    char * file_path = rcutils_join_path(node_secure_root, file_names[i]);
     if (!file_path) {
       RMW_SET_ERROR_MSG("Failed to allocate memory for security file path");
       return false;
     }
 
     if (rcutils_is_readable(file_path)) {
-      security_files_paths[i] = std::string(file_prefix + std::string(file_path));
+      security_files_paths[i] = std::string(file_prefix) + std::string(file_path);
     } else {
       RMW_SET_ERROR_MSG("No security file found");
       free(file_path);

--- a/rmw_fastrtps_cpp/src/rmw_node.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_node.cpp
@@ -168,14 +168,25 @@ get_security_file_paths(
 
   const char * file_prefix = "file://";
 
-  std::string tmpstr;
+  char * file_path = nullptr;
   for (size_t i = 0; i < num_files; i++) {
-    tmpstr = std::string(rcutils_join_path(node_secure_root, file_names[i]));
-    if (!rcutils_is_readable(tmpstr.c_str())) {
-      return false;
+    file_path = rcutils_join_path(node_secure_root, file_names[i]);
+    if (file_path) {
+      if (!rcutils_is_readable(std::string(file_path).c_str())) {
+        free(file_path);
+        file_path = nullptr;
+        return false;
+      }
+
+      security_files_paths[i] = std::string(file_prefix + std::string(file_path));
+      free(file_path);
+    } else {
+        RMW_SET_ERROR_MSG("Failed to allocate memory to get security file path");
+        return false;
     }
-    security_files_paths[i] = std::string(file_prefix + tmpstr);
   }
+
+  file_path = nullptr;
   return true;
 }
 


### PR DESCRIPTION
Failing to save or free storage allocated from
`rcutils_join_path()`, which results in memory leak

Signed-off-by: Ethan Gao <ethan.gao@linux.intel.com>