### PR TITLE
Fix compile warning with -Wsign-compare

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/qos.cpp
+++ b/rmw_fastrtps_shared_cpp/src/qos.cpp
@@ -95,7 +95,7 @@ bool fill_entity_qos_from_profile(
     eprosima::fastrtps::KEEP_LAST_HISTORY_QOS == history_qos.kind &&
     static_cast<size_t>(history_qos.depth) < qos_policies.depth)
   {
-    if (qos_policies.depth > (std::numeric_limits<int32_t>::max)()) {
+    if (qos_policies.depth > (std::numeric_limits<size_t>::max)()) {
       RMW_SET_ERROR_MSG(
         "failed to set history depth since the requested queue size exceeds the DDS type");
       return false;

--- a/rmw_fastrtps_shared_cpp/src/qos.cpp
+++ b/rmw_fastrtps_shared_cpp/src/qos.cpp
@@ -95,7 +95,7 @@ bool fill_entity_qos_from_profile(
     eprosima::fastrtps::KEEP_LAST_HISTORY_QOS == history_qos.kind &&
     static_cast<size_t>(history_qos.depth) < qos_policies.depth)
   {
-    if (qos_policies.depth > (std::numeric_limits<size_t>::max)()) {
+    if (qos_policies.depth > static_cast<size_t>((std::numeric_limits<int32_t>::max)())) {
       RMW_SET_ERROR_MSG(
         "failed to set history depth since the requested queue size exceeds the DDS type");
       return false;


### PR DESCRIPTION
## Bug report

**Required Info:**

- Operating System:
  - Fedora 30
- Installation type:
  - source
- Version or commit hash:
  - 0.7.3
- DDS implementation:
  - Fast-RTPS
- Client library (if applicable):
  - N/A

#### Steps to reproduce issue
Compile from source using system's default compiler, `g++ (GCC) 9.1.1 20190503 (Red Hat 9.1.1-1)`

#### Expected behavior
No warnings.

#### Actual behavior
```
src/ros2/rmw_fastrtps/rmw_fastrtps_shared_cpp/src/qos.cpp: In instantiation of ‘bool fill_entity_qos_from_profile(const rmw_qos_profile_t&, DDSEntityQos&, eprosima::fastrtps::HistoryQosPolicy&) [with DDSEntityQos = eprosima::fastrtps::ReaderQos; rmw_qos_profile_t = rmw_qos_profile_t]’:
src/ros2/rmw_fastrtps/rmw_fastrtps_shared_cpp/src/qos.cpp:150:86:   required from here
src/ros2/rmw_fastrtps/rmw_fastrtps_shared_cpp/src/qos.cpp:98:28: warning: comparison of integer expressions of different signedness: ‘const size_t’ {aka ‘const long unsigned int’} and ‘int’ [-Wsign-compare]
   98 |     if (qos_policies.depth > (std::numeric_limits<int32_t>::max)()) {
      |         ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/ros2/rmw_fastrtps/rmw_fastrtps_shared_cpp/src/qos.cpp: In instantiation of ‘bool fill_entity_qos_from_profile(const rmw_qos_profile_t&, DDSEntityQos&, eprosima::fastrtps::HistoryQosPolicy&) [with DDSEntityQos = eprosima::fastrtps::WriterQos; rmw_qos_profile_t = rmw_qos_profile_t]’:
src/ros2/rmw_fastrtps/rmw_fastrtps_shared_cpp/src/qos.cpp:157:86:   required from here
src/ros2/rmw_fastrtps/rmw_fastrtps_shared_cpp/src/qos.cpp:98:28: warning: comparison of integer expressions of different signedness: ‘const size_t’ {aka ‘const long unsigned int’} and ‘int’ [-Wsign-compare]
```

#### Additional information

The type is defined in [rmw/include/rmw/types.h](https://github.com/ros2/rmw/blob/0.7.1/rmw/include/rmw/types.h#L235).