### PR TITLE
rcutils_join_path returns a char * now.

### DIFF
--- a/rmw_fastrtps_cpp/src/rmw_node.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_node.cpp
@@ -169,7 +169,7 @@ get_security_file_paths(
   std::string file_prefix("file://");
 
   for (size_t i = 0; i < num_files; i++) {
-    const char * file_path = rcutils_join_path(node_secure_root, file_names[i]);
+    char * file_path = rcutils_join_path(node_secure_root, file_names[i]);
     if (!file_path) {
       return false;
     }
@@ -177,11 +177,11 @@ get_security_file_paths(
     if (rcutils_is_readable(file_path)) {
       security_files_paths[i] = file_prefix + std::string(file_path);
     } else {
-      free(const_cast<char *>(file_path));
+      free(file_path);
       return false;
     }
 
-    free(const_cast<char *>(file_path));
+    free(file_path);
   }
 
   return true;


### PR DESCRIPTION
Thus, we no longer need to cast away the const when freeing it.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

connects to ros2/ros2#423