### PR TITLE
Fix cpplint error

### DIFF
--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_client_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_client_info.hpp
@@ -20,6 +20,7 @@
 #include <list>
 #include <memory>
 #include <mutex>
+#include <set>
 #include <utility>
 
 #include "fastcdr/FastBuffer.h"


### PR DESCRIPTION
Error introduced in #262.

CI before: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=6450)](https://ci.ros2.org/job/ci_linux/6450/)
CI after: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=6452)](https://ci.ros2.org/job/ci_linux/6452/)