### PR TITLE
Correct linter failure

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/rmw_wait_set.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_wait_set.cpp
@@ -47,7 +47,8 @@ __rmw_create_wait_set(const char * identifier, rmw_context_t * context, size_t m
   wait_set->data = rmw_allocate(sizeof(CustomWaitsetInfo));
   // This should default-construct the fields of CustomWaitsetInfo
   wait_set_info = static_cast<CustomWaitsetInfo *>(wait_set->data);
-  RMW_TRY_PLACEMENT_NEW(wait_set_info, wait_set_info, goto fail, CustomWaitsetInfo)
+  // cppcheck-suppress syntaxError
+  RMW_TRY_PLACEMENT_NEW(wait_set_info, wait_set_info, goto fail, CustomWaitsetInfo, )
   if (!wait_set_info) {
     RMW_SET_ERROR_MSG("failed to construct wait set info struct");
     goto fail;

--- a/rmw_fastrtps_shared_cpp/src/rmw_wait_set.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_wait_set.cpp
@@ -47,7 +47,7 @@ __rmw_create_wait_set(const char * identifier, rmw_context_t * context, size_t m
   wait_set->data = rmw_allocate(sizeof(CustomWaitsetInfo));
   // This should default-construct the fields of CustomWaitsetInfo
   wait_set_info = static_cast<CustomWaitsetInfo *>(wait_set->data);
-  RMW_TRY_PLACEMENT_NEW(wait_set_info, wait_set_info, goto fail, CustomWaitsetInfo, )
+  RMW_TRY_PLACEMENT_NEW(wait_set_info, wait_set_info, goto fail, CustomWaitsetInfo)
   if (!wait_set_info) {
     RMW_SET_ERROR_MSG("failed to construct wait set info struct");
     goto fail;


### PR DESCRIPTION
I guess this will solve this failure in the nightlies:
https://ci.ros2.org/view/nightly/job/nightly_win_rel/1310/testReport/junit/rmw_fastrtps_shared_cpp/cppcheck/error__syntaxError__src_rmw_wait_set_cpp_50_/