### PR TITLE
Renamed dds_qos_to_rmw_qos to dds_attributes_to_rmw_qos

### DIFF
--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/qos.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/qos.hpp
@@ -46,19 +46,19 @@ get_datawriter_qos(
 
 template<typename AttributeT>
 void
-dds_qos_to_rmw_qos(
+dds_attributes_to_rmw_qos(
   const AttributeT & dds_qos,
   rmw_qos_profile_t * qos);
 
 extern template RMW_FASTRTPS_SHARED_CPP_PUBLIC
 void
-dds_qos_to_rmw_qos<eprosima::fastrtps::PublisherAttributes>(
+dds_attributes_to_rmw_qos<eprosima::fastrtps::PublisherAttributes>(
   const eprosima::fastrtps::PublisherAttributes & dds_qos,
   rmw_qos_profile_t * qos);
 
 extern template RMW_FASTRTPS_SHARED_CPP_PUBLIC
 void
-dds_qos_to_rmw_qos<eprosima::fastrtps::SubscriberAttributes>(
+dds_attributes_to_rmw_qos<eprosima::fastrtps::SubscriberAttributes>(
   const eprosima::fastrtps::SubscriberAttributes & dds_qos,
   rmw_qos_profile_t * qos);
 

--- a/rmw_fastrtps_shared_cpp/src/qos.cpp
+++ b/rmw_fastrtps_shared_cpp/src/qos.cpp
@@ -165,7 +165,7 @@ is_valid_qos(const rmw_qos_profile_t & /* qos_policies */)
 
 template<typename AttributeT>
 void
-dds_qos_to_rmw_qos(
+dds_attributes_to_rmw_qos(
   const AttributeT & dds_qos,
   rmw_qos_profile_t * qos)
 {
@@ -231,11 +231,11 @@ dds_qos_to_rmw_qos(
 }
 
 template
-void dds_qos_to_rmw_qos<eprosima::fastrtps::PublisherAttributes>(
+void dds_attributes_to_rmw_qos<eprosima::fastrtps::PublisherAttributes>(
   const eprosima::fastrtps::PublisherAttributes & dds_qos,
   rmw_qos_profile_t * qos);
 
 template
-void dds_qos_to_rmw_qos<eprosima::fastrtps::SubscriberAttributes>(
+void dds_attributes_to_rmw_qos<eprosima::fastrtps::SubscriberAttributes>(
   const eprosima::fastrtps::SubscriberAttributes & dds_qos,
   rmw_qos_profile_t * qos);

--- a/rmw_fastrtps_shared_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_publisher.cpp
@@ -144,7 +144,7 @@ __rmw_publisher_get_actual_qos(
   const eprosima::fastrtps::PublisherAttributes & attributes =
     fastrtps_pub->getAttributes();
 
-  dds_qos_to_rmw_qos(attributes, qos);
+  dds_attributes_to_rmw_qos(attributes, qos);
 
   return RMW_RET_OK;
 }

--- a/rmw_fastrtps_shared_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_subscription.cpp
@@ -125,7 +125,7 @@ __rmw_subscription_get_actual_qos(
   const eprosima::fastrtps::SubscriberAttributes & attributes =
     fastrtps_sub->getAttributes();
 
-  dds_qos_to_rmw_qos(attributes, qos);
+  dds_attributes_to_rmw_qos(attributes, qos);
 
   return RMW_RET_OK;
 }


### PR DESCRIPTION
Made sure this change is reflected in places where the function is
called; namely in rmw_publisher.cpp and rmw_subscription.cpp

Note: colcon build and test for packages-up-to rmw_fastrtps_shared_cpp
built successfully and passed the tests without any failures or errors.

Signed-off-by: Jaison Titus <jaisontj92@gmail.com>