### PR TITLE
get_actual_qos() is not setting all of rmw_qos_profile_t

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_publisher.cpp
@@ -157,17 +157,8 @@ __rmw_publisher_get_actual_qos(
       qos->history = RMW_QOS_POLICY_HISTORY_UNKNOWN;
       break;
   }
-  switch (attributes.qos.m_durability.kind) {
-    case eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS:
-      qos->durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
-      break;
-    case eprosima::fastrtps::VOLATILE_DURABILITY_QOS:
-      qos->durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
-      break;
-    default:
-      qos->durability = RMW_QOS_POLICY_DURABILITY_UNKNOWN;
-      break;
-  }
+  qos->depth = static_cast<size_t>(attributes.topic.historyQos.depth);
+
   switch (attributes.qos.m_reliability.kind) {
     case eprosima::fastrtps::BEST_EFFORT_RELIABILITY_QOS:
       qos->reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
@@ -179,7 +170,41 @@ __rmw_publisher_get_actual_qos(
       qos->reliability = RMW_QOS_POLICY_RELIABILITY_UNKNOWN;
       break;
   }
-  qos->depth = static_cast<size_t>(attributes.topic.historyQos.depth);
+
+  switch (attributes.qos.m_durability.kind) {
+    case eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS:
+      qos->durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
+      break;
+    case eprosima::fastrtps::VOLATILE_DURABILITY_QOS:
+      qos->durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+      break;
+    default:
+      qos->durability = RMW_QOS_POLICY_DURABILITY_UNKNOWN;
+      break;
+  }
+
+  qos->deadline.sec = attributes.qos.m_deadline.period.seconds;
+  qos->deadline.nsec = attributes.qos.m_deadline.period.nanosec;
+
+  qos->lifespan.sec = attributes.qos.m_lifespan.duration.seconds;
+  qos->lifespan.nsec = attributes.qos.m_lifespan.duration.nanosec;
+
+  switch (attributes.qos.m_liveliness.kind) {
+    case eprosima::fastrtps::AUTOMATIC_LIVELINESS_QOS:
+      qos->liveliness = RMW_QOS_POLICY_LIVELINESS_AUTOMATIC;
+      break;
+    case eprosima::fastrtps::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS:
+      qos->liveliness = RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_NODE;
+      break;
+    case eprosima::fastrtps::MANUAL_BY_TOPIC_LIVELINESS_QOS:
+      qos->liveliness = RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC;
+      break;
+    default:
+      qos->liveliness = RMW_QOS_POLICY_LIVELINESS_UNKNOWN;
+      break;
+  }
+  qos->liveliness_lease_duration.sec = attributes.qos.m_liveliness.lease_duration.seconds;
+  qos->liveliness_lease_duration.nsec = attributes.qos.m_liveliness.lease_duration.nanosec;
 
   return RMW_RET_OK;
 }


### PR DESCRIPTION
The current implementation of `get_actual_qos()` is not setting/output the values for lifespan, deadline, and liveliness QoS policies.

Depends on https://github.com/ros2/rmw/pull/175.