### PR TITLE
Fix bug in graph API by node

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/rmw_node_info_and_types.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_node_info_and_types.cpp
@@ -59,7 +59,7 @@ rmw_ret_t __get_guid_by_name(
   const char * node_namespace, GUID_t & guid)
 {
   auto impl = static_cast<CustomParticipantInfo *>(node->data);
-  if (strcmp(node->name, node_name) == 0) {
+  if (strcmp(node->name, node_name) == 0 && strcmp(node->namespace_, node_namespace) == 0) {
     guid = impl->participant->getGuid();
   } else {
     std::set<GUID_t> nodes_in_desired_namespace;


### PR DESCRIPTION
Taken from #311, as requested in https://github.com/ros2/rmw_fastrtps/pull/311#issuecomment-526735087.

Fixes the following TODOs in `rcl/test_graph`:
- https://github.com/ros2/rcl/blob/e8bbb752dfc0c6278869d0e18a54397b784baaeb/rcl/test/rcl/test_graph.cpp#L320-L324
- https://github.com/ros2/rcl/blob/e8bbb752dfc0c6278869d0e18a54397b784baaeb/rcl/test/rcl/test_graph.cpp#L336-L340
- https://github.com/ros2/rcl/blob/e8bbb752dfc0c6278869d0e18a54397b784baaeb/rcl/test/rcl/test_graph.cpp#L407-L412
- https://github.com/ros2/rcl/blob/e8bbb752dfc0c6278869d0e18a54397b784baaeb/rcl/test/rcl/test_graph.cpp#L423-L427
- https://github.com/ros2/rcl/blob/e8bbb752dfc0c6278869d0e18a54397b784baaeb/rcl/test/rcl/test_graph.cpp#L491-L495
- https://github.com/ros2/rcl/blob/e8bbb752dfc0c6278869d0e18a54397b784baaeb/rcl/test/rcl/test_graph.cpp#L507-L511