### PR TITLE
Enhance TopicCache to include QoS Policies of publishers and subscribers

### DIFF
--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
@@ -169,8 +169,11 @@ public:
     {
       std::lock_guard<std::mutex> guard(topic_cache.getMutex());
       if (is_alive) {
-        trigger = topic_cache().addTopic(proxyData.RTPSParticipantKey(),
-            proxyData.topicName().to_string(), proxyData.typeName().to_string());
+        trigger = topic_cache().addTopic(
+          proxyData.RTPSParticipantKey(),
+          proxyData.topicName().to_string(),
+          proxyData.typeName().to_string(),
+          proxyData.m_qos);
       } else {
         trigger = topic_cache().removeTopic(proxyData.RTPSParticipantKey(),
             proxyData.topicName().to_string(), proxyData.typeName().to_string());

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/qos_converter.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/qos_converter.hpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2018 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 
-#ifndef QOS_CONVERTER_HPP_
-#define QOS_CONVERTER_HPP_
+#ifndef RMW_FASTRTPS_SHARED_CPP__QOS_CONVERTER_HPP_
+#define RMW_FASTRTPS_SHARED_CPP__QOS_CONVERTER_HPP_
 
 #include "rmw/types.h"
 
@@ -83,4 +83,4 @@ dds_qos_to_rmw_qos(
   qos->liveliness_lease_duration.nsec = dds_qos.m_liveliness.lease_duration.nanosec;
 }
 
-#endif  // QOS_CONVERTER_HPP_
+#endif  // RMW_FASTRTPS_SHARED_CPP__QOS_CONVERTER_HPP_

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/topic_cache.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/topic_cache.hpp
@@ -21,6 +21,7 @@
 #include <set>
 #include <sstream>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -28,6 +29,7 @@
 #include "fastrtps/participant/Participant.h"
 #include "fastrtps/rtps/common/Guid.h"
 #include "fastrtps/rtps/common/InstanceHandle.h"
+#include "qos_converter.hpp"
 #include "rcpputils/thread_safety_annotations.hpp"
 #include "rcutils/logging_macros.h"
 
@@ -39,19 +41,20 @@ typedef eprosima::fastrtps::rtps::GUID_t GUID_t;
 class TopicCache
 {
 private:
-  typedef std::map<GUID_t,
-      std::unordered_map<std::string, std::vector<std::string>>> ParticipantTopicMap;
   typedef std::unordered_map<std::string, std::vector<std::string>> TopicToTypes;
+  typedef std::map<GUID_t, TopicToTypes> ParticipantTopicMap;
+  typedef std::vector<std::tuple<GUID_t, std::string, rmw_qos_profile_t>> TopicData;
+  typedef std::unordered_map<std::string, TopicData> TopicNameToTopicData;
 
   /**
-   * Map of topic names to a vector of types that topic may use.
+   * Map of topic names to TopicData. Where topic data is vector of tuples containing
+   * participant GUID, topic type and the qos policy of the respective participant.
    * Topics here are represented as one to many, DDS XTypes 1.2
    * specifies application code 'generally' uses a 1-1 relationship.
    * However, generic services such as logger and monitor, can discover
    * multiple types on the same topic.
-   *
    */
-  TopicToTypes topic_to_types_;
+  TopicNameToTopicData topic_name_to_topic_data_;
 
   /**
    * Map of participant GUIDS to a set of topic-type.
@@ -59,11 +62,27 @@ private:
   ParticipantTopicMap participant_to_topics_;
 
   /**
-   * Helper function to initialize a topic vector.
+   * Helper function to initialize an empty TopicData for a topic name.
    *
-   * @param topic_name
+   * @param topic_name the topic name for which the TopicNameToTopicData map should be initialised.
+   * @param topic_name_to_topic_data the map to initialise.
    */
-  void initializeTopic(const std::string & topic_name, TopicToTypes & topic_to_types)
+  void initializeTopicDataMap(
+    const std::string & topic_name,
+    TopicNameToTopicData & topic_name_to_topic_data)
+  {
+    if (topic_name_to_topic_data.find(topic_name) == topic_name_to_topic_data.end()) {
+      topic_name_to_topic_data[topic_name] = TopicData();
+    }
+  }
+
+  /**
+    * Helper function to initialize a topic vector.
+    *
+    * @param topic_name the topic name for which the TopicToTypes map should be initialised.
+    * @param topic_to_types the map to initialise.
+    */
+  void initializeTopicTypesMap(const std::string & topic_name, TopicToTypes & topic_to_types)
   {
     if (topic_to_types.find(topic_name) == topic_to_types.end()) {
       topic_to_types[topic_name] = std::vector<std::string>();
@@ -89,9 +108,16 @@ public:
   /**
    * @return a map of topic name to the vector of topic types used.
    */
-  const TopicToTypes & getTopicToTypes() const
+  const TopicToTypes getTopicToTypes() const
   {
-    return topic_to_types_;
+    TopicToTypes topic_to_types;
+    for (const auto & it : topic_name_to_topic_data_) {
+      topic_to_types[it.first] = std::vector<std::string>();
+      for (const auto & mit : it.second) {
+        topic_to_types[it.first].push_back(std::get<1>(mit));
+      }
+    }
+    return topic_to_types;
   }
 
   /**
@@ -103,6 +129,14 @@ public:
   }
 
   /**
+   * @return a map of topic name to a vector of GUID_t, type name and qos profile tuple.
+   */
+  const TopicNameToTopicData & getTopicNameToTopicData() const
+  {
+    return topic_name_to_topic_data_;
+  }
+
+  /**
    * Add a topic based on discovery.
    *
    * @param rtpsParticipantKey
@@ -110,15 +144,17 @@ public:
    * @param type_name
    * @return true if a change has been recorded
    */
+  template<class T>
   bool addTopic(
     const eprosima::fastrtps::rtps::InstanceHandle_t & rtpsParticipantKey,
     const std::string & topic_name,
-    const std::string & type_name)
+    const std::string & type_name,
+    const T & dds_qos)
   {
-    initializeTopic(topic_name, topic_to_types_);
+    initializeTopicDataMap(topic_name, topic_name_to_topic_data_);
     auto guid = iHandle2GUID(rtpsParticipantKey);
     initializeParticipantMap(participant_to_topics_, guid);
-    initializeTopic(topic_name, participant_to_topics_[guid]);
+    initializeTopicTypesMap(topic_name, participant_to_topics_[guid]);
     if (rcutils_logging_logger_is_enabled_for("rmw_fastrtps_shared_cpp",
       RCUTILS_LOG_SEVERITY_DEBUG))
     {
@@ -129,7 +165,9 @@ public:
         "Adding topic '%s' with type '%s' for node '%s'",
         topic_name.c_str(), type_name.c_str(), guid_stream.str().c_str());
     }
-    topic_to_types_[topic_name].push_back(type_name);
+    auto qos_profile = rmw_qos_profile_t();
+    dds_qos_to_rmw_qos(dds_qos, &qos_profile);
+    topic_name_to_topic_data_[topic_name].push_back(std::make_tuple(guid, type_name, qos_profile));
     participant_to_topics_[guid][topic_name].push_back(type_name);
     return true;
   }
@@ -147,22 +185,26 @@ public:
     const std::string & topic_name,
     const std::string & type_name)
   {
-    if (topic_to_types_.find(topic_name) == topic_to_types_.end()) {
+    if (topic_name_to_topic_data_.find(topic_name) == topic_name_to_topic_data_.end()) {
       RCUTILS_LOG_DEBUG_NAMED(
         "rmw_fastrtps_shared_cpp",
         "unexpected removal on topic '%s' with type '%s'",
         topic_name.c_str(), type_name.c_str());
       return false;
     }
+    auto guid = iHandle2GUID(rtpsParticipantKey);
     {
-      auto & type_vec = topic_to_types_[topic_name];
-      type_vec.erase(std::find(type_vec.begin(), type_vec.end(), type_name));
+      auto & type_vec = topic_name_to_topic_data_[topic_name];
+      type_vec.erase(std::find_if(type_vec.begin(), type_vec.end(),
+        [type_name, guid](const auto & topic_info) {
+          return type_name.compare(std::get<1>(topic_info)) == 0 &&
+          guid == std::get<0>(topic_info);
+        }));
       if (type_vec.empty()) {
-        topic_to_types_.erase(topic_name);
+        topic_name_to_topic_data_.erase(topic_name);
       }
     }
 
-    auto guid = iHandle2GUID(rtpsParticipantKey);
     auto guid_topics_pair = participant_to_topics_.find(guid);
     if (guid_topics_pair != participant_to_topics_.end() &&
       guid_topics_pair->second.find(topic_name) != guid_topics_pair->second.end())
@@ -180,6 +222,7 @@ public:
         "rmw_fastrtps_shared_cpp",
         "Unable to remove topic, does not exist '%s' with type '%s'",
         topic_name.c_str(), type_name.c_str());
+      return false;
     }
     return true;
   }

--- a/rmw_fastrtps_shared_cpp/src/qos.cpp
+++ b/rmw_fastrtps_shared_cpp/src/qos.cpp
@@ -14,7 +14,7 @@
 
 #include <limits>
 
-#include "qos_converter.hpp"
+#include "rmw_fastrtps_shared_cpp/qos_converter.hpp"
 #include "rmw_fastrtps_shared_cpp/qos.hpp"
 
 #include "fastrtps/attributes/PublisherAttributes.h"

--- a/rmw_fastrtps_shared_cpp/test/CMakeLists.txt
+++ b/rmw_fastrtps_shared_cpp/test/CMakeLists.txt
@@ -1,6 +1,13 @@
 find_package(ament_cmake_gtest REQUIRED)
+
 ament_add_gtest(test_dds_attributes_to_rmw_qos test_dds_attributes_to_rmw_qos.cpp)
 if(TARGET test_dds_attributes_to_rmw_qos)
     ament_target_dependencies(test_dds_attributes_to_rmw_qos)
     target_link_libraries(test_dds_attributes_to_rmw_qos ${PROJECT_NAME})
+endif()
+
+ament_add_gtest(test_topic_cache test_topic_cache.cpp)
+if(TARGET test_topic_cache)
+    ament_target_dependencies(test_topic_cache)
+    target_link_libraries(test_topic_cache ${PROJECT_NAME})
 endif()

--- a/rmw_fastrtps_shared_cpp/test/test_topic_cache.cpp
+++ b/rmw_fastrtps_shared_cpp/test/test_topic_cache.cpp
@@ -1,0 +1,88 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gtest/gtest.h"
+
+#include "fastrtps/qos/ReaderQos.h"
+#include "fastrtps/qos/WriterQos.h"
+#include "fastrtps/rtps/common/InstanceHandle.h"
+
+#include "rmw/types.h"
+#include "rmw_fastrtps_shared_cpp/topic_cache.hpp"
+
+using eprosima::fastrtps::WriterQos;
+using eprosima::fastrtps::ReaderQos;
+using eprosima::fastrtps::rtps::GUID_t;
+using eprosima::fastrtps::rtps::GuidPrefix_t;
+using eprosima::fastrtps::rtps::InstanceHandle_t;
+
+TEST(TopicCacheTest, test_topic_cache_add_topic) {
+  // Create an instance handler
+  const auto guid = GUID_t(GuidPrefix_t(), 1);
+  InstanceHandle_t instance_handler = InstanceHandle_t();
+  instance_handler = guid;
+
+  // Create an instance of TopicCache
+  auto topic_cache = TopicCache();
+  // Add Topic
+  bool did_add = topic_cache.addTopic(instance_handler, "TestTopic", "TestType");
+  // Verify that the returned value was true
+  EXPECT_TRUE(did_add);
+
+  // Verify that there exists a value of the guid in the map
+  const auto & it = topic_cache.getTopicToTypes().find("TestTopic");
+  ASSERT_FALSE(it == topic_cache.getTopicToTypes().end());
+
+  // Verify that the object returned from the map is indeed the one expected
+  const auto topic_types = it->second;
+  // Verify that this vector only has one element
+  EXPECT_EQ(topic_types.size(), 1u);
+  // Verify the topic topic is present in the vector
+  EXPECT_TRUE(std::find(topic_types.begin(), topic_types.end(), "TestType") != topic_types.end());
+}
+
+TEST(TopicCacheTest, test_topic_cache_remove_policy_element_exists) {
+  // Create an instance handler
+  const auto guid = GUID_t(GuidPrefix_t(), 2);
+  InstanceHandle_t instance_handler = InstanceHandle_t();
+  instance_handler = guid;
+
+  // Create an instance of TopicCache
+  auto topic_cache = TopicCache();
+  // add topic
+  topic_cache.addTopic(instance_handler, "TestTopic", "TestType");
+  // remove topic
+  auto did_remove = topic_cache.removeTopic(instance_handler, "TestTopic", "TestType");
+  // Assert that the return was true
+  ASSERT_TRUE(did_remove);
+
+  // Verify that there does not exist a value for the guid in the map
+  const auto & it = topic_cache.getTopicToTypes().find("TestTopic");
+  ASSERT_TRUE(it == topic_cache.getTopicToTypes().end());
+}
+
+TEST(TopicCacheTest, test_topic_cache_remove_policy_element_does_not_exist) {
+  // Create an instance handler
+  const auto guid = GUID_t(GuidPrefix_t(), 3);
+  InstanceHandle_t instance_handler = InstanceHandle_t();
+  instance_handler = guid;
+
+  // Create an instance of TopicCache
+  auto topic_cache = TopicCache();
+  // add topic
+  topic_cache.addTopic(instance_handler, "TestTopic", "TestType");
+  // Assert that the return was false
+  auto const did_remove = topic_cache.removeTopic(instance_handler, "NewTestTopic", "TestType");
+  ASSERT_FALSE(did_remove);
+}


### PR DESCRIPTION
As per discussion [here](https://github.com/ros2/rmw_fastrtps/issues/319). The `topic_cache` class needs to cache the QoS policies of participants along with topic name and types; this is so that the feature request [here](https://github.com/ros2/rmw/issues/151) can be implemented.

Summary of changes:
- Modified topic_cache to include qos policies: 
- Modified call to topic_cache.addTopic at custom_participant_info.hpp
- Wrote tests for topic_cache

Connected to [aws-roadmap#83](https://github.com/ros-security/aws-roadmap/issues/83)

Note: `colcon build --packages-up-to rmw_fastrtps_shared_cpp && colcon test --packages-select rmw_fastrtps_shared_cpp` builds and passes without errors or failures.

Signed-off-by: Jaison Titus <jaisontj92@gmail.com>

