### PR TITLE
Restrict traffic to localhost only if env var is provided

### DIFF
--- a/rmw_fastrtps_cpp/src/rmw_node.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_node.cpp
@@ -37,7 +37,8 @@ rmw_create_node(
   const char * name,
   const char * namespace_,
   size_t domain_id,
-  const rmw_node_security_options_t * security_options)
+  const rmw_node_security_options_t * security_options,
+  bool localhost_only)
 {
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(context, NULL);
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
@@ -47,7 +48,7 @@ rmw_create_node(
     // TODO(wjwwood): replace this with RMW_RET_INCORRECT_RMW_IMPLEMENTATION when refactored
     return NULL);
   return rmw_fastrtps_shared_cpp::__rmw_create_node(
-    eprosima_fastrtps_identifier, name, namespace_, domain_id, security_options);
+    eprosima_fastrtps_identifier, name, namespace_, domain_id, security_options, localhost_only);
 }
 
 rmw_ret_t

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_node.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_node.cpp
@@ -37,7 +37,8 @@ rmw_create_node(
   const char * name,
   const char * namespace_,
   size_t domain_id,
-  const rmw_node_security_options_t * security_options)
+  const rmw_node_security_options_t * security_options,
+  bool localhost_only)
 {
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(context, NULL);
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
@@ -47,7 +48,7 @@ rmw_create_node(
     // TODO(wjwwood): replace this with RMW_RET_INCORRECT_RMW_IMPLEMENTATION when refactored
     return NULL);
   return rmw_fastrtps_shared_cpp::__rmw_create_node(
-    eprosima_fastrtps_identifier, name, namespace_, domain_id, security_options);
+    eprosima_fastrtps_identifier, name, namespace_, domain_id, security_options, localhost_only);
 }
 
 rmw_ret_t

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/rmw_common.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/rmw_common.hpp
@@ -89,7 +89,8 @@ __rmw_create_node(
   const char * name,
   const char * namespace_,
   size_t domain_id,
-  const rmw_node_security_options_t * security_options);
+  const rmw_node_security_options_t * security_options,
+  bool localhost_only);
 
 RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t

--- a/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
@@ -241,9 +241,7 @@ __rmw_create_node(
   // since the participant name is not part of the DDS spec
   participantAttrs.rtps.setName(name);
 
-  char * allowed_hosts = NULL;
-  const rmw_ret_t ret_host = rmw_allowed_hosts(allowed_hosts);
-  if (ret_host == RMW_LOCAL_HOST_ENABLED) {
+  if (rmw_local_host_only()) {
     Locator_t local_network_interface_locator;
     static const std::string local_ip_name("127.0.0.1");
     local_network_interface_locator.kind = 1;
@@ -252,10 +250,6 @@ __rmw_create_node(
     participantAttrs.rtps.builtin.metatrafficUnicastLocatorList.push_back(
       local_network_interface_locator);
     participantAttrs.rtps.builtin.initialPeersList.push_back(local_network_interface_locator);
-    free(allowed_hosts);
-  } else if (ret_host == RMW_INVALID_ALLOWED_HOSTS) {
-    RMW_SET_ERROR_MSG("an invalid host was provided");
-    return nullptr;
   }
   bool leave_middleware_default_qos = false;
   const char * env_var = "RMW_FASTRTPS_USE_QOS_FROM_XML";

--- a/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
@@ -22,7 +22,6 @@
 
 #include "rmw/allocators.h"
 #include "rmw/error_handling.h"
-#include "rmw/localhost.h"
 #include "rmw/impl/cpp/macros.hpp"
 #include "rmw/rmw.h"
 
@@ -221,7 +220,8 @@ __rmw_create_node(
   const char * name,
   const char * namespace_,
   size_t domain_id,
-  const rmw_node_security_options_t * security_options)
+  const rmw_node_security_options_t * security_options,
+  bool localhost_only)
 {
   if (!name) {
     RMW_SET_ERROR_MSG("name is null");
@@ -241,7 +241,7 @@ __rmw_create_node(
   // since the participant name is not part of the DDS spec
   participantAttrs.rtps.setName(name);
 
-  if (rmw_localhost_only()) {
+  if (localhost_only) {
     Locator_t local_network_interface_locator;
     static const std::string local_ip_name("127.0.0.1");
     local_network_interface_locator.kind = 1;

--- a/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
@@ -22,7 +22,7 @@
 
 #include "rmw/allocators.h"
 #include "rmw/error_handling.h"
-#include "rmw/host.h"
+#include "rmw/localhost.h"
 #include "rmw/impl/cpp/macros.hpp"
 #include "rmw/rmw.h"
 
@@ -241,7 +241,7 @@ __rmw_create_node(
   // since the participant name is not part of the DDS spec
   participantAttrs.rtps.setName(name);
 
-  if (rmw_local_host_only()) {
+  if (rmw_localhost_only()) {
     Locator_t local_network_interface_locator;
     static const std::string local_ip_name("127.0.0.1");
     local_network_interface_locator.kind = 1;


### PR DESCRIPTION
PR to implement [network traffic restriction for localhost](https://github.com/ros2/ros2/issues/798). There are no test yet since this is a mock open for implementation discussion. Connected to [rmw](https://github.com/ros2/rmw/pull/190)

- Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=8441)](https://ci.ros2.org/job/ci_linux/8441/)
- Arch [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=4343)](https://ci.ros2.org/job/ci_linux-aarch64/4343/)
- Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=8352)](https://ci.ros2.org/job/ci_windows/8352/)
- OSX [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6866)](https://ci.ros2.org/job/ci_osx/6866/)