### PR TITLE
RMW configuration from XML only

### DIFF
--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -120,7 +120,7 @@ rmw_create_client(
     _register_type(participant, info->response_type_support_);
   }
 
-  if (!qos_policies->config_only_from_xml)
+  if (!impl->leave_middleware_default_qos)
   {
     subscriberParam.historyMemoryPolicy =
       eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
@@ -135,7 +135,7 @@ rmw_create_client(
   }
   subscriberParam.topic.topicName += "Reply";
 
-  if (!qos_policies->config_only_from_xml)
+  if (!impl->leave_middleware_default_qos)
   {
     publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
     publisherParam.historyMemoryPolicy =

--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -120,10 +120,14 @@ rmw_create_client(
     _register_type(participant, info->response_type_support_);
   }
 
+  if (!qos_policies->config_only_from_xml)
+  {
+    subscriberParam.historyMemoryPolicy =
+      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  }
+
   subscriberParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
   subscriberParam.topic.topicDataType = response_type_name;
-  subscriberParam.historyMemoryPolicy =
-    eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
   if (!qos_policies->avoid_ros_namespace_conventions) {
     subscriberParam.topic.topicName = std::string(ros_service_response_prefix) + service_name;
   } else {
@@ -131,11 +135,15 @@ rmw_create_client(
   }
   subscriberParam.topic.topicName += "Reply";
 
+  if (!qos_policies->config_only_from_xml)
+  {
+    publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
+    publisherParam.historyMemoryPolicy =
+      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  }
+
   publisherParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
   publisherParam.topic.topicDataType = request_type_name;
-  publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
-  publisherParam.historyMemoryPolicy =
-    eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
   if (!qos_policies->avoid_ros_namespace_conventions) {
     publisherParam.topic.topicName = std::string(ros_service_requester_prefix) + service_name;
   } else {

--- a/rmw_fastrtps_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publisher.cpp
@@ -113,9 +113,13 @@ rmw_create_publisher(
     _register_type(participant, info->type_support_);
   }
 
-  publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
-  publisherParam.historyMemoryPolicy =
-    eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  if (!qos_policies->config_only_from_xml)
+  {
+    publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
+    publisherParam.historyMemoryPolicy =
+      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  }
+
   publisherParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
   publisherParam.topic.topicDataType = type_name;
   if (!qos_policies->avoid_ros_namespace_conventions) {

--- a/rmw_fastrtps_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publisher.cpp
@@ -113,7 +113,7 @@ rmw_create_publisher(
     _register_type(participant, info->type_support_);
   }
 
-  if (!qos_policies->config_only_from_xml)
+  if (!impl->leave_middleware_default_qos)
   {
     publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
     publisherParam.historyMemoryPolicy =

--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -132,7 +132,7 @@ rmw_create_service(
     _register_type(participant, info->response_type_support_);
   }
 
-  if (!qos_policies->config_only_from_xml)
+  if (!impl->leave_middleware_default_qos)
   {
     subscriberParam.historyMemoryPolicy =
       eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
@@ -147,7 +147,7 @@ rmw_create_service(
   }
   subscriberParam.topic.topicName += "Request";
 
-  if (!qos_policies->config_only_from_xml)
+  if (!impl->leave_middleware_default_qos)
   {
     publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
     publisherParam.historyMemoryPolicy =

--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -132,9 +132,13 @@ rmw_create_service(
     _register_type(participant, info->response_type_support_);
   }
 
+  if (!qos_policies->config_only_from_xml)
+  {
+    subscriberParam.historyMemoryPolicy =
+      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  }
+
   subscriberParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
-  subscriberParam.historyMemoryPolicy =
-    eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
   subscriberParam.topic.topicDataType = request_type_name;
   if (!qos_policies->avoid_ros_namespace_conventions) {
     subscriberParam.topic.topicName = std::string(ros_service_requester_prefix) + service_name;
@@ -143,11 +147,15 @@ rmw_create_service(
   }
   subscriberParam.topic.topicName += "Request";
 
+  if (!qos_policies->config_only_from_xml)
+  {
+    publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
+    publisherParam.historyMemoryPolicy =
+      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  }
+
   publisherParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
   publisherParam.topic.topicDataType = response_type_name;
-  publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
-  publisherParam.historyMemoryPolicy =
-    eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
   if (!qos_policies->avoid_ros_namespace_conventions) {
     publisherParam.topic.topicName = std::string(ros_service_response_prefix) + service_name;
   } else {

--- a/rmw_fastrtps_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_subscription.cpp
@@ -116,7 +116,7 @@ rmw_create_subscription(
     _register_type(participant, info->type_support_);
   }
 
-  if (!qos_policies->config_only_from_xml)
+  if (!impl->leave_middleware_default_qos)
   {
     subscriberParam.historyMemoryPolicy =
       eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;

--- a/rmw_fastrtps_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_subscription.cpp
@@ -116,8 +116,12 @@ rmw_create_subscription(
     _register_type(participant, info->type_support_);
   }
 
-  subscriberParam.historyMemoryPolicy =
-    eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  if (!qos_policies->config_only_from_xml)
+  {
+    subscriberParam.historyMemoryPolicy =
+      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  }
+
   subscriberParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
   subscriberParam.topic.topicDataType = type_name;
   if (!qos_policies->avoid_ros_namespace_conventions) {

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
@@ -125,10 +125,14 @@ rmw_create_client(
     _register_type(participant, info->response_type_support_);
   }
 
+  if (!impl->leave_middleware_default_qos)
+  {
+    subscriberParam.historyMemoryPolicy =
+      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;    
+  }
+
   subscriberParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
   subscriberParam.topic.topicDataType = response_type_name;
-  subscriberParam.historyMemoryPolicy =
-    eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
   if (!qos_policies->avoid_ros_namespace_conventions) {
     subscriberParam.topic.topicName = std::string(ros_service_response_prefix) + service_name;
   } else {
@@ -138,9 +142,14 @@ rmw_create_client(
 
   publisherParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
   publisherParam.topic.topicDataType = request_type_name;
-  publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
-  publisherParam.historyMemoryPolicy =
-    eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+
+  if (!impl->leave_middleware_default_qos)
+  {
+    publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
+    publisherParam.historyMemoryPolicy =
+      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  }
+  
   if (!qos_policies->avoid_ros_namespace_conventions) {
     publisherParam.topic.topicName = std::string(ros_service_requester_prefix) + service_name;
   } else {

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_publisher.cpp
@@ -108,9 +108,13 @@ rmw_create_publisher(
     _register_type(participant, info->type_support_);
   }
 
-  publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
-  publisherParam.historyMemoryPolicy =
-    eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  if (!impl->leave_middleware_default_qos)
+  {
+    publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
+    publisherParam.historyMemoryPolicy =
+      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  }
+  
   publisherParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
   publisherParam.topic.topicDataType = type_name;
   if (!qos_policies->avoid_ros_namespace_conventions) {

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
@@ -137,9 +137,13 @@ rmw_create_service(
     _register_type(participant, info->response_type_support_);
   }
 
+  if (!impl->leave_middleware_default_qos)
+  {
+    subscriberParam.historyMemoryPolicy =
+      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  }
+
   subscriberParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
-  subscriberParam.historyMemoryPolicy =
-    eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
   subscriberParam.topic.topicDataType = request_type_name;
   if (!qos_policies->avoid_ros_namespace_conventions) {
     subscriberParam.topic.topicName = std::string(ros_service_requester_prefix) + service_name;
@@ -148,11 +152,15 @@ rmw_create_service(
   }
   subscriberParam.topic.topicName += "Request";
 
+  if (!impl->leave_middleware_default_qos)
+  {
+    publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
+    publisherParam.historyMemoryPolicy =
+      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  }
+  
   publisherParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
   publisherParam.topic.topicDataType = response_type_name;
-  publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
-  publisherParam.historyMemoryPolicy =
-    eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
   if (!qos_policies->avoid_ros_namespace_conventions) {
     publisherParam.topic.topicName = std::string(ros_service_response_prefix) + service_name;
   } else {

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_subscription.cpp
@@ -112,8 +112,12 @@ rmw_create_subscription(
     _register_type(participant, info->type_support_);
   }
 
-  subscriberParam.historyMemoryPolicy =
-    eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  if (!impl->leave_middleware_default_qos)
+  {
+    subscriberParam.historyMemoryPolicy =
+      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  }
+  
   subscriberParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
   subscriberParam.topic.topicDataType = type_name;
   if (!qos_policies->avoid_ros_namespace_conventions) {

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
@@ -37,6 +37,7 @@ typedef struct CustomParticipantInfo
   ReaderInfo * secondarySubListener;
   WriterInfo * secondaryPubListener;
   rmw_guard_condition_t * graph_guard_condition;
+  bool leave_middleware_default_qos;
 } CustomParticipantInfo;
 
 class ParticipantListener : public eprosima::fastrtps::ParticipantListener

--- a/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
@@ -104,6 +104,29 @@ create_node(
 
   try {
     node_impl = new CustomParticipantInfo();
+
+    node_impl->leave_middleware_default_qos = false;
+    const char * env_var = "RMW_FASTRTPS_LEAVE_MIDDLEWARE_DEFAULT_QOS";
+
+    // Check if the configuration from XML has been enabled from 
+    // the RMW_FASTRTPS_LEAVE_MIDDLEWARE_DEFAULT_QOS env variable.
+    char * config_env_val = nullptr;
+#ifndef _WIN32
+    config_env_val = getenv(env_var);
+    if (config_env_val != nullptr)
+    {
+      node_impl->leave_middleware_default_qos = strcmp(config_env_val, "1") == 0;
+    }
+#else
+    size_t config_env_val_size;
+    _dupenv_s(&config_env_val, &config_env_val_size, env_var);
+    if (config_env_val != nullptr)
+    {
+      node_impl->leave_middleware_default_qos = strcmp(config_env_val, "1") == 0;
+    }
+    free(config_env_val);
+#endif
+    
   } catch (std::bad_alloc &) {
     RMW_SET_ERROR_MSG("failed to allocate node impl struct");
     goto fail;
@@ -237,6 +260,12 @@ __rmw_create_node(
     return nullptr;
   }
 
+  auto impl = static_cast<CustomParticipantInfo *>(node->data);
+  if (!impl) {
+    RMW_SET_ERROR_MSG("node impl is null");
+    return RMW_RET_ERROR;
+  }
+
   ParticipantAttributes participantAttrs;
 
   // Load default XML profile.
@@ -246,11 +275,14 @@ __rmw_create_node(
   // since the participant name is not part of the DDS spec
   participantAttrs.rtps.setName(name);
 
-  // allow reallocation to support discovery messages bigger than 5000 bytes
-  participantAttrs.rtps.builtin.readerHistoryMemoryPolicy =
-    eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
-  participantAttrs.rtps.builtin.writerHistoryMemoryPolicy =
-    eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  if (!impl->leave_middleware_default_qos)
+  {
+    // allow reallocation to support discovery messages bigger than 5000 bytes
+    participantAttrs.rtps.builtin.readerHistoryMemoryPolicy =
+      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+    participantAttrs.rtps.builtin.writerHistoryMemoryPolicy =
+      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  }
 
   size_t length = strlen(name) + strlen("name=;") +
     strlen(namespace_) + strlen("namespace=;") + 1;


### PR DESCRIPTION
We have implemented a new feature to apply the RMW configuration only from XML files, avoiding the current configuration set by code. To do that we have added a new boolean value to the `rmw_qos_profile_t` struct.

Connects to ros2/ros2#589