### PR TITLE
Load profiles based on topic names

### DIFF
--- a/rmw_fastrtps_cpp/src/publisher.cpp
+++ b/rmw_fastrtps_cpp/src/publisher.cpp
@@ -17,6 +17,7 @@
 
 #include "fastrtps/Domain.h"
 #include "fastrtps/participant/Participant.h"
+#include "fastrtps/xmlparser/XMLProfileManager.h"
 
 #include "rcutils/error_handling.h"
 #include "rcutils/macros.h"
@@ -44,6 +45,7 @@
 using Domain = eprosima::fastrtps::Domain;
 using Participant = eprosima::fastrtps::Participant;
 using TopicDataType = eprosima::fastrtps::TopicDataType;
+using XMLProfileManager = eprosima::fastrtps::xmlparser::XMLProfileManager;
 
 rmw_publisher_t *
 rmw_fastrtps_cpp::create_publisher(
@@ -104,14 +106,17 @@ rmw_fastrtps_cpp::create_publisher(
 
   CustomPublisherInfo * info = nullptr;
   rmw_publisher_t * rmw_publisher = nullptr;
-  eprosima::fastrtps::PublisherAttributes publisherParam;
 
   if (!is_valid_qos(*qos_policies)) {
     return nullptr;
   }
 
-  // Load default XML profile.
-  Domain::getDefaultPublisherAttributes(publisherParam);
+  // If the user defined an XML file via env "FASTRTPS_DEFAULT_PROFILES_FILE", try to load
+  // publisher which profile name matches with topic_name. If such profile does not exist,
+  // then use the default attributes.
+  eprosima::fastrtps::PublisherAttributes publisherParam;
+  Domain::getDefaultPublisherAttributes(publisherParam);  // Loads the XML file if not loaded
+  XMLProfileManager::fillPublisherAttributes(topic_name, publisherParam, false);
 
   info = new (std::nothrow) CustomPublisherInfo();
   if (!info) {

--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -119,7 +119,6 @@ rmw_create_client(
       delete info;
     });
 
-  info = new CustomClientInfo();
   info->participant_ = participant;
   info->typesupport_identifier_ = type_support->typesupport_identifier;
   info->request_publisher_matched_count_ = 0;
@@ -167,22 +166,19 @@ rmw_create_client(
     _register_type(participant, info->response_type_support_);
   }
 
-  // If FASTRTPS_DEFAULT_PROFILES_FILE defined, fill subscriber attributes with a subscriber profile located
-  // based of topic name defined by _create_topic_name(). If no profile is found, a search with profile_name "client"
-  // is attempted. Else, use the default attributes.
+  // If FASTRTPS_DEFAULT_PROFILES_FILE defined, fill subscriber attributes with a subscriber profile
+  // located based of topic name defined by _create_topic_name(). If no profile is found, a search
+  // with profile_name "client" is attempted. Else, use the default attributes.
   std::string topic_name_fallback = "client";
   eprosima::fastrtps::SubscriberAttributes subscriberParam;
   eprosima::fastrtps::fixed_string<255> sub_topic_name = _create_topic_name(
     qos_policies, ros_service_response_prefix, service_name, "Reply");
   Domain::getDefaultSubscriberAttributes(subscriberParam);
 
-  if (std::getenv("FASTRTPS_DEFAULT_PROFILES_FILE") != nullptr)
+  if (XMLProfileManager::fillSubscriberAttributes(
+    sub_topic_name.to_string(), subscriberParam, false) != XMLP_ret::XML_OK)
   {
-    if (XMLProfileManager::fillSubscriberAttributes(sub_topic_name.to_string(), subscriberParam) !=
-      XMLP_ret::XML_OK)
-    {
-      XMLProfileManager::fillSubscriberAttributes(topic_name_fallback, subscriberParam);
-    }
+    XMLProfileManager::fillSubscriberAttributes(topic_name_fallback, subscriberParam, false);
   }
 
   if (!participant_info->leave_middleware_default_qos) {
@@ -194,21 +190,18 @@ rmw_create_client(
   subscriberParam.topic.topicDataType = response_type_name;
   subscriberParam.topic.topicName = sub_topic_name;
 
-  // If FASTRTPS_DEFAULT_PROFILES_FILE defined, fill publisher attributes with a publisher profile located
-  // based of topic name defined by _create_topic_name(). If no profile is found, a search with profile_name "client"
-  // is attempted. Else, use the default attributes.
+  // If FASTRTPS_DEFAULT_PROFILES_FILE defined, fill publisher attributes with a publisher profile
+  // located based of topic name defined by _create_topic_name(). If no profile is found, a search
+  // with profile_name "client" is attempted. Else, use the default attributes.
   eprosima::fastrtps::fixed_string<255> pub_topic_name = _create_topic_name(
     qos_policies, ros_service_requester_prefix, service_name, "Request");
   eprosima::fastrtps::PublisherAttributes publisherParam;
   Domain::getDefaultPublisherAttributes(publisherParam);
 
-  if (std::getenv("FASTRTPS_DEFAULT_PROFILES_FILE") != nullptr)
+  if (XMLProfileManager::fillPublisherAttributes(
+    pub_topic_name.to_string(), publisherParam, false) != XMLP_ret::XML_OK)
   {
-    if (XMLProfileManager::fillPublisherAttributes(pub_topic_name.to_string(), publisherParam) !=
-      XMLP_ret::XML_OK)
-    {
-      XMLProfileManager::fillPublisherAttributes(topic_name_fallback, publisherParam);
-    }
+    XMLProfileManager::fillPublisherAttributes(topic_name_fallback, publisherParam, false);
   }
 
   if (!participant_info->leave_middleware_default_qos) {

--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -176,7 +176,7 @@ rmw_create_client(
   Domain::getDefaultSubscriberAttributes(subscriberParam);
 
   if (XMLProfileManager::fillSubscriberAttributes(
-    sub_topic_name.to_string(), subscriberParam, false) != XMLP_ret::XML_OK)
+      sub_topic_name.to_string(), subscriberParam, false) != XMLP_ret::XML_OK)
   {
     XMLProfileManager::fillSubscriberAttributes(topic_name_fallback, subscriberParam, false);
   }
@@ -199,7 +199,7 @@ rmw_create_client(
   Domain::getDefaultPublisherAttributes(publisherParam);
 
   if (XMLProfileManager::fillPublisherAttributes(
-    pub_topic_name.to_string(), publisherParam, false) != XMLP_ret::XML_OK)
+      pub_topic_name.to_string(), publisherParam, false) != XMLP_ret::XML_OK)
   {
     XMLProfileManager::fillPublisherAttributes(topic_name_fallback, publisherParam, false);
   }

--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -167,7 +167,7 @@ rmw_create_client(
     _register_type(participant, info->response_type_support_);
   }
 
-  // If FASTRTPS_DEFAULT_PROFILES_FILE defined, fill subscriber attributes with a subscriber profile profile located
+  // If FASTRTPS_DEFAULT_PROFILES_FILE defined, fill subscriber attributes with a subscriber profile located
   // based of topic name defined by _create_topic_name(). If no profile is found, a search with profile_name "client"
   // is attempted. Else, use the default attributes.
   std::string topic_name_fallback = "client";
@@ -194,7 +194,7 @@ rmw_create_client(
   subscriberParam.topic.topicDataType = response_type_name;
   subscriberParam.topic.topicName = sub_topic_name;
 
-  // If FASTRTPS_DEFAULT_PROFILES_FILE defined, fill publisher attributes with a publisher profile profile located
+  // If FASTRTPS_DEFAULT_PROFILES_FILE defined, fill publisher attributes with a publisher profile located
   // based of topic name defined by _create_topic_name(). If no profile is found, a search with profile_name "client"
   // is attempted. Else, use the default attributes.
   eprosima::fastrtps::fixed_string<255> pub_topic_name = _create_topic_name(

--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -36,9 +36,13 @@
 
 #include "./type_support_common.hpp"
 
+#include "fastrtps/xmlparser/XMLProfileManager.h"
+
 using Domain = eprosima::fastrtps::Domain;
 using Participant = eprosima::fastrtps::Participant;
 using TopicDataType = eprosima::fastrtps::TopicDataType;
+using XMLProfileManager = eprosima::fastrtps::xmlparser::XMLProfileManager;
+using XMLP_ret = eprosima::fastrtps::xmlparser::XMLP_ret;
 
 extern "C"
 {
@@ -114,6 +118,8 @@ rmw_create_client(
       }
       delete info;
     });
+
+  info = new CustomClientInfo();
   info->participant_ = participant;
   info->typesupport_identifier_ = type_support->typesupport_identifier;
   info->request_publisher_matched_count_ = 0;
@@ -161,8 +167,23 @@ rmw_create_client(
     _register_type(participant, info->response_type_support_);
   }
 
+  // If FASTRTPS_DEFAULT_PROFILES_FILE defined, fill subscriber attributes with a subscriber profile profile located
+  // based of topic name defined by _create_topic_name(). If no profile is found, a search with profile_name "client"
+  // is attempted. Else, use the default attributes.
+  std::string topic_name_fallback = "client";
   eprosima::fastrtps::SubscriberAttributes subscriberParam;
-  eprosima::fastrtps::PublisherAttributes publisherParam;
+  eprosima::fastrtps::fixed_string<255> sub_topic_name = _create_topic_name(
+    qos_policies, ros_service_response_prefix, service_name, "Reply");
+  Domain::getDefaultSubscriberAttributes(subscriberParam);
+
+  if (std::getenv("FASTRTPS_DEFAULT_PROFILES_FILE") != nullptr)
+  {
+    if (XMLProfileManager::fillSubscriberAttributes(sub_topic_name.to_string(), subscriberParam) !=
+      XMLP_ret::XML_OK)
+    {
+      XMLProfileManager::fillSubscriberAttributes(topic_name_fallback, subscriberParam);
+    }
+  }
 
   if (!participant_info->leave_middleware_default_qos) {
     subscriberParam.historyMemoryPolicy =
@@ -171,8 +192,24 @@ rmw_create_client(
 
   subscriberParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
   subscriberParam.topic.topicDataType = response_type_name;
-  subscriberParam.topic.topicName = _create_topic_name(
-    qos_policies, ros_service_response_prefix, service_name, "Reply");
+  subscriberParam.topic.topicName = sub_topic_name;
+
+  // If FASTRTPS_DEFAULT_PROFILES_FILE defined, fill publisher attributes with a publisher profile profile located
+  // based of topic name defined by _create_topic_name(). If no profile is found, a search with profile_name "client"
+  // is attempted. Else, use the default attributes.
+  eprosima::fastrtps::fixed_string<255> pub_topic_name = _create_topic_name(
+    qos_policies, ros_service_requester_prefix, service_name, "Request");
+  eprosima::fastrtps::PublisherAttributes publisherParam;
+  Domain::getDefaultPublisherAttributes(publisherParam);
+
+  if (std::getenv("FASTRTPS_DEFAULT_PROFILES_FILE") != nullptr)
+  {
+    if (XMLProfileManager::fillPublisherAttributes(pub_topic_name.to_string(), publisherParam) !=
+      XMLP_ret::XML_OK)
+    {
+      XMLProfileManager::fillPublisherAttributes(topic_name_fallback, publisherParam);
+    }
+  }
 
   if (!participant_info->leave_middleware_default_qos) {
     publisherParam.historyMemoryPolicy =
@@ -186,8 +223,7 @@ rmw_create_client(
 
   publisherParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
   publisherParam.topic.topicDataType = request_type_name;
-  publisherParam.topic.topicName = _create_topic_name(
-    qos_policies, ros_service_requester_prefix, service_name, "Request");
+  publisherParam.topic.topicName = pub_topic_name;
 
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_fastrtps_cpp",

--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -177,7 +177,7 @@ rmw_create_service(
     _register_type(participant, info->response_type_support_);
   }
 
-  // If FASTRTPS_DEFAULT_PROFILES_FILE defined, fill subscriber attributes with a subscriber profile profile located
+  // If FASTRTPS_DEFAULT_PROFILES_FILE defined, fill subscriber attributes with a subscriber profile located
   // based of topic name defined by _create_topic_name(). If no profile is found, a search with profile_name "service"
   // is attempted. Else, use the default attributes.
   std::string topic_name_fallback = "service";
@@ -203,7 +203,7 @@ rmw_create_service(
   subscriberParam.topic.topicDataType = request_type_name;
   subscriberParam.topic.topicName = sub_topic_name;
 
-  // If FASTRTPS_DEFAULT_PROFILES_FILE defined, fill publisher attributes with a publisher profile profile located
+  // If FASTRTPS_DEFAULT_PROFILES_FILE defined, fill publisher attributes with a publisher profile located
   // based of topic name defined by _create_topic_name(). If no profile is found, a search with profile_name "service"
   // is attempted. Else, use the default attributes.
   eprosima::fastrtps::fixed_string<255> pub_topic_name = _create_topic_name(

--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -186,7 +186,7 @@ rmw_create_service(
   Domain::getDefaultSubscriberAttributes(subscriberParam);
 
   if (XMLProfileManager::fillSubscriberAttributes(
-    sub_topic_name.to_string(), subscriberParam, false) != XMLP_ret::XML_OK)
+      sub_topic_name.to_string(), subscriberParam, false) != XMLP_ret::XML_OK)
   {
     XMLProfileManager::fillSubscriberAttributes(topic_name_fallback, subscriberParam, false);
   }
@@ -208,7 +208,7 @@ rmw_create_service(
   Domain::getDefaultPublisherAttributes(publisherParam);
 
   if (XMLProfileManager::fillPublisherAttributes(
-    pub_topic_name.to_string(), publisherParam, false) != XMLP_ret::XML_OK)
+      pub_topic_name.to_string(), publisherParam, false) != XMLP_ret::XML_OK)
   {
     XMLProfileManager::fillPublisherAttributes(topic_name_fallback, publisherParam, false);
   }

--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -131,7 +131,6 @@ rmw_create_service(
       delete info;
     });
 
-  info = new CustomServiceInfo();
   info->participant_ = participant;
   info->typesupport_identifier_ = type_support->typesupport_identifier;
 
@@ -177,22 +176,19 @@ rmw_create_service(
     _register_type(participant, info->response_type_support_);
   }
 
-  // If FASTRTPS_DEFAULT_PROFILES_FILE defined, fill subscriber attributes with a subscriber profile located
-  // based of topic name defined by _create_topic_name(). If no profile is found, a search with profile_name "service"
-  // is attempted. Else, use the default attributes.
+  // If FASTRTPS_DEFAULT_PROFILES_FILE defined, fill subscriber attributes with a subscriber profile
+  // located based of topic name defined by _create_topic_name(). If no profile is found, a search
+  // with profile_name "service" is attempted. Else, use the default attributes.
   std::string topic_name_fallback = "service";
   eprosima::fastrtps::SubscriberAttributes subscriberParam;
   eprosima::fastrtps::fixed_string<255> sub_topic_name = _create_topic_name(
     qos_policies, ros_service_requester_prefix, service_name, "Request");
   Domain::getDefaultSubscriberAttributes(subscriberParam);
 
-  if (std::getenv("FASTRTPS_DEFAULT_PROFILES_FILE") != nullptr)
+  if (XMLProfileManager::fillSubscriberAttributes(
+    sub_topic_name.to_string(), subscriberParam, false) != XMLP_ret::XML_OK)
   {
-    if (XMLProfileManager::fillSubscriberAttributes(sub_topic_name.to_string(), subscriberParam) !=
-      XMLP_ret::XML_OK)
-    {
-      XMLProfileManager::fillSubscriberAttributes(topic_name_fallback, subscriberParam);
-    }
+    XMLProfileManager::fillSubscriberAttributes(topic_name_fallback, subscriberParam, false);
   }
 
   if (!impl->leave_middleware_default_qos) {
@@ -203,21 +199,18 @@ rmw_create_service(
   subscriberParam.topic.topicDataType = request_type_name;
   subscriberParam.topic.topicName = sub_topic_name;
 
-  // If FASTRTPS_DEFAULT_PROFILES_FILE defined, fill publisher attributes with a publisher profile located
-  // based of topic name defined by _create_topic_name(). If no profile is found, a search with profile_name "service"
-  // is attempted. Else, use the default attributes.
+  // If FASTRTPS_DEFAULT_PROFILES_FILE defined, fill publisher attributes with a publisher profile
+  // located based of topic name defined by _create_topic_name(). If no profile is found, a search
+  // with profile_name "service" is attempted. Else, use the default attributes.
   eprosima::fastrtps::fixed_string<255> pub_topic_name = _create_topic_name(
     qos_policies, ros_service_response_prefix, service_name, "Reply");
   eprosima::fastrtps::PublisherAttributes publisherParam;
   Domain::getDefaultPublisherAttributes(publisherParam);
 
-  if (std::getenv("FASTRTPS_DEFAULT_PROFILES_FILE") != nullptr)
+  if (XMLProfileManager::fillPublisherAttributes(
+    pub_topic_name.to_string(), publisherParam, false) != XMLP_ret::XML_OK)
   {
-    if (XMLProfileManager::fillPublisherAttributes(pub_topic_name.to_string(), publisherParam) !=
-      XMLP_ret::XML_OK)
-    {
-      XMLProfileManager::fillPublisherAttributes(topic_name_fallback, publisherParam);
-    }
+    XMLProfileManager::fillPublisherAttributes(topic_name_fallback, publisherParam, false);
   }
 
   if (!impl->leave_middleware_default_qos) {

--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -47,10 +47,14 @@
 
 #include "type_support_common.hpp"
 
+#include "fastrtps/xmlparser/XMLProfileManager.h"
+
 using Domain = eprosima::fastrtps::Domain;
 using Participant = eprosima::fastrtps::Participant;
 using TopicDataType = eprosima::fastrtps::TopicDataType;
 using CustomParticipantInfo = CustomParticipantInfo;
+using XMLProfileManager = eprosima::fastrtps::xmlparser::XMLProfileManager;
+using XMLP_ret = eprosima::fastrtps::xmlparser::XMLP_ret;
 
 extern "C"
 {
@@ -126,6 +130,8 @@ rmw_create_service(
       }
       delete info;
     });
+
+  info = new CustomServiceInfo();
   info->participant_ = participant;
   info->typesupport_identifier_ = type_support->typesupport_identifier;
 
@@ -171,8 +177,23 @@ rmw_create_service(
     _register_type(participant, info->response_type_support_);
   }
 
+  // If FASTRTPS_DEFAULT_PROFILES_FILE defined, fill subscriber attributes with a subscriber profile profile located
+  // based of topic name defined by _create_topic_name(). If no profile is found, a search with profile_name "service"
+  // is attempted. Else, use the default attributes.
+  std::string topic_name_fallback = "service";
   eprosima::fastrtps::SubscriberAttributes subscriberParam;
-  eprosima::fastrtps::PublisherAttributes publisherParam;
+  eprosima::fastrtps::fixed_string<255> sub_topic_name = _create_topic_name(
+    qos_policies, ros_service_requester_prefix, service_name, "Request");
+  Domain::getDefaultSubscriberAttributes(subscriberParam);
+
+  if (std::getenv("FASTRTPS_DEFAULT_PROFILES_FILE") != nullptr)
+  {
+    if (XMLProfileManager::fillSubscriberAttributes(sub_topic_name.to_string(), subscriberParam) !=
+      XMLP_ret::XML_OK)
+    {
+      XMLProfileManager::fillSubscriberAttributes(topic_name_fallback, subscriberParam);
+    }
+  }
 
   if (!impl->leave_middleware_default_qos) {
     subscriberParam.historyMemoryPolicy =
@@ -180,8 +201,24 @@ rmw_create_service(
   }
   subscriberParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
   subscriberParam.topic.topicDataType = request_type_name;
-  subscriberParam.topic.topicName = _create_topic_name(
-    qos_policies, ros_service_requester_prefix, service_name, "Request");
+  subscriberParam.topic.topicName = sub_topic_name;
+
+  // If FASTRTPS_DEFAULT_PROFILES_FILE defined, fill publisher attributes with a publisher profile profile located
+  // based of topic name defined by _create_topic_name(). If no profile is found, a search with profile_name "service"
+  // is attempted. Else, use the default attributes.
+  eprosima::fastrtps::fixed_string<255> pub_topic_name = _create_topic_name(
+    qos_policies, ros_service_response_prefix, service_name, "Reply");
+  eprosima::fastrtps::PublisherAttributes publisherParam;
+  Domain::getDefaultPublisherAttributes(publisherParam);
+
+  if (std::getenv("FASTRTPS_DEFAULT_PROFILES_FILE") != nullptr)
+  {
+    if (XMLProfileManager::fillPublisherAttributes(pub_topic_name.to_string(), publisherParam) !=
+      XMLP_ret::XML_OK)
+    {
+      XMLProfileManager::fillPublisherAttributes(topic_name_fallback, publisherParam);
+    }
+  }
 
   if (!impl->leave_middleware_default_qos) {
     publisherParam.historyMemoryPolicy =
@@ -195,8 +232,7 @@ rmw_create_service(
 
   publisherParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;
   publisherParam.topic.topicDataType = response_type_name;
-  publisherParam.topic.topicName = _create_topic_name(
-    qos_policies, ros_service_response_prefix, service_name, "Reply");
+  publisherParam.topic.topicName = pub_topic_name;
 
   RCUTILS_LOG_DEBUG_NAMED(
     "rmw_fastrtps_cpp",

--- a/rmw_fastrtps_cpp/src/subscription.cpp
+++ b/rmw_fastrtps_cpp/src/subscription.cpp
@@ -36,6 +36,7 @@
 
 #include "fastrtps/participant/Participant.h"
 #include "fastrtps/subscriber/Subscriber.h"
+#include "fastrtps/xmlparser/XMLProfileManager.h"
 
 #include "rmw_fastrtps_cpp/identifier.hpp"
 #include "rmw_fastrtps_cpp/subscription.hpp"
@@ -45,7 +46,7 @@
 using Domain = eprosima::fastrtps::Domain;
 using Participant = eprosima::fastrtps::Participant;
 using TopicDataType = eprosima::fastrtps::TopicDataType;
-
+using XMLProfileManager = eprosima::fastrtps::xmlparser::XMLProfileManager;
 
 namespace rmw_fastrtps_cpp
 {
@@ -109,9 +110,11 @@ create_subscription(
     return nullptr;
   }
 
-  // Load default XML profile.
+  // If the user defined an XML file via env "FASTRTPS_DEFAULT_PROFILES_FILE", try to load subscriber which profile name
+  // matches with topic_name. If such profile does not exist, then use the default attributes.
   eprosima::fastrtps::SubscriberAttributes subscriberParam;
-  Domain::getDefaultSubscriberAttributes(subscriberParam);
+  Domain::getDefaultSubscriberAttributes(subscriberParam);  // Loads the XML file if not loaded
+  XMLProfileManager::fillSubscriberAttributes(topic_name, subscriberParam, false);
 
   CustomSubscriberInfo * info = new (std::nothrow) CustomSubscriberInfo();
   if (!info) {

--- a/rmw_fastrtps_cpp/src/subscription.cpp
+++ b/rmw_fastrtps_cpp/src/subscription.cpp
@@ -110,8 +110,9 @@ create_subscription(
     return nullptr;
   }
 
-  // If the user defined an XML file via env "FASTRTPS_DEFAULT_PROFILES_FILE", try to load subscriber which profile name
-  // matches with topic_name. If such profile does not exist, then use the default attributes.
+  // If the user defined an XML file via env "FASTRTPS_DEFAULT_PROFILES_FILE", try to load
+  // subscriber which profile name matches with topic_name. If such profile does not exist, then use
+  // the default attributes.
   eprosima::fastrtps::SubscriberAttributes subscriberParam;
   Domain::getDefaultSubscriberAttributes(subscriberParam);  // Loads the XML file if not loaded
   XMLProfileManager::fillSubscriberAttributes(topic_name, subscriberParam, false);


### PR DESCRIPTION
When loading configuration from a Fast DDS XML file, the current code uses the same publisher profile for all publishers and the same subscriber profile for all subscribers.

This PR aims to change this behavior, allowing the user to specify different settings on each publisher or subscriber, according to the following rules:

#### When creating a ROS2 publisher

If a `<publisher>` profile with `profile_name=topic_name` exists in FASTRTPS_DEFAULT_PROFILES_FILE, then load it.
Otherwise, use the `<publisher>` profile with `is_default_profile="true"`

#### When creating a ROS2 subscription

If a `<subscriber>` profile with `profile_name=topic_name` exists in FASTRTPS_DEFAULT_PROFILES_FILE, then load it.
Otherwise, use the `<subscriber>` profile with `is_default_profile="true"`

#### When creating a ROS2 service

For the creation of the request subscriber, if a `<subscriber>` profile with `profile_name=topic_name` exists in FASTRTPS_DEFAULT_PROFILES_FILE, then load it.
Otherwise, if a `<subscriber>` profile with `profile_name="service"` exists in FASTRTPS_DEFAULT_PROFILES_FILE, then load it.
Otherwise, use the `<subscriber>` profile with `is_default_profile="true"`

For the creation of the reply publisher, if a `<publisher>` profile with `profile_name=topic_name` exists in FASTRTPS_DEFAULT_PROFILES_FILE, then load it.
Otherwise, if a `<publisher>` profile with `profile_name="service"` exists in FASTRTPS_DEFAULT_PROFILES_FILE, then load it.
Otherwise, use the `<publisher>` profile with `is_default_profile="true"`

#### When creating a ROS2 client

For the creation of the request publisher, if a `<publisher>` profile with `profile_name=topic_name` exists in FASTRTPS_DEFAULT_PROFILES_FILE, then load it.
Otherwise, if a `<publisher>` profile with `profile_name="client"` exists in FASTRTPS_DEFAULT_PROFILES_FILE, then load it.
Otherwise, use the `<publisher>` profile with `is_default_profile="true"`

For the creation of the reply subscriber, if a `<subscriber>` profile with `profile_name=topic_name` exists in FASTRTPS_DEFAULT_PROFILES_FILE, then load it.
Otherwise, if a `<subscriber>` profile with `profile_name="client"` exists in FASTRTPS_DEFAULT_PROFILES_FILE, then load it.
Otherwise, use the `<subscriber>` profile with `is_default_profile="true"`