### PR TITLE
Temporary buffer remove

### DIFF
--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/MessageTypeSupport_impl.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/MessageTypeSupport_impl.hpp
@@ -43,7 +43,7 @@ MessageTypeSupport<MembersType>::MessageTypeSupport(const MembersType * members)
   if (members->member_count_ != 0) {
     this->m_typeSize = static_cast<uint32_t>(this->calculateMaxSerializedSize(members, 0));
   } else {
-    this->m_typeSize = 4;
+    this->m_typeSize = 5;
   }
 }
 

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/MessageTypeSupport_impl.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/MessageTypeSupport_impl.hpp
@@ -38,12 +38,14 @@ MessageTypeSupport<MembersType>::MessageTypeSupport(const MembersType * members)
     members->message_name_ + "_";
   this->setName(name.c_str());
 
-  // TODO(wjwwood): this could be more intelligent, setting m_typeSize to the
-  // maximum serialized size of the message, when the message is a bounded one.
-  if (members->member_count_ != 0) {
-    this->m_typeSize = static_cast<uint32_t>(this->calculateMaxSerializedSize(members, 0));
+  // Fully bound by default
+  this->max_size_bound_ = true;
+  // Encapsulation size
+  this->m_typeSize = 4;
+  if (this->members_->member_count_ != 0) {
+    this->m_typeSize += static_cast<uint32_t>(this->calculateMaxSerializedSize(members, 4));
   } else {
-    this->m_typeSize = 5;
+    this->m_typeSize++;
   }
 }
 

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/ServiceTypeSupport_impl.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/ServiceTypeSupport_impl.hpp
@@ -47,7 +47,7 @@ RequestTypeSupport<ServiceMembersType, MessageMembersType>::RequestTypeSupport(
   if (this->members_->member_count_ != 0) {
     this->m_typeSize = static_cast<uint32_t>(this->calculateMaxSerializedSize(this->members_, 0));
   } else {
-    this->m_typeSize = 4;
+    this->m_typeSize = 5;
   }
 }
 
@@ -67,7 +67,7 @@ ResponseTypeSupport<ServiceMembersType, MessageMembersType>::ResponseTypeSupport
   if (this->members_->member_count_ != 0) {
     this->m_typeSize = static_cast<uint32_t>(this->calculateMaxSerializedSize(this->members_, 0));
   } else {
-    this->m_typeSize = 4;
+    this->m_typeSize = 5;
   }
 }
 

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/ServiceTypeSupport_impl.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/ServiceTypeSupport_impl.hpp
@@ -42,12 +42,14 @@ RequestTypeSupport<ServiceMembersType, MessageMembersType>::RequestTypeSupport(
     members->service_name_ + "_Request_";
   this->setName(name.c_str());
 
-  // TODO(wjwwood): this could be more intelligent, setting m_typeSize to the
-  // maximum serialized size of the message, when the message is a bounded one.
+  // Fully bound by default
+  this->max_size_bound_ = true;
+  // Encapsulation size
+  this->m_typeSize = 4;
   if (this->members_->member_count_ != 0) {
-    this->m_typeSize = static_cast<uint32_t>(this->calculateMaxSerializedSize(this->members_, 0));
+    this->m_typeSize += static_cast<uint32_t>(this->calculateMaxSerializedSize(this->members_, 4));
   } else {
-    this->m_typeSize = 5;
+    this->m_typeSize++;
   }
 }
 
@@ -62,12 +64,14 @@ ResponseTypeSupport<ServiceMembersType, MessageMembersType>::ResponseTypeSupport
     members->service_name_ + "_Response_";
   this->setName(name.c_str());
 
