### PR TITLE
Add semicolons to all RCLCPP and RCUTILS macros.

### DIFF
--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -145,14 +145,14 @@ rmw_create_client(
 
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_fastrtps_cpp",
-    "************ Client Details *********")
+    "************ Client Details *********");
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_fastrtps_cpp",
-    "Sub Topic %s", subscriberParam.topic.topicName.c_str())
+    "Sub Topic %s", subscriberParam.topic.topicName.c_str());
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_fastrtps_cpp",
-    "Pub Topic %s", publisherParam.topic.topicName.c_str())
-  RCUTILS_LOG_DEBUG_NAMED("rmw_fastrtps_cpp", "***********")
+    "Pub Topic %s", publisherParam.topic.topicName.c_str());
+  RCUTILS_LOG_DEBUG_NAMED("rmw_fastrtps_cpp", "***********");
 
   // Create Client Subscriber and set QoS
   if (!get_datareader_qos(*qos_policies, subscriberParam)) {
@@ -224,7 +224,7 @@ fail:
     } else {
       RCUTILS_LOG_ERROR_NAMED(
         "rmw_fastrtps_cpp",
-        "leaking type support objects because node impl is null")
+        "leaking type support objects because node impl is null");
     }
 
     delete info;

--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -157,14 +157,14 @@ rmw_create_service(
 
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_fastrtps_cpp",
-    "************ Service Details *********")
+    "************ Service Details *********");
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_fastrtps_cpp",
-    "Sub Topic %s", subscriberParam.topic.topicName.c_str())
+    "Sub Topic %s", subscriberParam.topic.topicName.c_str());
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_fastrtps_cpp",
-    "Pub Topic %s", publisherParam.topic.topicName.c_str())
-  RCUTILS_LOG_DEBUG_NAMED("rmw_fastrtps_cpp", "***********")
+    "Pub Topic %s", publisherParam.topic.topicName.c_str());
+  RCUTILS_LOG_DEBUG_NAMED("rmw_fastrtps_cpp", "***********");
 
   // Create Service Subscriber and set QoS
   if (!get_datareader_qos(*qos_policies, subscriberParam)) {

--- a/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport.hpp
+++ b/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport.hpp
@@ -62,13 +62,13 @@ struct StringHelper<rosidl_typesupport_introspection_c__MessageMembers>
     if (!c_string) {
       RCUTILS_LOG_ERROR_NAMED(
         "rmw_fastrtps_dynamic_cpp",
-        "Failed to cast data as rosidl_generator_c__String")
+        "Failed to cast data as rosidl_generator_c__String");
       return current_alignment;
     }
     if (!c_string->data) {
       RCUTILS_LOG_ERROR_NAMED(
         "rmw_fastrtps_dynamic_cpp",
-        "rosidl_generator_c_String had invalid data")
+        "rosidl_generator_c_String had invalid data");
       return current_alignment;
     }
 
@@ -83,13 +83,13 @@ struct StringHelper<rosidl_typesupport_introspection_c__MessageMembers>
     if (!c_string) {
       RCUTILS_LOG_ERROR_NAMED(
         "rmw_fastrtps_dynamic_cpp",
-        "Failed to cast data as rosidl_generator_c__String")
+        "Failed to cast data as rosidl_generator_c__String");
       return "";
     }
     if (!c_string->data) {
       RCUTILS_LOG_ERROR_NAMED(
         "rmw_fastrtps_dynamic_cpp",
-        "rosidl_generator_c_String had invalid data")
+        "rosidl_generator_c_String had invalid data");
       return "";
     }
     return std::string(c_string->data);

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
@@ -150,14 +150,14 @@ rmw_create_client(
 
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_fastrtps_dynamic_cpp",
-    "************ Client Details *********")
+    "************ Client Details *********");
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_fastrtps_dynamic_cpp",
-    "Sub Topic %s", subscriberParam.topic.topicName.c_str())
+    "Sub Topic %s", subscriberParam.topic.topicName.c_str());
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_fastrtps_dynamic_cpp",
-    "Pub Topic %s", publisherParam.topic.topicName.c_str())
-  RCUTILS_LOG_DEBUG_NAMED("rmw_fastrtps_dynamic_cpp", "***********")
+    "Pub Topic %s", publisherParam.topic.topicName.c_str());
+  RCUTILS_LOG_DEBUG_NAMED("rmw_fastrtps_dynamic_cpp", "***********");
 
   // Create Client Subscriber and set QoS
   if (!get_datareader_qos(*qos_policies, subscriberParam)) {
@@ -229,7 +229,7 @@ fail:
     } else {
       RCUTILS_LOG_ERROR_NAMED(
         "rmw_fastrtps_dynamic_cpp",
-        "leaking type support objects because node impl is null")
+        "leaking type support objects because node impl is null");
     }
 
     delete info;

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
@@ -162,14 +162,14 @@ rmw_create_service(
 
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_fastrtps_dynamic_cpp",
-    "************ Service Details *********")
+    "************ Service Details *********");
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_fastrtps_dynamic_cpp",
-    "Sub Topic %s", subscriberParam.topic.topicName.c_str())
+    "Sub Topic %s", subscriberParam.topic.topicName.c_str());
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_fastrtps_dynamic_cpp",
-    "Pub Topic %s", publisherParam.topic.topicName.c_str())
-  RCUTILS_LOG_DEBUG_NAMED("rmw_fastrtps_dynamic_cpp", "***********")
+    "Pub Topic %s", publisherParam.topic.topicName.c_str());
+  RCUTILS_LOG_DEBUG_NAMED("rmw_fastrtps_dynamic_cpp", "***********");
 
   // Create Service Subscriber and set QoS
   if (!get_datareader_qos(*qos_policies, subscriberParam)) {

--- a/rmw_fastrtps_shared_cpp/src/demangle.cpp
+++ b/rmw_fastrtps_shared_cpp/src/demangle.cpp
@@ -82,7 +82,7 @@ _demangle_service_from_topic(const std::string & topic_name)
       if (topic_name.length() - suffix_position - suffix.length() != 0) {
         RCUTILS_LOG_WARN_NAMED("rmw_fastrtps_shared_cpp",
           "service topic has service prefix and a suffix, but not at the end"
-          ", report this: '%s'", topic_name.c_str())
+          ", report this: '%s'", topic_name.c_str());
         continue;
       }
       found_suffix = suffix;
