### PR TITLE
Enable manual_by_node and node liveliness assertion

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/qos.cpp
+++ b/rmw_fastrtps_shared_cpp/src/qos.cpp
@@ -158,12 +158,8 @@ get_datawriter_qos(
 }
 
 bool
-is_valid_qos(const rmw_qos_profile_t & qos_policies)
+is_valid_qos(const rmw_qos_profile_t & /* qos_policies */)
 {
-  if (qos_policies.liveliness == RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_NODE) {
-    RMW_SET_ERROR_MSG("Liveliness policy MANUAL_BY_NODE is not yet supported for fastrtps.");
-    return false;
-  }
   return true;
 }
 

--- a/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
@@ -386,10 +386,8 @@ __rmw_node_assert_liveliness(
     return RMW_RET_ERROR;
   }
 
-  // node_info->participant->assert_liveliness();
-  RMW_SET_ERROR_MSG("assert_liveliness() of node is currently not supported");
-
-  return RMW_RET_UNSUPPORTED;
+  node_info->participant->assert_liveliness();
+  return RMW_RET_OK;
 }
 
 const rmw_guard_condition_t *


### PR DESCRIPTION
Enable participant assert_liveliness and MANUAL_BY_NODE liveliness policy, since they are supported in v1.8.1

Signed-off-by: Emerson Knapp <eknapp@amazon.com>