### PR TITLE
Improve service_is_available logic to protect that client is waiting …

### DIFF
--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -92,6 +92,8 @@ rmw_create_client(
   info = new CustomClientInfo();
   info->participant_ = participant;
   info->typesupport_identifier_ = type_support->typesupport_identifier;
+  info->request_publisher_matched_count_ = 0;
+  info->response_subscriber_matched_count_ = 0;
 
   const service_type_support_callbacks_t * service_members;
   const message_type_support_callbacks_t * request_members;
@@ -178,8 +180,9 @@ rmw_create_client(
     RMW_SET_ERROR_MSG("failed to get datawriter qos");
     goto fail;
   }
+  info->pub_listener_ = new ClientPubListener(info);
   info->request_publisher_ =
-    Domain::createPublisher(participant, publisherParam, nullptr);
+    Domain::createPublisher(participant, publisherParam, info->pub_listener_);
   if (!info->request_publisher_) {
     RMW_SET_ERROR_MSG("create_publisher() could not create publisher");
     goto fail;
@@ -213,6 +216,10 @@ fail:
 
     if (info->response_subscriber_ != nullptr) {
       Domain::removeSubscriber(info->response_subscriber_);
+    }
+
+    if (info->pub_listener_ != nullptr) {
+      delete info->pub_listener_;
     }
 
     if (info->listener_ != nullptr) {

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_client_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_client_info.hpp
@@ -27,10 +27,12 @@
 #include "fastrtps/subscriber/SubscriberListener.h"
 #include "fastrtps/participant/Participant.h"
 #include "fastrtps/publisher/Publisher.h"
+#include "fastrtps/publisher/PublisherListener.h"
 
 #include "rmw_fastrtps_shared_cpp/TypeSupport.hpp"
 
 class ClientListener;
+class ClientPubListener;
 
 typedef struct CustomClientInfo
 {
@@ -42,6 +44,9 @@ typedef struct CustomClientInfo
   eprosima::fastrtps::rtps::GUID_t writer_guid_;
   eprosima::fastrtps::Participant * participant_;
   const char * typesupport_identifier_;
+  ClientPubListener * pub_listener_;
+  uint32_t response_subscriber_matched_count_;
+  uint32_t request_publisher_matched_count_;
 } CustomClientInfo;
 
 typedef struct CustomClientResponse
@@ -141,6 +146,18 @@ public:
     return list_has_data_.load();
   }
 
+  void onSubscriptionMatched(eprosima::fastrtps::Subscriber * sub,
+      eprosima::fastrtps::rtps::MatchingInfo & matchingInfo)
+  {
+    if (info_ == nullptr || sub == nullptr)
+      return;
+
+    if (matchingInfo.status == eprosima::fastrtps::rtps::MATCHED_MATCHING)
+      info_->response_subscriber_matched_count_++;
+    else
+      info_->response_subscriber_matched_count_--;
+  }
+
 private:
   CustomClientInfo * info_;
   std::mutex internalMutex_;
@@ -148,6 +165,29 @@ private:
   std::atomic_bool list_has_data_;
   std::mutex * conditionMutex_;
   std::condition_variable * conditionVariable_;
+};
+
+class ClientPubListener : public eprosima::fastrtps::PublisherListener
+{
+public:
+  explicit ClientPubListener(CustomClientInfo *info) : info_(info)
+  {
+  }
+
+  void onPublicationMatched(eprosima::fastrtps::Publisher * pub,
+      eprosima::fastrtps::rtps::MatchingInfo & matchingInfo)
+  {
+    if (info_ == nullptr || pub == nullptr)
+      return;
+
+    if (matchingInfo.status == eprosima::fastrtps::rtps::MATCHED_MATCHING)
+      info_->request_publisher_matched_count_++;
+    else
+      info_->request_publisher_matched_count_--;
+  }
+
+private:
+  CustomClientInfo * info_;
 };
 
 #endif  // RMW_FASTRTPS_SHARED_CPP__CUSTOM_CLIENT_INFO_HPP_

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_client_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_client_info.hpp
@@ -146,16 +146,19 @@ public:
     return list_has_data_.load();
   }
 
