### PR TITLE
Don;t export pthread anymore

### DIFF
--- a/rmw_fastrtps_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_cpp/CMakeLists.txt
@@ -103,9 +103,6 @@ PRIVATE "RMW_FASTRTPS_CPP_BUILDING_LIBRARY")
 
 ament_export_include_directories(include)
 ament_export_libraries(rmw_fastrtps_cpp)
-if(NOT WIN32 AND NOT ANDROID)
-  ament_export_libraries(pthread)
-endif()
 
 register_rmw_implementation(
   "c:rosidl_typesupport_c:rosidl_typesupport_introspection_c"


### PR DESCRIPTION
This doesnt seem to be necessary anymore and may fix some cross-compilation issues we are facing.

This is a manual revert of #24 

Linux job with only fastrtps
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3552)](http://ci.ros2.org/job/ci_linux/3552/)