### PR TITLE
Adding namespaces

### DIFF
--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport.hpp
@@ -115,9 +115,9 @@ public:
 
   bool deserializeROSmessage(eprosima::fastcdr::FastBuffer * data, void * ros_message);
 
-  bool serialize(void * data, SerializedPayload_t * payload);
+  bool serialize(void * data, eprosima::fastrtps::rtps::SerializedPayload_t * payload);
 
-  bool deserialize(SerializedPayload_t * payload, void * data);
+  bool deserialize(eprosima::fastrtps::rtps::SerializedPayload_t * payload, void * data);
 
   std::function<uint32_t()> getSerializedSizeProvider(void * data);
 

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport_impl.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport_impl.hpp
@@ -738,7 +738,7 @@ void * TypeSupport<MembersType>::createData()
 
 template<typename MembersType>
 bool TypeSupport<MembersType>::serialize(
-  void * data, SerializedPayload_t * payload)
+  void * data, eprosima::fastrtps::rtps::SerializedPayload_t * payload)
 {
   assert(data);
   assert(payload);
@@ -756,7 +756,7 @@ bool TypeSupport<MembersType>::serialize(
 }
 
 template<typename MembersType>
-bool TypeSupport<MembersType>::deserialize(SerializedPayload_t * payload, void * data)
+bool TypeSupport<MembersType>::deserialize(eprosima::fastrtps::rtps::SerializedPayload_t * payload, void * data)
 {
   assert(data);
   assert(payload);

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/custom_client_info.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/custom_client_info.hpp
@@ -67,7 +67,7 @@ public:
     eprosima::fastrtps::SampleInfo_t sinfo;
 
     if (sub->takeNextData(response.buffer_, &sinfo)) {
-      if (sinfo.sampleKind == ALIVE) {
+      if (sinfo.sampleKind == eprosima::fastrtps::rtps::ALIVE) {
         response.sample_identity_ = sinfo.related_sample_identity;
 
         if (info_->writer_guid_ == response.sample_identity_.writer_guid()) {

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/custom_participant_info.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/custom_participant_info.hpp
@@ -43,17 +43,17 @@ typedef struct CustomParticipantInfo
 class ParticipantListener : public eprosima::fastrtps::ParticipantListener
 {
 public:
-  void onParticipantDiscovery(Participant *, ParticipantDiscoveryInfo info) override
+  void onParticipantDiscovery(eprosima::fastrtps::Participant *, eprosima::fastrtps::ParticipantDiscoveryInfo info) override
   {
     if (
-      info.rtps.m_status != DISCOVERED_RTPSPARTICIPANT &&
-      info.rtps.m_status != REMOVED_RTPSPARTICIPANT &&
-      info.rtps.m_status != DROPPED_RTPSPARTICIPANT)
+      info.rtps.m_status != eprosima::fastrtps::rtps::DISCOVERED_RTPSPARTICIPANT &&
+      info.rtps.m_status != eprosima::fastrtps::rtps::REMOVED_RTPSPARTICIPANT &&
+      info.rtps.m_status != eprosima::fastrtps::rtps::DROPPED_RTPSPARTICIPANT)
     {
       return;
     }
 
-    if (DISCOVERED_RTPSPARTICIPANT == info.rtps.m_status) {
+    if (eprosima::fastrtps::rtps::DISCOVERED_RTPSPARTICIPANT == info.rtps.m_status) {
       // ignore already known GUIDs
       if (discovered_names.find(info.rtps.m_guid) == discovered_names.end()) {
         auto map = rmw::impl::cpp::parse_key_value(info.rtps.m_userData);
@@ -90,7 +90,7 @@ public:
     return names;
   }
 
-  std::map<GUID_t, std::string> discovered_names;
+  std::map<eprosima::fastrtps::rtps::GUID_t, std::string> discovered_names;
 };
 
 #endif  // RMW_FASTRTPS_CPP__CUSTOM_PARTICIPANT_INFO_HPP_

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/custom_service_info.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/custom_service_info.hpp
@@ -70,7 +70,7 @@ public:
     eprosima::fastrtps::SampleInfo_t sinfo;
 
     if (sub->takeNextData(request.buffer_, &sinfo)) {
-      if (sinfo.sampleKind == ALIVE) {
+      if (sinfo.sampleKind == eprosima::fastrtps::rtps::ALIVE) {
         request.sample_identity_ = sinfo.sample_identity;
 
         std::lock_guard<std::mutex> lock(internalMutex_);

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/custom_subscriber_info.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/custom_subscriber_info.hpp
@@ -46,7 +46,7 @@ public:
 
   void
   onSubscriptionMatched(
-    eprosima::fastrtps::Subscriber * sub, eprosima::fastrtps::MatchingInfo & info)
+    eprosima::fastrtps::Subscriber * sub, eprosima::fastrtps::rtps::MatchingInfo & info)
   {
     (void)sub;
     (void)info;

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/reader_info.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/reader_info.hpp
@@ -33,7 +33,7 @@
 #include "fastrtps/rtps/reader/ReaderListener.h"
 #include "fastrtps/rtps/reader/RTPSReader.h"
 
-class ReaderInfo : public eprosima::fastrtps::ReaderListener
+class ReaderInfo : public eprosima::fastrtps::rtps::ReaderListener
 {
 public:
   ReaderInfo(
@@ -46,14 +46,14 @@ public:
   void
   onNewCacheChangeAdded(
     eprosima::fastrtps::rtps::RTPSReader *,
-    const eprosima::fastrtps::CacheChange_t * const change)
+    const eprosima::fastrtps::rtps::CacheChange_t * const change)
   {
     eprosima::fastrtps::rtps::ReaderProxyData proxyData;
-    if (change->kind == ALIVE) {
-      CDRMessage_t tempMsg(0);
+    if (change->kind == eprosima::fastrtps::rtps::ALIVE) {
+      eprosima::fastrtps::rtps::CDRMessage_t tempMsg(0);
       tempMsg.wraps = true;
       tempMsg.msg_endian = change->serializedPayload.encapsulation ==
-        PL_CDR_BE ? BIGEND : LITTLEEND;
+        PL_CDR_BE ? eprosima::fastrtps::rtps::BIGEND : eprosima::fastrtps::rtps::LITTLEEND;
       tempMsg.length = change->serializedPayload.length;
       tempMsg.max_size = change->serializedPayload.max_size;
       tempMsg.buffer = change->serializedPayload.data;
@@ -77,7 +77,7 @@ public:
 
     bool trigger = false;
     mapmutex.lock();
-    if (change->kind == ALIVE) {
+    if (change->kind == eprosima::fastrtps::rtps::ALIVE) {
       topicNtypes[fqdn].push_back(proxyData.typeName());
       trigger = true;
     } else {

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/writer_info.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/writer_info.hpp
@@ -31,7 +31,7 @@
 
 #include "rmw/rmw.h"
 
-class WriterInfo : public eprosima::fastrtps::ReaderListener
+class WriterInfo : public eprosima::fastrtps::rtps::ReaderListener
 {
 public:
   WriterInfo(
@@ -44,14 +44,14 @@ public:
   void
   onNewCacheChangeAdded(
     eprosima::fastrtps::rtps::RTPSReader *,
-    const eprosima::fastrtps::CacheChange_t * const change)
+    const eprosima::fastrtps::rtps::CacheChange_t * const change)
   {
     eprosima::fastrtps::rtps::WriterProxyData proxyData;
-    if (change->kind == ALIVE) {
-      eprosima::fastrtps::CDRMessage_t tempMsg(0);
+    if (change->kind == eprosima::fastrtps::rtps::ALIVE) {
+      eprosima::fastrtps::rtps::CDRMessage_t tempMsg(0);
       tempMsg.wraps = true;
       tempMsg.msg_endian = change->serializedPayload.encapsulation ==
-        PL_CDR_BE ? BIGEND : LITTLEEND;
+        PL_CDR_BE ? eprosima::fastrtps::rtps::BIGEND : eprosima::fastrtps::rtps::LITTLEEND;
       tempMsg.length = change->serializedPayload.length;
       tempMsg.max_size = change->serializedPayload.max_size;
       tempMsg.buffer = change->serializedPayload.data;
@@ -75,7 +75,7 @@ public:
 
     bool trigger = false;
     mapmutex.lock();
-    if (change->kind == ALIVE) {
+    if (change->kind == eprosima::fastrtps::rtps::ALIVE) {
       topicNtypes[fqdn].push_back(proxyData.typeName());
       trigger = true;
     } else {

--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -66,7 +66,7 @@ rmw_create_client(
     return nullptr;
   }
 
-  Participant * participant = impl->participant;
+  eprosima::fastrtps::Participant * participant = impl->participant;
   if (!participant) {
     RMW_SET_ERROR_MSG("participant handle is null");
     return nullptr;
@@ -84,8 +84,8 @@ rmw_create_client(
   }
 
   CustomClientInfo * info = nullptr;
-  SubscriberAttributes subscriberParam;
-  PublisherAttributes publisherParam;
+  eprosima::fastrtps::SubscriberAttributes subscriberParam;
+  eprosima::fastrtps::PublisherAttributes publisherParam;
   rmw_client_t * rmw_client = nullptr;
 
   info = new CustomClientInfo();
@@ -105,25 +105,25 @@ rmw_create_client(
   std::string response_type_name = _create_type_name(untyped_response_members, "srv",
       info->typesupport_identifier_);
 
-  if (!Domain::getRegisteredType(participant, request_type_name.c_str(),
-    reinterpret_cast<TopicDataType **>(&info->request_type_support_)))
+  if (!eprosima::fastrtps::Domain::getRegisteredType(participant, request_type_name.c_str(),
+    reinterpret_cast<eprosima::fastrtps::TopicDataType **>(&info->request_type_support_)))
   {
     info->request_type_support_ = _create_request_type_support(type_support->data,
         info->typesupport_identifier_);
     _register_type(participant, info->request_type_support_, info->typesupport_identifier_);
   }
 
-  if (!Domain::getRegisteredType(participant, response_type_name.c_str(),
-    reinterpret_cast<TopicDataType **>(&info->response_type_support_)))
+  if (!eprosima::fastrtps::Domain::getRegisteredType(participant, response_type_name.c_str(),
+    reinterpret_cast<eprosima::fastrtps::TopicDataType **>(&info->response_type_support_)))
   {
     info->response_type_support_ = _create_response_type_support(type_support->data,
         info->typesupport_identifier_);
     _register_type(participant, info->response_type_support_, info->typesupport_identifier_);
   }
 
-  subscriberParam.topic.topicKind = NO_KEY;
+  subscriberParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
   subscriberParam.topic.topicDataType = response_type_name;
-  subscriberParam.historyMemoryPolicy = PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  subscriberParam.historyMemoryPolicy = eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
   rcutils_ret_t ret = _assign_partitions_to_attributes(
     service_name, ros_service_response_prefix,
     qos_policies->avoid_ros_namespace_conventions, &subscriberParam);
@@ -133,10 +133,10 @@ rmw_create_client(
   }
   subscriberParam.topic.topicName += "Reply";
 
-  publisherParam.topic.topicKind = NO_KEY;
+  publisherParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
   publisherParam.topic.topicDataType = request_type_name;
-  publisherParam.qos.m_publishMode.kind = ASYNCHRONOUS_PUBLISH_MODE;
-  publisherParam.historyMemoryPolicy = PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
+  publisherParam.historyMemoryPolicy = eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
   ret = _assign_partitions_to_attributes(
     service_name, ros_service_requester_prefix,
     qos_policies->avoid_ros_namespace_conventions, &publisherParam);
@@ -170,7 +170,7 @@ rmw_create_client(
   }
   info->listener_ = new ClientListener(info);
   info->response_subscriber_ =
-    Domain::createSubscriber(participant, subscriberParam, info->listener_);
+    eprosima::fastrtps::Domain::createSubscriber(participant, subscriberParam, info->listener_);
   if (!info->response_subscriber_) {
     RMW_SET_ERROR_MSG("create_client() could not create subscriber");
     goto fail;
@@ -182,7 +182,7 @@ rmw_create_client(
     goto fail;
   }
   info->request_publisher_ =
-    Domain::createPublisher(participant, publisherParam, nullptr);
+    eprosima::fastrtps::Domain::createPublisher(participant, publisherParam, nullptr);
   if (!info->request_publisher_) {
     RMW_SET_ERROR_MSG("create_publisher() could not create publisher");
     goto fail;
@@ -211,11 +211,11 @@ rmw_create_client(
 fail:
   if (info != nullptr) {
     if (info->request_publisher_ != nullptr) {
-      Domain::removePublisher(info->request_publisher_);
+        eprosima::fastrtps::Domain::removePublisher(info->request_publisher_);
     }
 
     if (info->response_subscriber_ != nullptr) {
-      Domain::removeSubscriber(info->response_subscriber_);
+        eprosima::fastrtps::Domain::removeSubscriber(info->response_subscriber_);
     }
 
     if (info->listener_ != nullptr) {
@@ -267,10 +267,10 @@ rmw_destroy_client(rmw_node_t * node, rmw_client_t * client)
   auto info = static_cast<CustomClientInfo *>(client->data);
   if (info != nullptr) {
     if (info->response_subscriber_ != nullptr) {
-      Domain::removeSubscriber(info->response_subscriber_);
+        eprosima::fastrtps::Domain::removeSubscriber(info->response_subscriber_);
     }
     if (info->request_publisher_ != nullptr) {
-      Domain::removePublisher(info->request_publisher_);
+        eprosima::fastrtps::Domain::removePublisher(info->request_publisher_);
     }
     if (info->listener_ != nullptr) {
       delete info->listener_;

--- a/rmw_fastrtps_cpp/src/rmw_node.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_node.cpp
@@ -52,7 +52,7 @@ rmw_node_t *
 create_node(
   const char * name,
   const char * namespace_,
-  ParticipantAttributes participantAttrs)
+  eprosima::fastrtps::ParticipantAttributes participantAttrs)
 {
   if (!name) {
     RMW_SET_ERROR_MSG("name is null");
@@ -66,13 +66,13 @@ create_node(
 
   // Declare everything before beginning to create things.
   ::ParticipantListener * listener = nullptr;
-  Participant * participant = nullptr;
+  eprosima::fastrtps::Participant * participant = nullptr;
   rmw_guard_condition_t * graph_guard_condition = nullptr;
   CustomParticipantInfo * node_impl = nullptr;
   rmw_node_t * node_handle = nullptr;
   ReaderInfo * tnat_1 = nullptr;
   WriterInfo * tnat_2 = nullptr;
-  std::pair<StatefulReader *, StatefulReader *> edp_readers;
+  std::pair<eprosima::fastrtps::rtps::StatefulReader *, eprosima::fastrtps::rtps::StatefulReader *> edp_readers;
 
   try {
     listener = new ::ParticipantListener();
@@ -81,7 +81,7 @@ create_node(
     goto fail;
   }
 
-  participant = Domain::createParticipant(participantAttrs, listener);
+  participant = eprosima::fastrtps::Domain::createParticipant(participantAttrs, listener);
   if (!participant) {
     RMW_SET_ERROR_MSG("create_node() could not create participant");
     return nullptr;
@@ -172,7 +172,7 @@ fail:
   }
   rmw_free(listener);
   if (participant) {
-    Domain::removeParticipant(participant);
+    eprosima::fastrtps::Domain::removeParticipant(participant);
   }
   return nullptr;
 }
@@ -222,10 +222,10 @@ rmw_create_node(
     return nullptr;
   }
 
-  ParticipantAttributes participantAttrs;
+  eprosima::fastrtps::ParticipantAttributes participantAttrs;
 
   // Load default XML profile.
-  Domain::getDefaultParticipantAttributes(participantAttrs);
+  eprosima::fastrtps::Domain::getDefaultParticipantAttributes(participantAttrs);
 
   participantAttrs.rtps.builtin.domainId = static_cast<uint32_t>(domain_id);
   // since the participant name is not part of the DDS spec
@@ -297,10 +297,10 @@ rmw_destroy_node(rmw_node_t * node)
     return RMW_RET_ERROR;
   }
 
-  Participant * participant = impl->participant;
+  eprosima::fastrtps::Participant * participant = impl->participant;
 
   // Begin deleting things in the same order they were created in rmw_create_node().
-  std::pair<StatefulReader *, StatefulReader *> edp_readers = participant->getEDPReaders();
+  std::pair<eprosima::fastrtps::rtps::StatefulReader *, eprosima::fastrtps::rtps::StatefulReader *> edp_readers = participant->getEDPReaders();
   if (!edp_readers.first || !edp_readers.second) {
     RMW_SET_ERROR_MSG("failed to get EDPReader listener");
     result_ret = RMW_RET_ERROR;
@@ -328,7 +328,7 @@ rmw_destroy_node(rmw_node_t * node)
     result_ret = RMW_RET_ERROR;
   }
 
-  Domain::removeParticipant(participant);
+  eprosima::fastrtps::Domain::removeParticipant(participant);
 
   delete impl->listener;
   impl->listener = nullptr;

--- a/rmw_fastrtps_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publisher.cpp
@@ -60,7 +60,7 @@ rmw_create_publisher(
     return nullptr;
   }
 
-  Participant * participant = impl->participant;
+  eprosima::fastrtps::Participant * participant = impl->participant;
   if (!participant) {
     RMW_SET_ERROR_MSG("participant handle is null");
     return nullptr;
@@ -79,11 +79,11 @@ rmw_create_publisher(
 
   CustomPublisherInfo * info = nullptr;
   rmw_publisher_t * rmw_publisher = nullptr;
-  PublisherAttributes publisherParam;
-  const GUID_t * guid = nullptr;
+  eprosima::fastrtps::PublisherAttributes publisherParam;
+  const eprosima::fastrtps::rtps::GUID_t * guid = nullptr;
 
   // Load default XML profile.
-  Domain::getDefaultPublisherAttributes(publisherParam);
+  eprosima::fastrtps::Domain::getDefaultPublisherAttributes(publisherParam);
 
   // TODO(karsten1987) Verify consequences for std::unique_ptr?
   info = new CustomPublisherInfo();
@@ -91,17 +91,17 @@ rmw_create_publisher(
 
   std::string type_name = _create_type_name(
     type_support->data, "msg", info->typesupport_identifier_);
-  if (!Domain::getRegisteredType(participant, type_name.c_str(),
-    reinterpret_cast<TopicDataType **>(&info->type_support_)))
+  if (!eprosima::fastrtps::Domain::getRegisteredType(participant, type_name.c_str(),
+    reinterpret_cast<eprosima::fastrtps::TopicDataType **>(&info->type_support_)))
   {
     info->type_support_ = _create_message_type_support(type_support->data,
         info->typesupport_identifier_);
     _register_type(participant, info->type_support_, info->typesupport_identifier_);
   }
 
-  publisherParam.qos.m_publishMode.kind = ASYNCHRONOUS_PUBLISH_MODE;
-  publisherParam.historyMemoryPolicy = PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
-  publisherParam.topic.topicKind = NO_KEY;
+  publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
+  publisherParam.historyMemoryPolicy = eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  publisherParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
   publisherParam.topic.topicDataType = type_name;
   rcutils_ret_t ret = _assign_partitions_to_attributes(
     topic_name, ros_topic_prefix, qos_policies->avoid_ros_namespace_conventions, &publisherParam);
@@ -139,7 +139,7 @@ rmw_create_publisher(
     goto fail;
   }
 
-  info->publisher_ = Domain::createPublisher(participant, publisherParam, nullptr);
+  info->publisher_ = eprosima::fastrtps::Domain::createPublisher(participant, publisherParam, nullptr);
 
   if (!info->publisher_) {
     RMW_SET_ERROR_MSG("create_publisher() could not create publisher");
@@ -216,7 +216,7 @@ rmw_destroy_publisher(rmw_node_t * node, rmw_publisher_t * publisher)
   auto info = static_cast<CustomPublisherInfo *>(publisher->data);
   if (info != nullptr) {
     if (info->publisher_ != nullptr) {
-      Domain::removePublisher(info->publisher_);
+        eprosima::fastrtps::Domain::removePublisher(info->publisher_);
     }
     if (info->type_support_ != nullptr) {
       auto impl = static_cast<CustomParticipantInfo *>(node->data);
@@ -225,7 +225,7 @@ rmw_destroy_publisher(rmw_node_t * node, rmw_publisher_t * publisher)
         return RMW_RET_ERROR;
       }
 
-      Participant * participant = impl->participant;
+      eprosima::fastrtps::Participant * participant = impl->participant;
       _unregister_type(participant, info->type_support_, info->typesupport_identifier_);
     }
     delete info;

--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -76,7 +76,7 @@ rmw_create_service(
     return nullptr;
   }
 
-  Participant * participant = impl->participant;
+  eprosima::fastrtps::Participant * participant = impl->participant;
   if (!participant) {
     RMW_SET_ERROR_MSG("participant handle is null");
     return nullptr;
@@ -94,8 +94,8 @@ rmw_create_service(
   }
 
   CustomServiceInfo * info = nullptr;
-  SubscriberAttributes subscriberParam;
-  PublisherAttributes publisherParam;
+  eprosima::fastrtps::SubscriberAttributes subscriberParam;
+  eprosima::fastrtps::PublisherAttributes publisherParam;
   rmw_service_t * rmw_service = nullptr;
 
   info = new CustomServiceInfo();
@@ -115,24 +115,24 @@ rmw_create_service(
   std::string response_type_name = _create_type_name(untyped_response_members, "srv",
       info->typesupport_identifier_);
 
-  if (!Domain::getRegisteredType(participant, request_type_name.c_str(),
-    reinterpret_cast<TopicDataType **>(&info->request_type_support_)))
+  if (!eprosima::fastrtps::Domain::getRegisteredType(participant, request_type_name.c_str(),
+    reinterpret_cast<eprosima::fastrtps::TopicDataType **>(&info->request_type_support_)))
   {
     info->request_type_support_ = _create_request_type_support(type_support->data,
         info->typesupport_identifier_);
     _register_type(participant, info->request_type_support_, info->typesupport_identifier_);
   }
 
-  if (!Domain::getRegisteredType(participant, response_type_name.c_str(),
-    reinterpret_cast<TopicDataType **>(&info->response_type_support_)))
+  if (!eprosima::fastrtps::Domain::getRegisteredType(participant, response_type_name.c_str(),
+    reinterpret_cast<eprosima::fastrtps::TopicDataType **>(&info->response_type_support_)))
   {
     info->response_type_support_ = _create_response_type_support(type_support->data,
         info->typesupport_identifier_);
     _register_type(participant, info->response_type_support_, info->typesupport_identifier_);
   }
 
-  subscriberParam.topic.topicKind = NO_KEY;
-  subscriberParam.historyMemoryPolicy = PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  subscriberParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
+  subscriberParam.historyMemoryPolicy = eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
   subscriberParam.topic.topicDataType = request_type_name;
   rcutils_ret_t ret = _assign_partitions_to_attributes(
     service_name, ros_service_requester_prefix,
@@ -143,10 +143,10 @@ rmw_create_service(
   }
   subscriberParam.topic.topicName += "Request";
 
-  publisherParam.topic.topicKind = NO_KEY;
+  publisherParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
   publisherParam.topic.topicDataType = response_type_name;
-  publisherParam.qos.m_publishMode.kind = ASYNCHRONOUS_PUBLISH_MODE;
-  publisherParam.historyMemoryPolicy = PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
+  publisherParam.historyMemoryPolicy = eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
   ret = _assign_partitions_to_attributes(
     service_name, ros_service_response_prefix,
     qos_policies->avoid_ros_namespace_conventions, &publisherParam);
@@ -180,7 +180,7 @@ rmw_create_service(
   }
   info->listener_ = new ServiceListener(info);
   info->request_subscriber_ =
-    Domain::createSubscriber(participant, subscriberParam, info->listener_);
+    eprosima::fastrtps::Domain::createSubscriber(participant, subscriberParam, info->listener_);
   if (!info->request_subscriber_) {
     RMW_SET_ERROR_MSG("create_client() could not create subscriber");
     goto fail;
@@ -192,7 +192,7 @@ rmw_create_service(
     goto fail;
   }
   info->response_publisher_ =
-    Domain::createPublisher(participant, publisherParam, nullptr);
+    eprosima::fastrtps::Domain::createPublisher(participant, publisherParam, nullptr);
   if (!info->response_publisher_) {
     RMW_SET_ERROR_MSG("create_publisher() could not create publisher");
     goto fail;
@@ -219,11 +219,11 @@ fail:
 
   if (info) {
     if (info->response_publisher_) {
-      Domain::removePublisher(info->response_publisher_);
+        eprosima::fastrtps::Domain::removePublisher(info->response_publisher_);
     }
 
     if (info->request_subscriber_) {
-      Domain::removeSubscriber(info->request_subscriber_);
+        eprosima::fastrtps::Domain::removeSubscriber(info->request_subscriber_);
     }
 
     if (info->listener_) {
@@ -266,10 +266,10 @@ rmw_destroy_service(rmw_node_t * node, rmw_service_t * service)
   CustomServiceInfo * info = static_cast<CustomServiceInfo *>(service->data);
   if (info != nullptr) {
     if (info->request_subscriber_ != nullptr) {
-      Domain::removeSubscriber(info->request_subscriber_);
+        eprosima::fastrtps::Domain::removeSubscriber(info->request_subscriber_);
     }
     if (info->response_publisher_ != nullptr) {
-      Domain::removePublisher(info->response_publisher_);
+        eprosima::fastrtps::Domain::removePublisher(info->response_publisher_);
     }
     if (info->listener_ != nullptr) {
       delete info->listener_;

--- a/rmw_fastrtps_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_subscription.cpp
@@ -64,7 +64,7 @@ rmw_create_subscription(
     return nullptr;
   }
 
-  Participant * participant = impl->participant;
+  eprosima::fastrtps::Participant * participant = impl->participant;
   if (!participant) {
     RMW_SET_ERROR_MSG("participant handle is null");
     return nullptr;
@@ -84,26 +84,26 @@ rmw_create_subscription(
   (void)ignore_local_publications;
   CustomSubscriberInfo * info = nullptr;
   rmw_subscription_t * rmw_subscription = nullptr;
-  SubscriberAttributes subscriberParam;
+  eprosima::fastrtps::SubscriberAttributes subscriberParam;
 
   // Load default XML profile.
-  Domain::getDefaultSubscriberAttributes(subscriberParam);
+  eprosima::fastrtps::Domain::getDefaultSubscriberAttributes(subscriberParam);
 
   info = new CustomSubscriberInfo();
   info->typesupport_identifier_ = type_support->typesupport_identifier;
 
   std::string type_name = _create_type_name(
     type_support->data, "msg", info->typesupport_identifier_);
-  if (!Domain::getRegisteredType(participant, type_name.c_str(),
-    reinterpret_cast<TopicDataType **>(&info->type_support_)))
+  if (!eprosima::fastrtps::Domain::getRegisteredType(participant, type_name.c_str(),
+    reinterpret_cast<eprosima::fastrtps::TopicDataType **>(&info->type_support_)))
   {
     info->type_support_ = _create_message_type_support(type_support->data,
         info->typesupport_identifier_);
     _register_type(participant, info->type_support_, info->typesupport_identifier_);
   }
 
-  subscriberParam.historyMemoryPolicy = PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
-  subscriberParam.topic.topicKind = NO_KEY;
+  subscriberParam.historyMemoryPolicy = eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  subscriberParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
   subscriberParam.topic.topicDataType = type_name;
   rcutils_ret_t ret = _assign_partitions_to_attributes(
     topic_name, ros_topic_prefix, qos_policies->avoid_ros_namespace_conventions, &subscriberParam);
@@ -134,7 +134,7 @@ rmw_create_subscription(
   }
 
   info->listener_ = new SubListener(info);
-  info->subscriber_ = Domain::createSubscriber(participant, subscriberParam, info->listener_);
+  info->subscriber_ = eprosima::fastrtps::Domain::createSubscriber(participant, subscriberParam, info->listener_);
 
   if (!info->subscriber_) {
     RMW_SET_ERROR_MSG("create_subscriber() could not create subscriber");
@@ -202,7 +202,7 @@ rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription)
 
   if (info != nullptr) {
     if (info->subscriber_ != nullptr) {
-      Domain::removeSubscriber(info->subscriber_);
+        eprosima::fastrtps::Domain::removeSubscriber(info->subscriber_);
     }
     if (info->listener_ != nullptr) {
       delete info->listener_;
@@ -214,7 +214,7 @@ rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription)
         return RMW_RET_ERROR;
       }
 
-      Participant * participant = impl->participant;
+      eprosima::fastrtps::Participant * participant = impl->participant;
       _unregister_type(participant, info->type_support_, info->typesupport_identifier_);
     }
     delete info;

--- a/rmw_fastrtps_cpp/src/rmw_take.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_take.cpp
@@ -50,7 +50,7 @@ rmw_take(const rmw_subscription_t * subscription, void * ros_message, bool * tak
   if (info->subscriber_->takeNextData(&buffer, &sinfo)) {
     info->listener_->data_taken();
 
-    if (sinfo.sampleKind == ALIVE) {
+    if (sinfo.sampleKind == eprosima::fastrtps::rtps::ALIVE) {
       _deserialize_ros_message(&buffer, ros_message, info->type_support_,
         info->typesupport_identifier_);
       *taken = true;
@@ -92,7 +92,7 @@ rmw_take_with_info(
   if (info->subscriber_->takeNextData(&buffer, &sinfo)) {
     info->listener_->data_taken();
 
-    if (sinfo.sampleKind == ALIVE) {
+    if (sinfo.sampleKind == eprosima::fastrtps::rtps::ALIVE) {
       _deserialize_ros_message(&buffer, ros_message, info->type_support_,
         info->typesupport_identifier_);
       rmw_gid_t * sender_gid = &message_info->publisher_gid;


### PR DESCRIPTION
We removed in Fast-RTPS a `using eprosima::fastrtps` and a `using eprosima::fastrtps::rtps` located in a header file. Some users have had problem with this. This PR resolves compilation errors before upload our commit to Github.