### PR TITLE
Disable all liveliness until it is actually supported

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/qos.cpp
+++ b/rmw_fastrtps_shared_cpp/src/qos.cpp
@@ -161,9 +161,10 @@ bool
 is_valid_qos(const rmw_qos_profile_t & qos_policies)
 {
   if (qos_policies.liveliness == RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_NODE ||
-    qos_policies.liveliness == RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC)
+    qos_policies.liveliness == RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC ||
+    !is_time_default(qos_policies.liveliness_lease_duration))
   {
-    RMW_SET_ERROR_MSG("Manual liveliness unsupported for fastrtps");
+    RMW_SET_ERROR_MSG("Liveliness QoS is not yet supported for fastrtps.");
     return false;
   }
   return true;


### PR DESCRIPTION
When we first implemented QoS event support for Fast-RTPS 1.8, we were under the impression that AUTOMATIC Liveliness callbacks would be supported in the release, but this turned out to not be the case.

Fixes https://github.com/ros2/demos/issues/351

Signed-off-by: Emerson Knapp <eknapp@amazon.com>