-  void onSubscriptionMatched(eprosima::fastrtps::Subscriber * sub,
-      eprosima::fastrtps::rtps::MatchingInfo & matchingInfo)
+  void onSubscriptionMatched(
+    eprosima::fastrtps::Subscriber * sub,
+    eprosima::fastrtps::rtps::MatchingInfo & matchingInfo)
   {
-    if (info_ == nullptr || sub == nullptr)
+    if (info_ == nullptr || sub == nullptr) {
       return;
+    }
 
-    if (matchingInfo.status == eprosima::fastrtps::rtps::MATCHED_MATCHING)
+    if (matchingInfo.status == eprosima::fastrtps::rtps::MATCHED_MATCHING) {
       info_->response_subscriber_matched_count_++;
-    else
+    } else {
       info_->response_subscriber_matched_count_--;
+    }
   }
 
 private:
@@ -170,20 +173,24 @@ private:
 class ClientPubListener : public eprosima::fastrtps::PublisherListener
 {
 public:
-  explicit ClientPubListener(CustomClientInfo *info) : info_(info)
+  explicit ClientPubListener(CustomClientInfo * info)
+  : info_(info)
   {
   }
 
-  void onPublicationMatched(eprosima::fastrtps::Publisher * pub,
-      eprosima::fastrtps::rtps::MatchingInfo & matchingInfo)
+  void onPublicationMatched(
+    eprosima::fastrtps::Publisher * pub,
+    eprosima::fastrtps::rtps::MatchingInfo & matchingInfo)
   {
-    if (info_ == nullptr || pub == nullptr)
+    if (info_ == nullptr || pub == nullptr) {
       return;
+    }
 
-    if (matchingInfo.status == eprosima::fastrtps::rtps::MATCHED_MATCHING)
+    if (matchingInfo.status == eprosima::fastrtps::rtps::MATCHED_MATCHING) {
       info_->request_publisher_matched_count_++;
-    else
+    } else {
       info_->request_publisher_matched_count_--;
+    }
   }
 
 private:

--- a/rmw_fastrtps_shared_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_client.cpp
@@ -56,6 +56,9 @@ __rmw_destroy_client(
     if (info->request_publisher_ != nullptr) {
       Domain::removePublisher(info->request_publisher_);
     }
+    if (info->pub_listener_ != nullptr) {
+      delete info->pub_listener_;
+    }
     if (info->listener_ != nullptr) {
       delete info->listener_;
     }

--- a/rmw_fastrtps_shared_cpp/src/rmw_service_server_is_available.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_service_server_is_available.cpp
@@ -104,6 +104,15 @@ __rmw_service_server_is_available(
     return RMW_RET_OK;
   }
 
+  if (0 == client_info->request_publisher_matched_count_) {
+    // not ready
+    return RMW_RET_OK;
+  }
+  if (0 == client_info->response_subscriber_matched_count_) {
+    // not ready
+    return RMW_RET_OK;
+  }
+
   // all conditions met, there is a service server available
   *is_available = true;
   return RMW_RET_OK;


### PR DESCRIPTION
…forever

When checking that service is ready, rmw_fastrtps uses CustomClientInfo's WriterInfo, ReaderInfo topic count.
It is increased when received message about Reader/Writer information from the service.
callstack is as below.
  eprosima::fastrtps::rtps::StatefulReader::processDataMsg
    eprosima::fastrtps::rtps::StatefulReader::change_received
      eprosima::fastrtps::rtps::EDPSimplePUBListener::onNewCacheChangeAdded
         WriterInfo::onNewCacheChangeAdded

But, although receiving the message from service, rtps is not ready to send a message yet.
If client tries to send request, there is no matched remote reader yet, the request is not properly sent to service. In that case, if client tries to wait until receiving the response, client will be blocked because any service does not send response.
After matching local writer proxy and remote reader, rtps is completely ready to send.

Especially, if SECURITY is ON, there is bigger time gap.
There is more possibility to fail to send request to service in SECURITY ON.

If you repeatedly test examples_rclcpp_minimal_client with examples_rclcpp_minimal_service,
you can reproduce the issue.

So, I add Listener to detect matching. callstack will be as below.
It will check that the service is ready using matched reader/writer count.
  eprosima::fastrtps::rtps::security::SecurityManager::discovered_reader
    eprosima::fastrtps::rtps::EDP::pairing_remote_reader_with_local_writer_after_security
     eprosima::fastrtps::PublisherImpl::PublisherWriterListener::onWriterMatched
       ClientPubListener::onPublicationMatched

Connects to ros2/rmw_fastrtps#239