### PR TITLE
Stubs for rmw_get_publishers_info_by_topic and rmw_get_subscriptions_info_by_topic

### DIFF
--- a/rmw_fastrtps_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_cpp/CMakeLists.txt
@@ -81,6 +81,7 @@ add_library(rmw_fastrtps_cpp
   src/rmw_wait_set.cpp
   src/serialization_format.cpp
   src/type_support_common.cpp
+  src/rmw_get_topic_info.cpp
 )
 target_link_libraries(rmw_fastrtps_cpp
   fastcdr fastrtps)

--- a/rmw_fastrtps_cpp/src/rmw_get_topic_info.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_get_topic_info.cpp
@@ -1,0 +1,45 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rmw/rmw.h"
+#include "rmw/types.h"
+#include "rmw_fastrtps_shared_cpp/rmw_common.hpp"
+#include "rmw_fastrtps_cpp/identifier.hpp"
+
+extern "C"
+{
+rmw_ret_t
+rmw_get_publishers_info_by_topic(
+  const rmw_node_t * node,
+  rcutils_allocator_t * allocator,
+  const char * topic_name,
+  bool no_mangle,
+  rmw_topic_info_array_t * publishers_info)
+{
+  return rmw_fastrtps_shared_cpp::__rmw_get_publishers_info_by_topic(
+    eprosima_fastrtps_identifier, node, allocator, topic_name, no_mangle, publishers_info);
+}
+
+rmw_ret_t
+rmw_get_subscriptions_info_by_topic(
+  const rmw_node_t * node,
+  rcutils_allocator_t * allocator,
+  const char * topic_name,
+  bool no_mangle,
+  rmw_topic_info_array_t * subscriptions_info)
+{
+  return rmw_fastrtps_shared_cpp::__rmw_get_subscriptions_info_by_topic(
+    eprosima_fastrtps_identifier, node, allocator, topic_name, no_mangle, subscriptions_info);
+}
+}  // extern "C"

--- a/rmw_fastrtps_dynamic_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_dynamic_cpp/CMakeLists.txt
@@ -85,6 +85,7 @@ add_library(rmw_fastrtps_dynamic_cpp
   src/rmw_wait_set.cpp
   src/type_support_common.cpp
   src/serialization_format.cpp
+  src/rmw_get_topic_info.cpp
 )
 target_link_libraries(rmw_fastrtps_dynamic_cpp
   fastcdr fastrtps)

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_get_topic_info.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_get_topic_info.cpp
@@ -1,0 +1,45 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rmw/rmw.h"
+#include "rmw/types.h"
+#include "rmw_fastrtps_shared_cpp/rmw_common.hpp"
+#include "rmw_fastrtps_dynamic_cpp/identifier.hpp"
+
+extern "C"
+{
+rmw_ret_t
+rmw_get_publishers_info_by_topic(
+  const rmw_node_t * node,
+  rcutils_allocator_t * allocator,
+  const char * topic_name,
+  bool no_mangle,
+  rmw_topic_info_array_t * publishers_info)
+{
+  return rmw_fastrtps_shared_cpp::__rmw_get_publishers_info_by_topic(
+    eprosima_fastrtps_identifier, node, allocator, topic_name, no_mangle, publishers_info);
+}
+
+rmw_ret_t
+rmw_get_subscriptions_info_by_topic(
+  const rmw_node_t * node,
+  rcutils_allocator_t * allocator,
+  const char * topic_name,
+  bool no_mangle,
+  rmw_topic_info_array_t * subscriptions_info)
+{
+  return rmw_fastrtps_shared_cpp::__rmw_get_subscriptions_info_by_topic(
+    eprosima_fastrtps_identifier, node, allocator, topic_name, no_mangle, subscriptions_info);
+}
+}  // extern "C"

--- a/rmw_fastrtps_shared_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_shared_cpp/CMakeLists.txt
@@ -75,6 +75,7 @@ add_library(rmw_fastrtps_shared_cpp
   src/rmw_wait.cpp
   src/rmw_wait_set.cpp
   src/TypeSupport_impl.cpp
+  src/rmw_get_topic_info.cpp
 )
 
 target_link_libraries(rmw_fastrtps_shared_cpp

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/rmw_common.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/rmw_common.hpp
@@ -348,6 +348,26 @@ RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_destroy_wait_set(const char * identifier, rmw_wait_set_t * wait_set);
 
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
+rmw_ret_t
+__rmw_get_publishers_info_by_topic(
+  const char * identifier,
+  const rmw_node_t * node,
+  rcutils_allocator_t * allocator,
+  const char * topic_name,
+  bool no_mangle,
+  rmw_topic_info_array_t * publishers_info);
+
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
+rmw_ret_t
+__rmw_get_subscriptions_info_by_topic(
+  const char * identifier,
+  const rmw_node_t * node,
+  rcutils_allocator_t * allocator,
+  const char * topic_name,
+  bool no_mangle,
+  rmw_topic_info_array_t * subscriptions_info);
+
 }  // namespace rmw_fastrtps_shared_cpp
 
 #endif  // RMW_FASTRTPS_SHARED_CPP__RMW_COMMON_HPP_

--- a/rmw_fastrtps_shared_cpp/src/rmw_get_topic_info.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_get_topic_info.cpp
@@ -1,0 +1,42 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rmw_fastrtps_shared_cpp/rmw_common.hpp"
+
+namespace rmw_fastrtps_shared_cpp
+{
+rmw_ret_t
+__rmw_get_publishers_info_by_topic(
+  const char * identifier,
+  const rmw_node_t * node,
+  rcutils_allocator_t * allocator,
+  const char * topic_name,
+  bool no_mangle,
+  rmw_topic_info_array_t * publishers_info)
+{
+  return RMW_RET_UNSUPPORTED;
+}
+
+rmw_ret_t
+__rmw_get_subscriptions_info_by_topic(
+  const char * identifier,
+  const rmw_node_t * node,
+  rcutils_allocator_t * allocator,
+  const char * topic_name,
+  bool no_mangle,
+  rmw_topic_info_array_t * subscriptions_info)
+{
+  return RMW_RET_UNSUPPORTED;
+}
+}  // namespace rmw_fastrtps_shared_cpp


### PR DESCRIPTION
Leaving stubs for `rmw_get_publishers_info_by_topic` and `rmw_get_subscriptions_info_by_topic` as per discussion [here](https://github.com/ros2/rmw/pull/186#issuecomment-542874852)

Related to - [aws-roadmap#94](https://app.zenhub.com/workspaces/aws-robotics-open-source-roadmap-5d9662bf4e1ec400011c53c6/issues/ros-security/aws-roadmap/94)