### PR TITLE
Crystal backports

### DIFF
--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_client_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_client_info.hpp
@@ -16,8 +16,10 @@
 #define RMW_FASTRTPS_SHARED_CPP__CUSTOM_CLIENT_INFO_HPP_
 
 #include <atomic>
+#include <condition_variable>
 #include <list>
 #include <memory>
+#include <mutex>
 #include <utility>
 
 #include "fastcdr/FastBuffer.h"

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
@@ -16,7 +16,9 @@
 #define RMW_FASTRTPS_SHARED_CPP__CUSTOM_SERVICE_INFO_HPP_
 
 #include <atomic>
+#include <condition_variable>
 #include <list>
+#include <mutex>
 
 #include "fastcdr/FastBuffer.h"
 

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
@@ -102,15 +102,15 @@ public:
   }
 
   void
-  data_taken()
+  data_taken(eprosima::fastrtps::Subscriber * sub)
   {
     std::lock_guard<std::mutex> lock(internalMutex_);
 
     if (conditionMutex_ != nullptr) {
       std::unique_lock<std::mutex> clock(*conditionMutex_);
-      --data_;
+      data_ = sub->getUnreadCount();
     } else {
-      --data_;
+      data_ = sub->getUnreadCount();
     }
   }
 

--- a/rmw_fastrtps_shared_cpp/src/rmw_take.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_take.cpp
@@ -67,7 +67,7 @@ _take(
   data.is_cdr_buffer = false;
   data.data = ros_message;
   if (info->subscriber_->takeNextData(&data, &sinfo)) {
-    info->listener_->data_taken();
+    info->listener_->data_taken(info->subscriber_);
 
     if (eprosima::fastrtps::rtps::ALIVE == sinfo.sampleKind) {
       if (message_info) {
@@ -140,7 +140,7 @@ _take_serialized_message(
   data.is_cdr_buffer = true;
   data.data = &buffer;
   if (info->subscriber_->takeNextData(&data, &sinfo)) {
-    info->listener_->data_taken();
+    info->listener_->data_taken(info->subscriber_);
 
     if (eprosima::fastrtps::rtps::ALIVE == sinfo.sampleKind) {
       auto buffer_size = static_cast<size_t>(buffer.getBufferSize());


### PR DESCRIPTION
This PR backports commits ea4fb7cfaa671a2118a7d54203c786d890d8ed38 and fc4b27e899efb91455de8863df2dbdd3887897f2 (PRs #256 and #264, respectively) into Crystal.  These are needed as part of the fixes to bring Fast-RTPS up to version 1.7.2.  Note that these have to go in *before* the update to v1.7.2, otherwise this will fail to build.  A full CI run for these changes was run as part of https://github.com/ros2/ros2/issues/669#issuecomment-475014351 .  @nuclearsandwich FYI