### PR TITLE
Nullify pointer to ClientListener in CustomClientInfo in destructor

### DIFF
--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/custom_client_info.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/custom_client_info.hpp
@@ -55,6 +55,12 @@ public:
   : info_(info), list_has_data_(false),
     conditionMutex_(nullptr), conditionVariable_(nullptr) {}
 
+  ~ClientListener()
+  {
+    // TODO(sloretz) must acquire lock before editing info_
+    // Remove reference to self to avoid crash in rmw_wait()
+    info_->listener_ = nullptr;
+  }
 
   void
   onNewDataMessage(eprosima::fastrtps::Subscriber * sub)

--- a/rmw_fastrtps_cpp/src/rmw_wait.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_wait.cpp
@@ -46,7 +46,11 @@ check_wait_set_for_data(
     for (size_t i = 0; i < clients->client_count; ++i) {
       void * data = clients->clients[i];
       CustomClientInfo * custom_client_info = static_cast<CustomClientInfo *>(data);
-      if (custom_client_info && custom_client_info->listener_->hasData()) {
+      if (
+        custom_client_info &&
+        custom_client_info->listener_ &&
+        custom_client_info->listener_->hasData())
+      {
         return true;
       }
     }
@@ -117,7 +121,9 @@ rmw_wait(
     for (size_t i = 0; i < clients->client_count; ++i) {
       void * data = clients->clients[i];
       CustomClientInfo * custom_client_info = static_cast<CustomClientInfo *>(data);
-      custom_client_info->listener_->attachCondition(conditionMutex, conditionVariable);
+      if (custom_client_info->listener_) {
+        custom_client_info->listener_->attachCondition(conditionMutex, conditionVariable);
+      }
     }
   }
 
@@ -184,9 +190,11 @@ rmw_wait(
     for (size_t i = 0; i < clients->client_count; ++i) {
       void * data = clients->clients[i];
       CustomClientInfo * custom_client_info = static_cast<CustomClientInfo *>(data);
-      custom_client_info->listener_->detachCondition();
-      if (!custom_client_info->listener_->hasData()) {
-        clients->clients[i] = 0;
+      if (custom_client_info->listener_) {
+        custom_client_info->listener_->detachCondition();
+        if (!custom_client_info->listener_->hasData()) {
+          clients->clients[i] = 0;
+        }
       }
     }
   }


### PR DESCRIPTION
This mitigates (does not fix) a race condition when one thread calls `rmw_wait()` and another calls `rmw_destroy_client()`. When `rmw_wait()` wakes up it calls `CustomClientInfo->listener_`, but both the instance of `CustomClientInfo` and the object pointed to by `listener_` have been destroyed. This nulls the field `listener_` and has `rmw_wait()` check this field before using it to reduce the likelyhood of a crash.

I observed this race condition while debugging a CI test failure in ros2/rclcpp#488. The symptom seen is a SIGABRT on OSX when trying to lock `ClientListener.internalMutex_`.

I'm not sure what a real fix would look like. `rmw_wait()` needs a way to tell the client it is holding onto has been destroyed. The other entities appear to be using the same pattern, so I suspect they suffer from similar race conditions too. (ticket to follow)