### PR TITLE
use newly exposed unread-count to avoid getting out-of-sync

### DIFF
--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/custom_subscriber_info.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/custom_subscriber_info.hpp
@@ -62,11 +62,11 @@ public:
       std::unique_lock<std::mutex> clock(*conditionMutex_);
       // the change to data_ needs to be mutually exclusive with rmw_wait()
       // which checks hasData() and decides if wait() needs to be called
-      ++data_;
+      data_ = sub->getUnreadCount();
       clock.unlock();
       conditionVariable_->notify_one();
     } else {
-      ++data_;
+      data_ = sub->getUnreadCount();
     }
   }
 


### PR DESCRIPTION
This fixes ros2/rclcpp#280 and requires the recent API extension from eProsima/Fast-RTPS#166.

The following set of builds only shows that it doesn't introduce a regression but doesn't prove that it actually addresses the problem:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3733)](http://ci.ros2.org/job/ci_linux/3733/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=888)](http://ci.ros2.org/job/ci_linux-aarch64/888/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3071)](http://ci.ros2.org/job/ci_osx/3071/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3830)](http://ci.ros2.org/job/ci_windows/3830/)

Connect to ros2/rclcpp#280.