### PR TITLE
Small performance improvments

### DIFF
--- a/rmw_fastrtps_cpp/src/demangle.cpp
+++ b/rmw_fastrtps_cpp/src/demangle.cpp
@@ -25,11 +25,7 @@
 std::string
 _demangle_if_ros_topic(const std::string & topic_name)
 {
-  std::string prefix = _get_ros_prefix_if_exists(topic_name);
-  if (prefix.length()) {
-    return topic_name.substr(strlen(ros_topic_prefix));
-  }
-  return topic_name;
+  return _strip_ros_prefix_if_exists(topic_name);
 }
 
 /// Return the demangled ROS type or the original if not a ROS type.

--- a/rmw_fastrtps_cpp/src/namespace_prefix.cpp
+++ b/rmw_fastrtps_cpp/src/namespace_prefix.cpp
@@ -32,10 +32,22 @@ const std::vector<std::string> _ros_prefixes =
 std::string
 _get_ros_prefix_if_exists(const std::string & topic_name)
 {
-  for (auto prefix : _ros_prefixes) {
-    if (topic_name.rfind(std::string(prefix) + "/", 0) == 0) {
+  for (const auto & prefix : _ros_prefixes) {
+    if (topic_name.rfind(prefix, 0) == 0 && topic_name.at(prefix.length()) == '/') {
       return prefix;
     }
   }
   return "";
+}
+
+/// Strip the ROS specific prefix if it exists from the topic name.
+std::string
+_strip_ros_prefix_if_exists(const std::string & topic_name)
+{
+  for (const auto & prefix : _ros_prefixes) {
+    if (topic_name.rfind(prefix, 0) == 0 && topic_name.at(prefix.length()) == '/') {
+      return topic_name.substr(prefix.length());
+    }
+  }
+  return topic_name;
 }

--- a/rmw_fastrtps_cpp/src/namespace_prefix.hpp
+++ b/rmw_fastrtps_cpp/src/namespace_prefix.hpp
@@ -31,4 +31,7 @@ extern const std::vector<std::string> _ros_prefixes;
 std::string
 _get_ros_prefix_if_exists(const std::string & topic_name);
 
+/// Returns the topic name stripped of and ROS specific prefix if exists.
+std::string
+_strip_ros_prefix_if_exists(const std::string & topic_name);
 #endif  // NAMESPACE_PREFIX_HPP_

--- a/rmw_fastrtps_cpp/src/rmw_count.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_count.cpp
@@ -51,8 +51,8 @@ rmw_count_publishers(
   WriterInfo * slave_target = impl->secondaryPubListener;
   slave_target->mapmutex.lock();
   *count = 0;
-  for (auto it : slave_target->topicNtypes) {
-    auto topic_fqdn = _demangle_if_ros_topic(it.first);
+  for (const auto & it : slave_target->topicNtypes) {
+    const auto topic_fqdn = _demangle_if_ros_topic(it.first);
     if (topic_fqdn == topic_name) {
       *count += it.second.size();
     }
@@ -90,8 +90,8 @@ rmw_count_subscribers(
   ReaderInfo * slave_target = impl->secondarySubListener;
   *count = 0;
   slave_target->mapmutex.lock();
-  for (auto it : slave_target->topicNtypes) {
-    auto topic_fqdn = _demangle_if_ros_topic(it.first);
+  for (const auto & it : slave_target->topicNtypes) {
+    const auto topic_fqdn = _demangle_if_ros_topic(it.first);
     if (topic_fqdn == topic_name) {
       *count += it.second.size();
     }


### PR DESCRIPTION
Address small performance issues to ROS2 impacting the `rmw_count_publishers` and `rmw_count_subscribers` method when called with a significante number of topics to count.
The root of the performance issues come from the duplication of `std::string` type of objects. These duplication are honerous with strings and cause a significante amount of CPU cycle to be wasted duplicating things.