### PR TITLE
allow builtin reader/writer to reallocate memory if needed

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
@@ -245,6 +245,12 @@ __rmw_create_node(
   participantAttrs.rtps.builtin.domainId = static_cast<uint32_t>(domain_id);
   // since the participant name is not part of the DDS spec
   participantAttrs.rtps.setName(name);
+
+  // allow reallocation to support discovery messages bigger than 5000 bytes
+  participantAttrs.rtps.builtin.readerHistoryMemoryPolicy =
+    eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  participantAttrs.rtps.builtin.writerHistoryMemoryPolicy =
+    eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
   // the node name is also set in the user_data
   size_t name_length = strlen(name);
   const char prefix[6] = "name=";


### PR DESCRIPTION
This makes use of the [newly exposed](https://github.com/eProsima/Fast-RTPS/issues/213#issuecomment-407300333) memory strategy for builtins.
This should avoid issues like
```
[RTPS_HISTORY Error] Change payload size of 'XXXX' bytes is larger than the history payload size of '5000' bytes and cannot be resized. -> Function add_change
```

I'm currently unable to reproduce the original issue but I think that we still want to integrate this change to avoid corner cases where we get large discovery messages.
I didnt revert https://github.com/ros2/rmw_connext/pull/288 as it seems that we don't want to send TypeCode regardless of this change.


* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4980)](http://ci.ros2.org/job/ci_linux/4980/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1793)](http://ci.ros2.org/job/ci_linux-aarch64/1793/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4135)](http://ci.ros2.org/job/ci_osx/4135/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4992)](http://ci.ros2.org/job/ci_windows/4992/)