### PR TITLE
Validate the buffer_ of CustomServiceRequest object before using it to

### DIFF
--- a/rmw_fastrtps_cpp/src/rmw_request.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_request.cpp
@@ -96,10 +96,10 @@ rmw_take_request(
   assert(info);
 
   CustomServiceRequest request = info->listener_->getRequest();
-  eprosima::fastcdr::Cdr deser(*request.buffer_, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
-    eprosima::fastcdr::Cdr::DDS_CDR);
 
   if (request.buffer_ != nullptr) {
+    eprosima::fastcdr::Cdr deser(*request.buffer_, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+      eprosima::fastcdr::Cdr::DDS_CDR);
     _deserialize_ros_message(deser, ros_request, info->request_type_support_,
       info->typesupport_identifier_);
 


### PR DESCRIPTION
instantiate class Cdr

Before we are going to instantiate the fastcdr::Cdr class by using the member
variable buffer_ of class CustomServiceRequest, we must ensure that the buffer_
can not be nullptr.

This patch implements the validation.

Fix #209