### PR TITLE
Avoid allocations

### DIFF
--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/MessageTypeSupport_impl.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/MessageTypeSupport_impl.hpp
@@ -43,7 +43,7 @@ MessageTypeSupport<MembersType>::MessageTypeSupport(const MembersType * members)
   // Encapsulation size
   this->m_typeSize = 4;
   if (this->members_->member_count_ != 0) {
-    this->m_typeSize += static_cast<uint32_t>(this->calculateMaxSerializedSize(members, 4));
+    this->m_typeSize += static_cast<uint32_t>(this->calculateMaxSerializedSize(members, 0));
   } else {
     this->m_typeSize++;
   }

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/ServiceTypeSupport_impl.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/ServiceTypeSupport_impl.hpp
@@ -47,7 +47,7 @@ RequestTypeSupport<ServiceMembersType, MessageMembersType>::RequestTypeSupport(
   // Encapsulation size
   this->m_typeSize = 4;
   if (this->members_->member_count_ != 0) {
-    this->m_typeSize += static_cast<uint32_t>(this->calculateMaxSerializedSize(this->members_, 4));
+    this->m_typeSize += static_cast<uint32_t>(this->calculateMaxSerializedSize(this->members_, 0));
   } else {
     this->m_typeSize++;
   }
@@ -69,7 +69,7 @@ ResponseTypeSupport<ServiceMembersType, MessageMembersType>::ResponseTypeSupport
   // Encapsulation size
   this->m_typeSize = 4;
   if (this->members_->member_count_ != 0) {
-    this->m_typeSize += static_cast<uint32_t>(this->calculateMaxSerializedSize(this->members_, 4));
+    this->m_typeSize += static_cast<uint32_t>(this->calculateMaxSerializedSize(this->members_, 0));
   } else {
     this->m_typeSize++;
   }

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport.hpp
@@ -42,6 +42,13 @@
 namespace rmw_fastrtps_cpp
 {
 
+// Publishers write method will receive a pointer to this struct
+struct SerializedData
+{
+  bool is_cdr_buffer;  // Whether next field is a pointer to a Cdr or to a plain ros message
+  void * data;
+};
+
 // Helper class that uses template specialization to read/write string types to/from a
 // eprosima::fastcdr::Cdr
 template<typename MembersType>

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport_impl.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport_impl.hpp
@@ -420,8 +420,11 @@ size_t next_field_align(
     std::vector<T> & data = *reinterpret_cast<std::vector<T> *>(field);
     current_alignment += eprosima::fastcdr::Cdr::alignment(current_alignment, padding);
     current_alignment += padding;
-    current_alignment += eprosima::fastcdr::Cdr::alignment(current_alignment, item_size);
-    current_alignment += item_size * data.size();
+    auto num_elems = data.size();
+    if (num_elems > 0) {
+      current_alignment += eprosima::fastcdr::Cdr::alignment(current_alignment, item_size);
+      current_alignment += item_size * data.size();
+    }
   }
   return current_alignment;
 }
@@ -437,7 +440,7 @@ size_t next_field_align<std::string>(
   if (!member->is_array_) {
     current_alignment += eprosima::fastcdr::Cdr::alignment(current_alignment, padding);
     current_alignment += padding;
-    auto str = *static_cast<std::string *>(field);
+    auto & str = *static_cast<std::string *>(field);
     current_alignment += str.size() + 1;
   } else if (member->array_size_ && !member->is_upper_bound_) {
     auto str_arr = static_cast<std::string *>(field);
@@ -935,7 +938,7 @@ size_t TypeSupport<MembersType>::getEstimatedSerializedSize(
   size_t ret_val = 4;
 
   if (members_->member_count_ != 0) {
-    ret_val += TypeSupport::getEstimatedSerializedSize(members_, ros_message, ret_val);
+    ret_val += TypeSupport::getEstimatedSerializedSize(members_, ros_message, 0);
   } else {
     ret_val += 1;
   }

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport_impl.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport_impl.hpp
@@ -997,13 +997,28 @@ bool TypeSupport<MembersType>::serialize(
   assert(data);
   assert(payload);
 
-  auto ser = static_cast<eprosima::fastcdr::Cdr *>(data);
-  if (payload->max_size >= ser->getSerializedDataLength()) {
-    payload->length = static_cast<uint32_t>(ser->getSerializedDataLength());
-    payload->encapsulation = ser->endianness() ==
-      eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
-    memcpy(payload->data, ser->getBufferPointer(), ser->getSerializedDataLength());
-    return true;
+  auto ser_data = static_cast<SerializedData *>(data);
+  if (ser_data->is_cdr_buffer) {
+    auto ser = static_cast<eprosima::fastcdr::Cdr *>(ser_data->data);
+    if (payload->max_size >= ser->getSerializedDataLength()) {
+      payload->length = static_cast<uint32_t>(ser->getSerializedDataLength());
+      payload->encapsulation = ser->endianness() ==
+        eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+      memcpy(payload->data, ser->getBufferPointer(), ser->getSerializedDataLength());
+      return true;
+    }
+  } else {
+    eprosima::fastcdr::FastBuffer fastbuffer(
+      reinterpret_cast<char *>(payload->data),
+      payload->max_size);  // Object that manages the raw buffer.
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+      eprosima::fastcdr::Cdr::DDS_CDR);  // Object that serializes the data.
+    if (this->serializeROSmessage(ser_data->data, ser)) {
+      payload->encapsulation = ser.endianness() ==
+        eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+      payload->length = (uint32_t)ser.getSerializedDataLength();
+      return true;
+    }
   }
 
   return false;
@@ -1030,8 +1045,16 @@ std::function<uint32_t()> TypeSupport<MembersType>::getSerializedSizeProvider(vo
 {
   assert(data);
 
-  auto ser = static_cast<eprosima::fastcdr::Cdr *>(data);
-  return [ser]() -> uint32_t {return static_cast<uint32_t>(ser->getSerializedDataLength());};
+  auto ser_data = static_cast<SerializedData *>(data);
+  auto ser_size = [this, ser_data]() -> uint32_t
+    {
+      if (ser_data->is_cdr_buffer) {
+        auto ser = static_cast<eprosima::fastcdr::Cdr *>(ser_data->data);
+        return static_cast<uint32_t>(ser->getSerializedDataLength());
+      }
+      return static_cast<uint32_t>(this->getEstimatedSerializedSize(ser_data->data));
+    };
+  return ser_size;
 }
 
 }  // namespace rmw_fastrtps_cpp

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/custom_client_info.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/custom_client_info.hpp
@@ -27,6 +27,7 @@
 #include "fastrtps/subscriber/SubscriberListener.h"
 #include "fastrtps/participant/Participant.h"
 #include "fastrtps/publisher/Publisher.h"
+#include "rmw_fastrtps_cpp/TypeSupport.hpp"
 
 class ClientListener;
 
@@ -66,7 +67,10 @@ public:
     response.buffer_.reset(new eprosima::fastcdr::FastBuffer());
     eprosima::fastrtps::SampleInfo_t sinfo;
 
-    if (sub->takeNextData(response.buffer_.get(), &sinfo)) {
+    rmw_fastrtps_cpp::SerializedData data;
+    data.is_cdr_buffer = true;
+    data.data = response.buffer_.get();
+    if (sub->takeNextData(&data, &sinfo)) {
       if (eprosima::fastrtps::rtps::ALIVE == sinfo.sampleKind) {
         response.sample_identity_ = sinfo.related_sample_identity;
 

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/custom_service_info.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/custom_service_info.hpp
@@ -26,6 +26,7 @@
 #include "fastrtps/subscriber/Subscriber.h"
 #include "fastrtps/subscriber/SubscriberListener.h"
 #include "fastrtps/subscriber/SampleInfo.h"
+#include "rmw_fastrtps_cpp/TypeSupport.hpp"
 
 class ServiceListener;
 
@@ -69,7 +70,10 @@ public:
     request.buffer_ = new eprosima::fastcdr::FastBuffer();
     eprosima::fastrtps::SampleInfo_t sinfo;
 
-    if (sub->takeNextData(request.buffer_, &sinfo)) {
+    rmw_fastrtps_cpp::SerializedData data;
+    data.is_cdr_buffer = true;
+    data.data = request.buffer_;
+    if (sub->takeNextData(&data, &sinfo)) {
       if (eprosima::fastrtps::rtps::ALIVE == sinfo.sampleKind) {
         request.sample_identity_ = sinfo.sample_identity;
 

--- a/rmw_fastrtps_cpp/src/rmw_serialize.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_serialize.cpp
@@ -41,19 +41,19 @@ rmw_serialize(
   }
 
   auto tss = _create_message_type_support(ts->data, ts->typesupport_identifier);
-  eprosima::fastcdr::FastBuffer buffer;
-  eprosima::fastcdr::Cdr ser(
-    buffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN, eprosima::fastcdr::Cdr::DDS_CDR);
-
-  auto ret = _serialize_ros_message(ros_message, buffer, ser, tss, ts->typesupport_identifier);
-  auto data_length = static_cast<size_t>(ser.getSerializedDataLength());
+  auto data_length = _get_serialized_size(ros_message, tss, ts->typesupport_identifier);
   if (serialized_message->buffer_capacity < data_length) {
     if (rmw_serialized_message_resize(serialized_message, data_length) != RMW_RET_OK) {
       RMW_SET_ERROR_MSG("unable to dynamically resize serialized message");
       return RMW_RET_ERROR;
     }
   }
-  memcpy(serialized_message->buffer, ser.getBufferPointer(), data_length);
+
+  eprosima::fastcdr::FastBuffer buffer(serialized_message->buffer, data_length);
+  eprosima::fastcdr::Cdr ser(
+    buffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN, eprosima::fastcdr::Cdr::DDS_CDR);
+
+  auto ret = _serialize_ros_message(ros_message, buffer, ser, tss, ts->typesupport_identifier);
   serialized_message->buffer_length = data_length;
   serialized_message->buffer_capacity = data_length;
   _delete_typesupport(tss, ts->typesupport_identifier);

--- a/rmw_fastrtps_cpp/src/ros_message_serialization.cpp
+++ b/rmw_fastrtps_cpp/src/ros_message_serialization.cpp
@@ -17,6 +17,23 @@
 
 #include "./type_support_common.hpp"
 
+size_t
+_get_serialized_size(
+  const void * ros_message,
+  void * untyped_typesupport,
+  const char * typesupport_identifier)
+{
+  if (using_introspection_c_typesupport(typesupport_identifier)) {
+    auto typed_typesupport = static_cast<MessageTypeSupport_c *>(untyped_typesupport);
+    return typed_typesupport->getEstimatedSerializedSize(ros_message);
+  } else if (using_introspection_cpp_typesupport(typesupport_identifier)) {
+    auto typed_typesupport = static_cast<MessageTypeSupport_cpp *>(untyped_typesupport);
+    return typed_typesupport->getEstimatedSerializedSize(ros_message);
+  }
+  RMW_SET_ERROR_MSG("Unknown typesupport identifier");
+  return 0;
+}
+
 bool
 _serialize_ros_message(
   const void * ros_message,

--- a/rmw_fastrtps_cpp/src/ros_message_serialization.hpp
+++ b/rmw_fastrtps_cpp/src/ros_message_serialization.hpp
@@ -24,6 +24,12 @@ class FastBuffer;
 }  // namespace fastcdr
 }  // namespace eprosima
 
+size_t
+_get_serialized_size(
+  const void * ros_message,
+  void * untyped_typesupport,
+  const char * typesupport_identifier);
+
 bool
 _serialize_ros_message(
   const void * ros_message,


### PR DESCRIPTION
This is an improvement over #207 that removes allocations on more cases, including rmw_serialize.

I am rebasing #203 on top of this one, so if this one gets merged the other will be easier to review and merge.

It is passing the tests locally, so I hope it can make it into bouncy