### PR TITLE
RMW_FastRTPS configuration from XML only

### DIFF
--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -120,10 +120,14 @@ rmw_create_client(
     _register_type(participant, info->response_type_support_);
   }
 
+  if (!impl->leave_middleware_default_qos)
+  {
+    subscriberParam.historyMemoryPolicy =
+      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  }
+
   subscriberParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
   subscriberParam.topic.topicDataType = response_type_name;
-  subscriberParam.historyMemoryPolicy =
-    eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
   if (!qos_policies->avoid_ros_namespace_conventions) {
     subscriberParam.topic.topicName = std::string(ros_service_response_prefix) + service_name;
   } else {
@@ -131,11 +135,15 @@ rmw_create_client(
   }
   subscriberParam.topic.topicName += "Reply";
 
+  if (!impl->leave_middleware_default_qos)
+  {
+    publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
+    publisherParam.historyMemoryPolicy =
+      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  }
+
   publisherParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
   publisherParam.topic.topicDataType = request_type_name;
-  publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
-  publisherParam.historyMemoryPolicy =
-    eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
   if (!qos_policies->avoid_ros_namespace_conventions) {
     publisherParam.topic.topicName = std::string(ros_service_requester_prefix) + service_name;
   } else {

--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -120,8 +120,7 @@ rmw_create_client(
     _register_type(participant, info->response_type_support_);
   }
 
-  if (!impl->leave_middleware_default_qos)
-  {
+  if (!impl->leave_middleware_default_qos) {
     subscriberParam.historyMemoryPolicy =
       eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
   }
@@ -135,8 +134,7 @@ rmw_create_client(
   }
   subscriberParam.topic.topicName += "Reply";
 
-  if (!impl->leave_middleware_default_qos)
-  {
+  if (!impl->leave_middleware_default_qos) {
     publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
     publisherParam.historyMemoryPolicy =
       eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;

--- a/rmw_fastrtps_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publisher.cpp
@@ -113,13 +113,12 @@ rmw_create_publisher(
     _register_type(participant, info->type_support_);
   }
 
-  if (!impl->leave_middleware_default_qos)
-  {
+  if (!impl->leave_middleware_default_qos) {
     publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
     publisherParam.historyMemoryPolicy =
       eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
   }
-  
+
   publisherParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
   publisherParam.topic.topicDataType = type_name;
   if (!qos_policies->avoid_ros_namespace_conventions) {

--- a/rmw_fastrtps_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publisher.cpp
@@ -113,9 +113,13 @@ rmw_create_publisher(
     _register_type(participant, info->type_support_);
   }
 
-  publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
-  publisherParam.historyMemoryPolicy =
-    eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  if (!impl->leave_middleware_default_qos)
+  {
+    publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
+    publisherParam.historyMemoryPolicy =
+      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  }
+  
   publisherParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
   publisherParam.topic.topicDataType = type_name;
   if (!qos_policies->avoid_ros_namespace_conventions) {

--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -132,9 +132,13 @@ rmw_create_service(
     _register_type(participant, info->response_type_support_);
   }
 
+  if (!impl->leave_middleware_default_qos)
+  {
+    subscriberParam.historyMemoryPolicy =
+      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;    
+  }
+
   subscriberParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
-  subscriberParam.historyMemoryPolicy =
-    eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
   subscriberParam.topic.topicDataType = request_type_name;
   if (!qos_policies->avoid_ros_namespace_conventions) {
     subscriberParam.topic.topicName = std::string(ros_service_requester_prefix) + service_name;
@@ -143,11 +147,15 @@ rmw_create_service(
   }
   subscriberParam.topic.topicName += "Request";
 
+  if (!impl->leave_middleware_default_qos)
+  {
+    publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
+    publisherParam.historyMemoryPolicy =
+      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;    
+  }
+
   publisherParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
   publisherParam.topic.topicDataType = response_type_name;
-  publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
-  publisherParam.historyMemoryPolicy =
-    eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
   if (!qos_policies->avoid_ros_namespace_conventions) {
     publisherParam.topic.topicName = std::string(ros_service_response_prefix) + service_name;
   } else {

--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -132,10 +132,9 @@ rmw_create_service(
     _register_type(participant, info->response_type_support_);
   }
 
-  if (!impl->leave_middleware_default_qos)
-  {
+  if (!impl->leave_middleware_default_qos) {
     subscriberParam.historyMemoryPolicy =
-      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;    
+      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
   }
 
   subscriberParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
@@ -147,11 +146,10 @@ rmw_create_service(
   }
   subscriberParam.topic.topicName += "Request";
 
-  if (!impl->leave_middleware_default_qos)
-  {
+  if (!impl->leave_middleware_default_qos) {
     publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
     publisherParam.historyMemoryPolicy =
-      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;    
+      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
   }
 
   publisherParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;

--- a/rmw_fastrtps_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_subscription.cpp
@@ -116,8 +116,12 @@ rmw_create_subscription(
     _register_type(participant, info->type_support_);
   }
 
-  subscriberParam.historyMemoryPolicy =
-    eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  if (!impl->leave_middleware_default_qos)
+  {
+    subscriberParam.historyMemoryPolicy =
+      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  }
+  
   subscriberParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
   subscriberParam.topic.topicDataType = type_name;
   if (!qos_policies->avoid_ros_namespace_conventions) {

--- a/rmw_fastrtps_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_subscription.cpp
@@ -116,12 +116,11 @@ rmw_create_subscription(
     _register_type(participant, info->type_support_);
   }
 
-  if (!impl->leave_middleware_default_qos)
-  {
+  if (!impl->leave_middleware_default_qos) {
     subscriberParam.historyMemoryPolicy =
       eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
   }
-  
+
   subscriberParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
   subscriberParam.topic.topicDataType = type_name;
   if (!qos_policies->avoid_ros_namespace_conventions) {

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
@@ -144,7 +144,7 @@ rmw_create_client(
     publisherParam.historyMemoryPolicy =
       eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
   }
-  
+
   publisherParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
   publisherParam.topic.topicDataType = request_type_name;
   if (!qos_policies->avoid_ros_namespace_conventions) {

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
@@ -125,10 +125,14 @@ rmw_create_client(
     _register_type(participant, info->response_type_support_);
   }
 
+  if (!impl->leave_middleware_default_qos)
+  {
+    subscriberParam.historyMemoryPolicy =
+      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;    
+  }
+
   subscriberParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
   subscriberParam.topic.topicDataType = response_type_name;
-  subscriberParam.historyMemoryPolicy =
-    eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
   if (!qos_policies->avoid_ros_namespace_conventions) {
     subscriberParam.topic.topicName = std::string(ros_service_response_prefix) + service_name;
   } else {
@@ -136,11 +140,15 @@ rmw_create_client(
   }
   subscriberParam.topic.topicName += "Reply";
 
+  if (!impl->leave_middleware_default_qos)
+  {
+    publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
+    publisherParam.historyMemoryPolicy =
+      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;    
+  }
+  
   publisherParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
   publisherParam.topic.topicDataType = request_type_name;
-  publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
-  publisherParam.historyMemoryPolicy =
-    eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
   if (!qos_policies->avoid_ros_namespace_conventions) {
     publisherParam.topic.topicName = std::string(ros_service_requester_prefix) + service_name;
   } else {

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
@@ -125,10 +125,9 @@ rmw_create_client(
     _register_type(participant, info->response_type_support_);
   }
 
-  if (!impl->leave_middleware_default_qos)
-  {
+  if (!impl->leave_middleware_default_qos) {
     subscriberParam.historyMemoryPolicy =
-      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;    
+      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
   }
 
   subscriberParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
@@ -140,11 +139,10 @@ rmw_create_client(
   }
   subscriberParam.topic.topicName += "Reply";
 
-  if (!impl->leave_middleware_default_qos)
-  {
+  if (!impl->leave_middleware_default_qos) {
     publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
     publisherParam.historyMemoryPolicy =
-      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;    
+      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
   }
   
   publisherParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_publisher.cpp
@@ -108,9 +108,13 @@ rmw_create_publisher(
     _register_type(participant, info->type_support_);
   }
 
-  publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
-  publisherParam.historyMemoryPolicy =
-    eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  if (!impl->leave_middleware_default_qos)
+  {
+    publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
+    publisherParam.historyMemoryPolicy =
+      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  }
+  
   publisherParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
   publisherParam.topic.topicDataType = type_name;
   if (!qos_policies->avoid_ros_namespace_conventions) {

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_publisher.cpp
@@ -108,8 +108,7 @@ rmw_create_publisher(
     _register_type(participant, info->type_support_);
   }
 
-  if (!impl->leave_middleware_default_qos)
-  {
+  if (!impl->leave_middleware_default_qos) {
     publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
     publisherParam.historyMemoryPolicy =
       eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_publisher.cpp
@@ -113,7 +113,7 @@ rmw_create_publisher(
     publisherParam.historyMemoryPolicy =
       eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
   }
-  
+
   publisherParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
   publisherParam.topic.topicDataType = type_name;
   if (!qos_policies->avoid_ros_namespace_conventions) {

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
@@ -137,10 +137,9 @@ rmw_create_service(
     _register_type(participant, info->response_type_support_);
   }
 
-  if (!impl->leave_middleware_default_qos)
-  {
+  if (!impl->leave_middleware_default_qos) {
     subscriberParam.historyMemoryPolicy =
-      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;    
+      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
   }
 
   subscriberParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
@@ -152,8 +151,7 @@ rmw_create_service(
   }
   subscriberParam.topic.topicName += "Request";
 
-  if (!impl->leave_middleware_default_qos)
-  {
+  if (!impl->leave_middleware_default_qos) {
     publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
     publisherParam.historyMemoryPolicy =
       eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
@@ -137,9 +137,13 @@ rmw_create_service(
     _register_type(participant, info->response_type_support_);
   }
 
+  if (!impl->leave_middleware_default_qos)
+  {
+    subscriberParam.historyMemoryPolicy =
+      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;    
+  }
+
   subscriberParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
-  subscriberParam.historyMemoryPolicy =
-    eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
   subscriberParam.topic.topicDataType = request_type_name;
   if (!qos_policies->avoid_ros_namespace_conventions) {
     subscriberParam.topic.topicName = std::string(ros_service_requester_prefix) + service_name;
@@ -148,11 +152,15 @@ rmw_create_service(
   }
   subscriberParam.topic.topicName += "Request";
 
+  if (!impl->leave_middleware_default_qos)
+  {
+    publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
+    publisherParam.historyMemoryPolicy =
+      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  }
+
   publisherParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
   publisherParam.topic.topicDataType = response_type_name;
-  publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
-  publisherParam.historyMemoryPolicy =
-    eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
   if (!qos_policies->avoid_ros_namespace_conventions) {
     publisherParam.topic.topicName = std::string(ros_service_response_prefix) + service_name;
   } else {

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_subscription.cpp
@@ -116,7 +116,7 @@ rmw_create_subscription(
     subscriberParam.historyMemoryPolicy =
       eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
   }
-  
+
   subscriberParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
   subscriberParam.topic.topicDataType = type_name;
   if (!qos_policies->avoid_ros_namespace_conventions) {

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_subscription.cpp
@@ -112,8 +112,12 @@ rmw_create_subscription(
     _register_type(participant, info->type_support_);
   }
 
-  subscriberParam.historyMemoryPolicy =
-    eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  if (!impl->leave_middleware_default_qos)
+  {
+    subscriberParam.historyMemoryPolicy =
+      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;    
+  }
+  
   subscriberParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
   subscriberParam.topic.topicDataType = type_name;
   if (!qos_policies->avoid_ros_namespace_conventions) {

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_subscription.cpp
@@ -112,10 +112,9 @@ rmw_create_subscription(
     _register_type(participant, info->type_support_);
   }
 
-  if (!impl->leave_middleware_default_qos)
-  {
+  if (!impl->leave_middleware_default_qos) {
     subscriberParam.historyMemoryPolicy =
-      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;    
+      eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
   }
   
   subscriberParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
@@ -37,6 +37,7 @@ typedef struct CustomParticipantInfo
   ReaderInfo * secondarySubListener;
   WriterInfo * secondaryPubListener;
   rmw_guard_condition_t * graph_guard_condition;
+  bool leave_middleware_default_qos;
 } CustomParticipantInfo;
 
 class ParticipantListener : public eprosima::fastrtps::ParticipantListener

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
@@ -37,6 +37,12 @@ typedef struct CustomParticipantInfo
   ReaderInfo * secondarySubListener;
   WriterInfo * secondaryPubListener;
   rmw_guard_condition_t * graph_guard_condition;
+
+  // Flag to establish if the QoS of the participant,
+  // its publishers and its subscribers are going
+  // to be configured only from an XML file or if 
+  // their settings are going to be overwritten by code 
+  // with the default configuration.
   bool leave_middleware_default_qos;
 } CustomParticipantInfo;
 

--- a/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
@@ -106,9 +106,9 @@ create_node(
     node_impl = new CustomParticipantInfo();
 
     node_impl->leave_middleware_default_qos = false;
-    const char * env_var = "RMW_FASTRTPS_LEAVE_MIDDLEWARE_DEFAULT_QOS";
+    const char * env_var = "RMW_FASTRTPS_USE_QOS_FROM_XML";
      // Check if the configuration from XML has been enabled from 
-    // the RMW_FASTRTPS_LEAVE_MIDDLEWARE_DEFAULT_QOS env variable.
+    // the RMW_FASTRTPS_USE_QOS_FROM_XML env variable.
     char * config_env_val = nullptr;
 #ifndef _WIN32
     config_env_val = getenv(env_var);
@@ -268,9 +268,9 @@ __rmw_create_node(
   participantAttrs.rtps.setName(name);
 
   bool leave_middleware_default_qos = false;
-  const char * env_var = "RMW_FASTRTPS_LEAVE_MIDDLEWARE_DEFAULT_QOS";
+  const char * env_var = "RMW_FASTRTPS_USE_QOS_FROM_XML";
    // Check if the configuration from XML has been enabled from 
-  // the RMW_FASTRTPS_LEAVE_MIDDLEWARE_DEFAULT_QOS env variable.
+  // the RMW_FASTRTPS_USE_QOS_FROM_XML env variable.
   char * config_env_val = nullptr;
 #ifndef _WIN32
   config_env_val = getenv(env_var);

--- a/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
@@ -107,20 +107,18 @@ create_node(
 
     node_impl->leave_middleware_default_qos = false;
     const char * env_var = "RMW_FASTRTPS_USE_QOS_FROM_XML";
-     // Check if the configuration from XML has been enabled from 
+    // Check if the configuration from XML has been enabled from
     // the RMW_FASTRTPS_USE_QOS_FROM_XML env variable.
     char * config_env_val = nullptr;
 #ifndef _WIN32
     config_env_val = getenv(env_var);
-    if (config_env_val != nullptr)
-    {
+    if (config_env_val != nullptr) {
       node_impl->leave_middleware_default_qos = strcmp(config_env_val, "1") == 0;
     }
 #else
     size_t config_env_val_size;
     _dupenv_s(&config_env_val, &config_env_val_size, env_var);
-    if (config_env_val != nullptr)
-    {
+    if (config_env_val != nullptr) {
       node_impl->leave_middleware_default_qos = strcmp(config_env_val, "1") == 0;
     }
     free(config_env_val);
@@ -269,28 +267,25 @@ __rmw_create_node(
 
   bool leave_middleware_default_qos = false;
   const char * env_var = "RMW_FASTRTPS_USE_QOS_FROM_XML";
-   // Check if the configuration from XML has been enabled from 
+  // Check if the configuration from XML has been enabled from
   // the RMW_FASTRTPS_USE_QOS_FROM_XML env variable.
   char * config_env_val = nullptr;
 #ifndef _WIN32
   config_env_val = getenv(env_var);
-  if (config_env_val != nullptr)
-  {
+  if (config_env_val != nullptr) {
     leave_middleware_default_qos = strcmp(config_env_val, "1") == 0;
   }
 #else
   size_t config_env_val_size;
   _dupenv_s(&config_env_val, &config_env_val_size, env_var);
-  if (config_env_val != nullptr)
-  {
+  if (config_env_val != nullptr) {
     leave_middleware_default_qos = strcmp(config_env_val, "1") == 0;
   }
   free(config_env_val);
 #endif
 
   // allow reallocation to support discovery messages bigger than 5000 bytes
-  if (!leave_middleware_default_qos)
-  {
+  if (!leave_middleware_default_qos) {
     participantAttrs.rtps.builtin.readerHistoryMemoryPolicy =
       eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
     participantAttrs.rtps.builtin.writerHistoryMemoryPolicy =


### PR DESCRIPTION
We have implemented a new feature to apply the RMW configuration only from XML files, avoiding the current configuration set by code. To do that, rmw_fastrtps checks an environment variable called `RMW_FASTRTPS_LEAVE_MIDDLEWARE_DEFAULT_QOS`

Connects to ros2/ros2#589