### PR TITLE
use target_include_directories

### DIFF
--- a/rmw_fastrtps_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_cpp/CMakeLists.txt
@@ -44,8 +44,6 @@ find_package(rosidl_generator_c REQUIRED)
 find_package(rosidl_typesupport_fastrtps_c REQUIRED)
 find_package(rosidl_typesupport_fastrtps_cpp REQUIRED)
 
-include_directories(include)
-
 add_library(rmw_fastrtps_cpp
   src/get_client.cpp
   src/get_participant.cpp
@@ -81,6 +79,11 @@ add_library(rmw_fastrtps_cpp
   src/rmw_wait_set.cpp
   src/serialization_format.cpp
   src/type_support_common.cpp
+)
+target_include_directories(rmw_fastrtps_cpp
+  INTERFACE ${fastcdr_INCLUDE_DIR}
+  INTERFACE ${fastrtps_INCLUDE_DIR}
+  PRIVATE include
 )
 target_link_libraries(rmw_fastrtps_cpp
   fastcdr fastrtps)

--- a/rmw_fastrtps_dynamic_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_dynamic_cpp/CMakeLists.txt
@@ -47,8 +47,6 @@ find_package(rosidl_typesupport_fastrtps_cpp REQUIRED)
 find_package(rosidl_typesupport_introspection_c REQUIRED)
 find_package(rosidl_typesupport_introspection_cpp REQUIRED)
 
-include_directories(include)
-
 add_library(rmw_fastrtps_dynamic_cpp
   src/client_service_common.cpp
   src/get_client.cpp
@@ -85,6 +83,11 @@ add_library(rmw_fastrtps_dynamic_cpp
   src/rmw_wait_set.cpp
   src/type_support_common.cpp
   src/serialization_format.cpp
+)
+target_include_directories(rmw_fastrtps_dynamic_cpp
+  INTERFACE ${fastcdr_INCLUDE_DIR}
+  INTERFACE ${fastrtps_INCLUDE_DIR}
+  PRIVATE include
 )
 target_link_libraries(rmw_fastrtps_dynamic_cpp
   fastcdr fastrtps)

--- a/rmw_fastrtps_shared_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_shared_cpp/CMakeLists.txt
@@ -44,7 +44,6 @@ find_package(fastrtps REQUIRED CONFIG)
 find_package(FastRTPS REQUIRED MODULE)
 
 find_package(rmw REQUIRED)
-include_directories(include)
 
 add_library(rmw_fastrtps_shared_cpp
   src/custom_publisher_info.cpp
@@ -76,7 +75,11 @@ add_library(rmw_fastrtps_shared_cpp
   src/rmw_wait_set.cpp
   src/TypeSupport_impl.cpp
 )
-
+target_include_directories(rmw_fastrtps_shared_cpp
+  INTERFACE ${fastcdr_INCLUDE_DIR}
+  INTERFACE ${fastrtps_INCLUDE_DIR}
+  PRIVATE include
+)
 target_link_libraries(rmw_fastrtps_shared_cpp
   fastcdr fastrtps
 )


### PR DESCRIPTION
Signed-off-by: karsten knese <karsten.knese@us.bosch.com>

When overlaying a workspace with FastRTPS, this changed helped me to point to the local FastRTPS include directories rather than the include dirs from `/opt/ros/dashing`.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=7482)](http://ci.ros2.org/job/ci_linux/7482/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=3622)](http://ci.ros2.org/job/ci_linux-aarch64/3622/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6137)](http://ci.ros2.org/job/ci_osx/6137/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=7318)](http://ci.ros2.org/job/ci_windows/7318/)