-  // TODO(wjwwood): this could be more intelligent, setting m_typeSize to the
-  // maximum serialized size of the message, when the message is a bounded one.
+  // Fully bound by default
+  this->max_size_bound_ = true;
+  // Encapsulation size
+  this->m_typeSize = 4;
   if (this->members_->member_count_ != 0) {
-    this->m_typeSize = static_cast<uint32_t>(this->calculateMaxSerializedSize(this->members_, 0));
+    this->m_typeSize += static_cast<uint32_t>(this->calculateMaxSerializedSize(this->members_, 4));
   } else {
-    this->m_typeSize = 5;
+    this->m_typeSize++;
   }
 }
 

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport.hpp
@@ -54,6 +54,27 @@ struct StringHelper<rosidl_typesupport_introspection_c__MessageMembers>
 {
   using type = rosidl_generator_c__String;
 
+  static size_t next_field_align(void * data, size_t current_alignment)
+  {
+    auto c_string = static_cast<rosidl_generator_c__String *>(data);
+    if (!c_string) {
+      RCUTILS_LOG_ERROR_NAMED(
+        "rmw_fastrtps_cpp",
+        "Failed to cast data as rosidl_generator_c__String")
+      return current_alignment;
+    }
+    if (!c_string->data) {
+      RCUTILS_LOG_ERROR_NAMED(
+        "rmw_fastrtps_cpp",
+        "rosidl_generator_c_String had invalid data")
+      return current_alignment;
+    }
+
+    current_alignment += eprosima::fastcdr::Cdr::alignment(current_alignment, 4);
+    current_alignment += 4;
+    return current_alignment + strlen(c_string->data) + 1;
+  }
+
   static std::string convert_to_std_string(void * data)
   {
     auto c_string = static_cast<rosidl_generator_c__String *>(data);
@@ -111,6 +132,8 @@ template<typename MembersType>
 class TypeSupport : public eprosima::fastrtps::TopicDataType
 {
 public:
+  size_t getEstimatedSerializedSize(const void * ros_message);
+
   bool serializeROSmessage(const void * ros_message, eprosima::fastcdr::Cdr & ser);
 
   bool deserializeROSmessage(eprosima::fastcdr::Cdr & deser, void * ros_message);
@@ -133,6 +156,9 @@ protected:
   const MembersType * members_;
 
 private:
+  size_t getEstimatedSerializedSize(
+    const MembersType * members, const void * ros_message, size_t current_alignment);
+
   bool serializeROSmessage(
     eprosima::fastcdr::Cdr & ser, const MembersType * members, const void * ros_message);
 

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport.hpp
@@ -154,6 +154,7 @@ protected:
   size_t calculateMaxSerializedSize(const MembersType * members, size_t current_alignment);
 
   const MembersType * members_;
+  bool max_size_bound_;
 
 private:
   size_t getEstimatedSerializedSize(

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport_impl.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport_impl.hpp
@@ -400,6 +400,212 @@ bool TypeSupport<MembersType>::serializeROSmessage(
   return true;
 }
 
+// C++ specialization
+template<typename T>
+size_t next_field_align(
+  const rosidl_typesupport_introspection_cpp::MessageMember * member,
+  void * field,
+  size_t current_alignment)
+{
+  const size_t padding = 4;
+  size_t item_size = sizeof(T);
+  if (!member->is_array_) {
+    current_alignment += eprosima::fastcdr::Cdr::alignment(current_alignment, item_size);
+    current_alignment += item_size;
+  } else if (member->array_size_ && !member->is_upper_bound_) {
+    current_alignment += eprosima::fastcdr::Cdr::alignment(current_alignment, item_size);
+    current_alignment += item_size * member->array_size_;
+  } else {
+    std::vector<T> & data = *reinterpret_cast<std::vector<T> *>(field);
+    current_alignment += eprosima::fastcdr::Cdr::alignment(current_alignment, padding);
+    current_alignment += padding;
+    current_alignment += eprosima::fastcdr::Cdr::alignment(current_alignment, item_size);
+    current_alignment += item_size * data.size();
+  }
+  return current_alignment;
+}
+
+template<>
+inline
+size_t next_field_align<std::string>(
+  const rosidl_typesupport_introspection_cpp::MessageMember * member,
+  void * field,
+  size_t current_alignment)
+{
+  const size_t padding = 4;
+  if (!member->is_array_) {
+    current_alignment += eprosima::fastcdr::Cdr::alignment(current_alignment, padding);
+    current_alignment += padding;
+    auto str = *static_cast<std::string *>(field);
+    current_alignment += str.size() + 1;
+  } else if (member->array_size_ && !member->is_upper_bound_) {
+    auto str_arr = static_cast<std::string *>(field);
+    for (size_t index = 0; index < member->array_size_; ++index) {
+      current_alignment += eprosima::fastcdr::Cdr::alignment(current_alignment, padding);
+      current_alignment += padding;
+      current_alignment += str_arr[index].size() + 1;
+    }
+  } else {
+    auto & data = *reinterpret_cast<std::vector<std::string> *>(field);
+    current_alignment += eprosima::fastcdr::Cdr::alignment(current_alignment, padding);
+    current_alignment += padding;
+    for (auto & it : data) {
+      current_alignment += eprosima::fastcdr::Cdr::alignment(current_alignment, padding);
+      current_alignment += padding;
+      current_alignment += it.size() + 1;
+    }
+  }
+  return current_alignment;
+}
+
+// C specialization
+template<typename T>
+size_t next_field_align(
+  const rosidl_typesupport_introspection_c__MessageMember * member,
+  void * field,
+  size_t current_alignment)
+{
+  const size_t padding = 4;
+  size_t item_size = sizeof(T);
+  if (!member->is_array_) {
+    current_alignment += eprosima::fastcdr::Cdr::alignment(current_alignment, item_size);
+    current_alignment += item_size;
+  } else if (member->array_size_ && !member->is_upper_bound_) {
+    current_alignment += eprosima::fastcdr::Cdr::alignment(current_alignment, item_size);
+    current_alignment += item_size * member->array_size_;
+  } else {
+    current_alignment += eprosima::fastcdr::Cdr::alignment(current_alignment, padding);
+    current_alignment += padding;
+
+    auto & data = *reinterpret_cast<typename GenericCArray<T>::type *>(field);
+    current_alignment += eprosima::fastcdr::Cdr::alignment(current_alignment, item_size);
+    current_alignment += item_size * data.size;
+  }
+  return current_alignment;
+}
+
+template<>
+inline
+size_t next_field_align<std::string>(
+  const rosidl_typesupport_introspection_c__MessageMember * member,
+  void * field,
+  size_t current_alignment)
+{
+  const size_t padding = 4;
+  using CStringHelper = StringHelper<rosidl_typesupport_introspection_c__MessageMembers>;
+  if (!member->is_array_) {
+    current_alignment = CStringHelper::next_field_align(field, current_alignment);
+  } else {
+    if (member->array_size_ && !member->is_upper_bound_) {
+      auto string_field = static_cast<rosidl_generator_c__String *>(field);
+      for (size_t i = 0; i < member->array_size_; ++i) {
+        current_alignment += eprosima::fastcdr::Cdr::alignment(current_alignment, padding);
+        current_alignment += padding;
+        current_alignment += strlen(string_field[i].data) + 1;
+      }
+    } else {
+      current_alignment += eprosima::fastcdr::Cdr::alignment(current_alignment, padding);
+      current_alignment += padding;
+      auto & string_array_field = *reinterpret_cast<rosidl_generator_c__String__Array *>(field);
+      for (size_t i = 0; i < string_array_field.size; ++i) {
+        current_alignment = CStringHelper::next_field_align(
+          &(string_array_field.data[i]), current_alignment);
+      }
+    }
+  }
+  return current_alignment;
+}
+
+template<typename MembersType>
+size_t TypeSupport<MembersType>::getEstimatedSerializedSize(
+  const MembersType * members, const void * ros_message, size_t current_alignment)
+{
+  assert(members);
+  assert(ros_message);
+
+  size_t initial_alignment = current_alignment;
+
+  for (uint32_t i = 0; i < members->member_count_; ++i) {
+    const auto member = members->members_ + i;
+    void * field = const_cast<char *>(static_cast<const char *>(ros_message)) + member->offset_;
+    switch (member->type_id_) {
+      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_BOOL:
+        current_alignment = next_field_align<bool>(member, field, current_alignment);
+        break;
+      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_BYTE:
+      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT8:
+        current_alignment = next_field_align<uint8_t>(member, field, current_alignment);
+        break;
+      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_CHAR:
+      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT8:
+        current_alignment = next_field_align<char>(member, field, current_alignment);
+        break;
+      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_FLOAT32:
+        current_alignment = next_field_align<float>(member, field, current_alignment);
+        break;
+      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_FLOAT64:
+        current_alignment = next_field_align<double>(member, field, current_alignment);
+        break;
+      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT16:
+        current_alignment = next_field_align<int16_t>(member, field, current_alignment);
+        break;
+      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT16:
+        current_alignment = next_field_align<uint16_t>(member, field, current_alignment);
+        break;
+      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT32:
+        current_alignment = next_field_align<int32_t>(member, field, current_alignment);
+        break;
+      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT32:
+        current_alignment = next_field_align<uint32_t>(member, field, current_alignment);
+        break;
+      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT64:
+        current_alignment = next_field_align<int64_t>(member, field, current_alignment);
+        break;
+      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT64:
+        current_alignment = next_field_align<uint64_t>(member, field, current_alignment);
+        break;
+      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_STRING:
+        current_alignment = next_field_align<std::string>(member, field, current_alignment);
+        break;
+      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_MESSAGE:
+        {
+          auto sub_members = static_cast<const MembersType *>(member->members_->data);
+          if (!member->is_array_) {
+            current_alignment += getEstimatedSerializedSize(sub_members, field, current_alignment);
+          } else {
+            void * subros_message = nullptr;
+            size_t array_size = 0;
+            size_t sub_members_size = sub_members->size_of_;
+            size_t max_align = calculateMaxAlign(sub_members);
+
+            if (member->array_size_ && !member->is_upper_bound_) {
+              subros_message = field;
+              array_size = member->array_size_;
+            } else {
+              array_size = get_array_size_and_assign_field(
+                member, field, subros_message, sub_members_size, max_align);
+
+              // Length serialization
+              current_alignment += 4 + eprosima::fastcdr::Cdr::alignment(current_alignment, 4);
+            }
+
+            for (size_t index = 0; index < array_size; ++index) {
+              current_alignment += getEstimatedSerializedSize(
+                sub_members, subros_message, current_alignment);
+              subros_message = static_cast<char *>(subros_message) + sub_members_size;
+              subros_message = align_(max_align, subros_message);
+            }
+          }
+        }
+        break;
+      default:
+        throw std::runtime_error("unknown type");
+    }
+  }
+
+  return current_alignment - initial_alignment;
+}
+
 template<typename T>
 void deserialize_field(
   const rosidl_typesupport_introspection_cpp::MessageMember * member,
@@ -712,6 +918,24 @@ size_t TypeSupport<MembersType>::calculateMaxSerializedSize(
   }
 
   return current_alignment - initial_alignment;
+}
+
+template<typename MembersType>
+size_t TypeSupport<MembersType>::getEstimatedSerializedSize(
+  const void * ros_message)
+{
+  assert(ros_message);
+
+  // Encapsulation size
+  size_t ret_val = 4;
+
+  if (members_->member_count_ != 0) {
+    ret_val += TypeSupport::getEstimatedSerializedSize(members_, ros_message, ret_val);
+  } else {
+    ret_val += 1;
+  }
+
+  return ret_val;
 }
 
 template<typename MembersType>

--- a/rmw_fastrtps_cpp/src/rmw_publish.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publish.cpp
@@ -49,7 +49,7 @@ rmw_publish(const rmw_publisher_t * publisher, const void * ros_message)
   eprosima::fastcdr::Cdr ser(buffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
     eprosima::fastcdr::Cdr::DDS_CDR);
 
-  if (!_serialize_ros_message(ros_message, ser, info->type_support_,
+  if (!_serialize_ros_message(ros_message, buffer, ser, info->type_support_,
     info->typesupport_identifier_))
   {
     RMW_SET_ERROR_MSG("cannot serialize data");

--- a/rmw_fastrtps_cpp/src/rmw_request.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_request.cpp
@@ -54,7 +54,7 @@ rmw_send_request(
   eprosima::fastcdr::Cdr ser(buffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
     eprosima::fastcdr::Cdr::DDS_CDR);
 
-  if (_serialize_ros_message(ros_request, ser, info->request_type_support_,
+  if (_serialize_ros_message(ros_request, buffer, ser, info->request_type_support_,
     info->typesupport_identifier_))
   {
     eprosima::fastrtps::rtps::WriteParams wparams;

--- a/rmw_fastrtps_cpp/src/rmw_response.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_response.cpp
@@ -93,7 +93,7 @@ rmw_send_response(
   eprosima::fastcdr::Cdr ser(buffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
     eprosima::fastcdr::Cdr::DDS_CDR);
 
-  _serialize_ros_message(ros_response, ser, info->response_type_support_,
+  _serialize_ros_message(ros_response, buffer, ser, info->response_type_support_,
     info->typesupport_identifier_);
   eprosima::fastrtps::rtps::WriteParams wparams;
   memcpy(&wparams.related_sample_identity().writer_guid(), request_header->writer_guid,

--- a/rmw_fastrtps_cpp/src/rmw_serialize.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_serialize.cpp
@@ -45,7 +45,7 @@ rmw_serialize(
   eprosima::fastcdr::Cdr ser(
     buffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN, eprosima::fastcdr::Cdr::DDS_CDR);
 
-  auto ret = _serialize_ros_message(ros_message, ser, tss, ts->typesupport_identifier);
+  auto ret = _serialize_ros_message(ros_message, buffer, ser, tss, ts->typesupport_identifier);
   auto data_length = static_cast<size_t>(ser.getSerializedDataLength());
   if (serialized_message->buffer_capacity < data_length) {
     if (rmw_serialized_message_resize(serialized_message, data_length) != RMW_RET_OK) {

--- a/rmw_fastrtps_cpp/src/ros_message_serialization.cpp
+++ b/rmw_fastrtps_cpp/src/ros_message_serialization.cpp
@@ -20,15 +20,20 @@
 bool
 _serialize_ros_message(
   const void * ros_message,
+  eprosima::fastcdr::FastBuffer & buffer,
   eprosima::fastcdr::Cdr & ser,
   void * untyped_typesupport,
   const char * typesupport_identifier)
 {
   if (using_introspection_c_typesupport(typesupport_identifier)) {
     auto typed_typesupport = static_cast<MessageTypeSupport_c *>(untyped_typesupport);
+    size_t estimated_size = typed_typesupport->getEstimatedSerializedSize(ros_message);
+    buffer.reserve(estimated_size);
     return typed_typesupport->serializeROSmessage(ros_message, ser);
   } else if (using_introspection_cpp_typesupport(typesupport_identifier)) {
     auto typed_typesupport = static_cast<MessageTypeSupport_cpp *>(untyped_typesupport);
+    size_t estimated_size = typed_typesupport->getEstimatedSerializedSize(ros_message);
+    buffer.reserve(estimated_size);
     return typed_typesupport->serializeROSmessage(ros_message, ser);
   }
   RMW_SET_ERROR_MSG("Unknown typesupport identifier");

--- a/rmw_fastrtps_cpp/src/ros_message_serialization.hpp
+++ b/rmw_fastrtps_cpp/src/ros_message_serialization.hpp
@@ -27,6 +27,7 @@ class FastBuffer;
 bool
 _serialize_ros_message(
   const void * ros_message,
+  eprosima::fastcdr::FastBuffer & buffer,
   eprosima::fastcdr::Cdr & ser,
   void * untyped_typesupport,
   const char * typesupport_identifier);


### PR DESCRIPTION
This PR includes the necessary changes to remove the temporary buffer used on (de)serialization of messages, but keeping only the introspection typesupport.

I am still performing tests locally, but I have started the PR so others can perform their own tests, and check how it compares to #203 