### PR TITLE
Fix guard condition trigger error

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/types/guard_condition.hpp
+++ b/rmw_fastrtps_shared_cpp/src/types/guard_condition.hpp
@@ -72,10 +72,7 @@ public:
   bool
   getHasTriggered()
   {
-    std::lock_guard<std::mutex> lock(internalMutex_);
-    bool ret = hasTriggered_;
-    hasTriggered_ = false;
-    return ret;
+    return hasTriggered_.exchange(false);
   }
 
 private:

--- a/rmw_fastrtps_shared_cpp/src/types/guard_condition.hpp
+++ b/rmw_fastrtps_shared_cpp/src/types/guard_condition.hpp
@@ -72,6 +72,7 @@ public:
   bool
   getHasTriggered()
   {
+    std::lock_guard<std::mutex> lock(internalMutex_);
     bool ret = hasTriggered_;
     hasTriggered_ = false;
     return ret;


### PR DESCRIPTION
1. ret is set as false at line 75 in thread A
2. hasTriggered_ is set as true at line 42 or 46 in thread B
3. hasTriggered_ is set as false at line 76 in thread A

In that case, guard condition triggered information is gone.
So, line 75, 76 codes MUST be thread synchronized with line 42 code.