@@ -92,7 +92,7 @@ _demangle_service_from_topic(const std::string & topic_name)
   if (std::string::npos == suffix_position) {
     RCUTILS_LOG_WARN_NAMED("rmw_fastrtps_shared_cpp",
       "service topic has prefix but no suffix"
-      ", report this: '%s'", topic_name.c_str())
+      ", report this: '%s'", topic_name.c_str());
     return "";
   }
   // strip off the suffix first
@@ -124,7 +124,7 @@ _demangle_service_type_only(const std::string & dds_type_name)
       if (dds_type_name.length() - suffix_position - suffix.length() != 0) {
         RCUTILS_LOG_WARN_NAMED("rmw_fastrtps_shared_cpp",
           "service type contains '::srv::dds_::' and a suffix, but not at the end"
-          ", report this: '%s'", dds_type_name.c_str())
+          ", report this: '%s'", dds_type_name.c_str());
         continue;
       }
       found_suffix = suffix;
@@ -134,7 +134,7 @@ _demangle_service_type_only(const std::string & dds_type_name)
   if (std::string::npos == suffix_position) {
     RCUTILS_LOG_WARN_NAMED("rmw_fastrtps_shared_cpp",
       "service type contains '::srv::dds_::' but does not have a suffix"
-      ", report this: '%s'", dds_type_name.c_str())
+      ", report this: '%s'", dds_type_name.c_str());
     return "";
   }
   // everything checks out, reformat it from '<pkg>::srv::dds_::<type><suffix>' to '<pkg>/<type>'

--- a/rmw_fastrtps_shared_cpp/src/rmw_count.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_count.cpp
@@ -79,7 +79,7 @@ __rmw_count_publishers(
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_fastrtps_shared_cpp",
     "looking for subscriber topic: %s, number of matches: %zu",
-    topic_name, *count)
+    topic_name, *count);
 
   return RMW_RET_OK;
 }
@@ -132,7 +132,7 @@ __rmw_count_subscribers(
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_fastrtps_shared_cpp",
     "looking for subscriber topic: %s, number of matches: %zu",
-    topic_name, *count)
+    topic_name, *count);
 
   return RMW_RET_OK;
 }

--- a/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
@@ -176,7 +176,7 @@ fail:
     if (ret != RMW_RET_OK) {
       RCUTILS_LOG_ERROR_NAMED(
         "rmw_fastrtps_shared_cpp",
-        "failed to destroy guard condition during error handling")
+        "failed to destroy guard condition during error handling");
     }
   }
   rmw_free(listener);

--- a/rmw_fastrtps_shared_cpp/src/rmw_node_names.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_node_names.cpp
@@ -97,7 +97,7 @@ fail:
     if (rcutils_ret != RCUTILS_RET_OK) {
       RCUTILS_LOG_ERROR_NAMED(
         "rmw_connext_cpp",
-        "failed to cleanup during error handling: %s", rcutils_get_error_string_safe())
+        "failed to cleanup during error handling: %s", rcutils_get_error_string_safe());
       rcutils_reset_error();
     }
   }
@@ -106,7 +106,7 @@ fail:
     if (rcutils_ret != RCUTILS_RET_OK) {
       RCUTILS_LOG_ERROR_NAMED(
         "rmw_connext_cpp",
-        "failed to cleanup during error handling: %s", rcutils_get_error_string_safe())
+        "failed to cleanup during error handling: %s", rcutils_get_error_string_safe());
       rcutils_reset_error();
     }
   }

--- a/rmw_fastrtps_shared_cpp/src/rmw_service_names_and_types.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_service_names_and_types.cpp
@@ -116,7 +116,7 @@ __rmw_get_service_names_and_types(
         if (rmw_ret != RMW_RET_OK) {
           RCUTILS_LOG_ERROR_NAMED(
             "rmw_fastrtps_shared_cpp",
-            "error during report of error: %s", rmw_get_error_string_safe())
+            "error during report of error: %s", rmw_get_error_string_safe());
         }
       };
     // For each service, store the name, initialize the string array for types, and store all types

--- a/rmw_fastrtps_shared_cpp/src/rmw_topic_names_and_types.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_topic_names_and_types.cpp
@@ -116,7 +116,7 @@ __rmw_get_topic_names_and_types(
         if (rmw_ret != RMW_RET_OK) {
           RCUTILS_LOG_ERROR_NAMED(
             "rmw_fastrtps_shared_cpp",
-            "error during report of error: %s", rmw_get_error_string_safe())
+            "error during report of error: %s", rmw_get_error_string_safe());
         }
       };
     // Setup demangling functions based on no_demangle option


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Connects to https://github.com/ros2/rcutils/issues/113