### PR TITLE
Fix logging in rmw_node_info_and_types.cpp

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/rmw_node_info_and_types.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_node_info_and_types.cpp
@@ -206,7 +206,7 @@ __copy_data_to_results(
         if (rmw_ret != RMW_RET_OK) {
           RCUTILS_LOG_ERROR_NAMED(
             kLoggerTag,
-            "error during report of error: %s", rmw_get_error_string());
+            "error during report of error: %s", rmw_get_error_string().str);
         }
       };
     // Setup demangling functions based on no_demangle option
@@ -444,7 +444,7 @@ __rmw_get_service_names_and_types_by_node(
       if (rmw_ret != RMW_RET_OK) {
         RCUTILS_LOG_ERROR_NAMED(
           kLoggerTag,
-          "error during report of error: %s", rmw_get_error_string());
+          "error during report of error: %s", rmw_get_error_string().str);
       }
     };
   // For each service, store the name, initialize the string array for types, and store all types


### PR DESCRIPTION
When logging a rcutils_error_string_t variable, the
str field of the rcutils_error_string_t variable needs
to be logged, not the struct directly.

Signed-off-by: Thomas Moulard <tmoulard@amazon.com>