### PR TITLE
Fix leak if client reponse is never taken

### DIFF
--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/custom_client_info.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/custom_client_info.hpp
@@ -63,7 +63,7 @@ public:
 
     CustomClientResponse response;
     // Todo(sloretz) eliminate heap allocation pending eprosima/Fast-CDR#19
-    response.buffer_.reset(new eprosima::fastcdr::FastBuffer);
+    response.buffer_.reset(new eprosima::fastcdr::FastBuffer());
     eprosima::fastrtps::SampleInfo_t sinfo;
 
     if (sub->takeNextData(response.buffer_.get(), &sinfo)) {

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/custom_client_info.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/custom_client_info.hpp
@@ -17,6 +17,8 @@
 
 #include <atomic>
 #include <list>
+#include <memory>
+#include <utility>
 
 #include "fastcdr/FastBuffer.h"
 
@@ -43,7 +45,7 @@ typedef struct CustomClientInfo
 typedef struct CustomClientResponse
 {
   eprosima::fastrtps::rtps::SampleIdentity sample_identity_;
-  eprosima::fastcdr::FastBuffer * buffer_;
+  std::unique_ptr<eprosima::fastcdr::FastBuffer> buffer_;
 
   CustomClientResponse()
   : buffer_(nullptr) {}
@@ -63,10 +65,10 @@ public:
     assert(sub);
 
     CustomClientResponse response;
-    response.buffer_ = new eprosima::fastcdr::FastBuffer();
+    response.buffer_.reset(new eprosima::fastcdr::FastBuffer());
     eprosima::fastrtps::SampleInfo_t sinfo;
 
-    if (sub->takeNextData(response.buffer_, &sinfo)) {
+    if (sub->takeNextData(response.buffer_.get(), &sinfo)) {
       if (eprosima::fastrtps::rtps::ALIVE == sinfo.sampleKind) {
         response.sample_identity_ = sinfo.related_sample_identity;
 
@@ -75,7 +77,7 @@ public:
 
           if (conditionMutex_ != nullptr) {
             std::unique_lock<std::mutex> clock(*conditionMutex_);
-            list.push_back(response);
+            list.emplace_back(std::move(response));
             // the change to list_has_data_ needs to be mutually exclusive with
             // rmw_wait() which checks hasData() and decides if wait() needs to
             // be called
@@ -83,7 +85,7 @@ public:
             clock.unlock();
             conditionVariable_->notify_one();
           } else {
-            list.push_back(response);
+            list.emplace_back(std::move(response));
             list_has_data_.store(true);
           }
         }
@@ -100,19 +102,19 @@ public:
     if (conditionMutex_ != nullptr) {
       std::unique_lock<std::mutex> clock(*conditionMutex_);
       if (!list.empty()) {
-        response = list.front();
+        response = std::move(list.front());
         list.pop_front();
         list_has_data_.store(!list.empty());
       }
     } else {
       if (!list.empty()) {
-        response = list.front();
+        response = std::move(list.front());
         list.pop_front();
         list_has_data_.store(!list.empty());
       }
     }
 
-    return response;
+    return std::move(response);
   }
 
   void

--- a/rmw_fastrtps_cpp/src/rmw_response.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_response.cpp
@@ -50,9 +50,9 @@ rmw_take_response(
   auto info = static_cast<CustomClientInfo *>(client->data);
   assert(info);
 
-  CustomClientResponse response = info->listener_->getResponse();
+  CustomClientResponse response;
 
-  if (response.buffer_ != nullptr) {
+  if (info->listener_->getResponse(response)) {
     _deserialize_ros_message(response.buffer_.get(), ros_response, info->response_type_support_,
       info->typesupport_identifier_);
 

--- a/rmw_fastrtps_cpp/src/rmw_response.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_response.cpp
@@ -53,13 +53,11 @@ rmw_take_response(
   CustomClientResponse response = info->listener_->getResponse();
 
   if (response.buffer_ != nullptr) {
-    _deserialize_ros_message(response.buffer_, ros_response, info->response_type_support_,
+    _deserialize_ros_message(response.buffer_.get(), ros_response, info->response_type_support_,
       info->typesupport_identifier_);
 
     request_header->sequence_number = ((int64_t)response.sample_identity_.sequence_number().high) <<
       32 | response.sample_identity_.sequence_number().low;
-
-    delete response.buffer_;
 
     *taken = true;
   }


### PR DESCRIPTION
This fixes a leak exposed by the `rclcpp` test `test_time_source`. A buffer is created on the heap, but it is only freed if someone takes the response. This PR uses an `std::unique_ptr` instead of a raw pointer to let RAII free the buffer if an error occurs or the listener is destroyed without taking a response.

CI
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4413)](http://ci.ros2.org/job/ci_linux/4413/)
    * False positive cmake warning ros2/build_cop#79
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1361)](http://ci.ros2.org/job/ci_linux-aarch64/1361/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3606)](http://ci.ros2.org/job/ci_osx/3606/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4469)](http://ci.ros2.org/job/ci_windows/4469/)