### PR TITLE
Segmentation error to dereference nullptr

### DIFF
--- a/rmw_fastrtps_cpp/src/rmw_node.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_node.cpp
@@ -127,13 +127,18 @@ create_node(
   node_impl->secondaryPubListener = tnat_2;
 
   edp_readers = participant->getEDPReaders();
-  if (edp_readers.first && edp_readers.second) {
-    if (!(edp_readers.first->setListener(tnat_1) & edp_readers.second->setListener(tnat_2))) {
-      RMW_SET_ERROR_MSG("Failed to attach ROS related logic to the Participant");
-      goto fail;
-    }
-  } else {
-    RMW_SET_ERROR_MSG("Failed to get valid reader for node subscriber and publisher");
+  if (!edp_readers.first) {
+    RMW_SET_ERROR_MSG("edp_readers.first is null");
+    goto fail;
+  }
+
+  if (!edp_readers.second) {
+    RMW_SET_ERROR_MSG("edp_readers.second is null");
+    goto fail;
+  }
+
+  if (!(edp_readers.first->setListener(tnat_1) & edp_readers.second->setListener(tnat_2))) {
+    RMW_SET_ERROR_MSG("Failed to attach ROS related logic to the Participant");
     goto fail;
   }
 

--- a/rmw_fastrtps_cpp/src/rmw_node.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_node.cpp
@@ -127,8 +127,13 @@ create_node(
   node_impl->secondaryPubListener = tnat_2;
 
   edp_readers = participant->getEDPReaders();
-  if (!(edp_readers.first->setListener(tnat_1) & edp_readers.second->setListener(tnat_2))) {
-    RMW_SET_ERROR_MSG("Failed to attach ROS related logic to the Participant");
+  if (edp_readers.first && edp_readers.second) {
+    if (!(edp_readers.first->setListener(tnat_1) & edp_readers.second->setListener(tnat_2))) {
+      RMW_SET_ERROR_MSG("Failed to attach ROS related logic to the Participant");
+      goto fail;
+    }
+  } else {
+    RMW_SET_ERROR_MSG("Failed to get valid reader for node subsciber and publisher");
     goto fail;
   }
 
@@ -272,12 +277,12 @@ rmw_destroy_node(rmw_node_t * node)
 
   // Begin deleting things in the same order they were created in rmw_create_node().
   std::pair<StatefulReader *, StatefulReader *> edp_readers = participant->getEDPReaders();
-  if (!edp_readers.first->setListener(nullptr)) {
+  if (!edp_readers.first || !edp_readers.first->setListener(nullptr)) {
     RMW_SET_ERROR_MSG("failed to unset EDPReader listener");
     result_ret = RMW_RET_ERROR;
   }
   delete impl->secondarySubListener;
-  if (!edp_readers.second->setListener(nullptr)) {
+  if (!edp_readers.second || !edp_readers.second->setListener(nullptr)) {
     RMW_SET_ERROR_MSG("failed to unset EDPReader listener");
     result_ret = RMW_RET_ERROR;
   }

--- a/rmw_fastrtps_cpp/src/rmw_node.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_node.cpp
@@ -133,7 +133,7 @@ create_node(
       goto fail;
     }
   } else {
-    RMW_SET_ERROR_MSG("Failed to get valid reader for node subsciber and publisher");
+    RMW_SET_ERROR_MSG("Failed to get valid reader for node subscriber and publisher");
     goto fail;
   }
 
@@ -277,12 +277,17 @@ rmw_destroy_node(rmw_node_t * node)
 
   // Begin deleting things in the same order they were created in rmw_create_node().
   std::pair<StatefulReader *, StatefulReader *> edp_readers = participant->getEDPReaders();
-  if (!edp_readers.first || !edp_readers.first->setListener(nullptr)) {
+  if (!edp_readers.first || !edp_readers.second) {
+    RMW_SET_ERROR_MSG("failed to get EDPReader listener");
+    result_ret = RMW_RET_ERROR;
+  }
+
+  if (edp_readers.first && !edp_readers.first->setListener(nullptr)) {
     RMW_SET_ERROR_MSG("failed to unset EDPReader listener");
     result_ret = RMW_RET_ERROR;
   }
   delete impl->secondarySubListener;
-  if (!edp_readers.second || !edp_readers.second->setListener(nullptr)) {
+  if (edp_readers.second && !edp_readers.second->setListener(nullptr)) {
     RMW_SET_ERROR_MSG("failed to unset EDPReader listener");
     result_ret = RMW_RET_ERROR;
   }

--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -241,7 +241,7 @@ fail:
     delete info;
   }
 
-  if (rmw_service && rmw_service->service_name != nullptr) {
+  if (rmw_service && rmw_service->service_name) {
     rmw_free(const_cast<char *>(rmw_service->service_name));
     rmw_service->service_name = nullptr;
   }

--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -199,6 +199,10 @@ rmw_create_service(
   }
 
   rmw_service = rmw_service_allocate();
+  if (!rmw_service) {
+    RMW_SET_ERROR_MSG("failed to allocate memory for service");
+    goto fail;
+  }
   rmw_service->implementation_identifier = eprosima_fastrtps_identifier;
   rmw_service->data = info;
   rmw_service->service_name = reinterpret_cast<const char *>(
@@ -237,7 +241,7 @@ fail:
     delete info;
   }
 
-  if (rmw_service->service_name != nullptr) {
+  if (rmw_service && rmw_service->service_name != nullptr) {
     rmw_free(const_cast<char *>(rmw_service->service_name));
     rmw_service->service_name = nullptr;
   }


### PR DESCRIPTION
`getEDPReaders` is possible to return `nullptr`

Signed-off-by: Ethan Gao <ethan.gao@linux.intel.com>