### PR TITLE
Enable assert liveliness on publisher.

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/qos.cpp
+++ b/rmw_fastrtps_shared_cpp/src/qos.cpp
@@ -160,11 +160,10 @@ get_datawriter_qos(
 bool
 is_valid_qos(const rmw_qos_profile_t & qos_policies)
 {
-  if (qos_policies.liveliness == RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_NODE ||
-    qos_policies.liveliness == RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC ||
+  if (qos_policies.liveliness == RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_NODE &&
     !is_time_default(qos_policies.liveliness_lease_duration))
   {
-    RMW_SET_ERROR_MSG("Liveliness QoS is not yet supported for fastrtps.");
+    RMW_SET_ERROR_MSG("Liveliness policy MANUAL_BY_NODE is not yet supported for fastrtps.");
     return false;
   }
   return true;

--- a/rmw_fastrtps_shared_cpp/src/qos.cpp
+++ b/rmw_fastrtps_shared_cpp/src/qos.cpp
@@ -160,9 +160,7 @@ get_datawriter_qos(
 bool
 is_valid_qos(const rmw_qos_profile_t & qos_policies)
 {
-  if (qos_policies.liveliness == RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_NODE &&
-    !is_time_default(qos_policies.liveliness_lease_duration))
-  {
+  if (qos_policies.liveliness == RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_NODE) {
     RMW_SET_ERROR_MSG("Liveliness policy MANUAL_BY_NODE is not yet supported for fastrtps.");
     return false;
   }

--- a/rmw_fastrtps_shared_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_publisher.cpp
@@ -121,10 +121,8 @@ __rmw_publisher_assert_liveliness(
     return RMW_RET_ERROR;
   }
 
-  // info->publisher_->assert_liveliness();
-  RMW_SET_ERROR_MSG("assert_liveliness() of publisher is currently not supported");
-
-  return RMW_RET_UNSUPPORTED;
+  info->publisher_->assert_liveliness();
+  return RMW_RET_OK;
 }
 
 rmw_ret_t


### PR DESCRIPTION
Working against the release/1.8.1 branch on Fast-RTPS.

It doesn't provide the Participant::assert_liveliness API, but it has added this API for Publishers.