### PR TITLE
Fix unprotected use of mutex-guarded variable

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/rmw_get_topic_endpoint_info.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_get_topic_endpoint_info.cpp
@@ -181,26 +181,29 @@ _set_rmw_topic_endpoint_info(
   // and hence we must find its name and namespace from the discovered_names and
   // discovered_namespace maps
   // set node name
-  const auto & d_name_it = slave_target->discovered_names.find(topic_data.participant_guid);
-  if (d_name_it != slave_target->discovered_names.end()) {
-    ret = rmw_topic_endpoint_info_set_node_name(
-      topic_endpoint_info, d_name_it->second.c_str(), allocator);
-  } else {
-    ret = rmw_topic_endpoint_info_set_node_name(
-      topic_endpoint_info, "_NODE_NAME_UNKNOWN_", allocator);
-  }
-  if (ret != RMW_RET_OK) {
-    return ret;
-  }
-  // set node namespace
-  const auto & d_namespace_it =
-    slave_target->discovered_namespaces.find(topic_data.participant_guid);
-  if (d_namespace_it != slave_target->discovered_namespaces.end()) {
-    ret = rmw_topic_endpoint_info_set_node_namespace(
-      topic_endpoint_info, d_namespace_it->second.c_str(), allocator);
-  } else {
-    ret = rmw_topic_endpoint_info_set_node_namespace(
-      topic_endpoint_info, "_NODE_NAMESPACE_UNKNOWN_", allocator);
+  { // Scope for lock guard
+    std::lock_guard<std::mutex> guard(slave_target->names_mutex_);
+    const auto & d_name_it = slave_target->discovered_names.find(topic_data.participant_guid);
+    if (d_name_it != slave_target->discovered_names.end()) {
+      ret = rmw_topic_endpoint_info_set_node_name(
+        topic_endpoint_info, d_name_it->second.c_str(), allocator);
+    } else {
+      ret = rmw_topic_endpoint_info_set_node_name(
+        topic_endpoint_info, "_NODE_NAME_UNKNOWN_", allocator);
+    }
+    if (ret != RMW_RET_OK) {
+      return ret;
+    }
+    // set node namespace
+    const auto & d_namespace_it =
+      slave_target->discovered_namespaces.find(topic_data.participant_guid);
+    if (d_namespace_it != slave_target->discovered_namespaces.end()) {
+      ret = rmw_topic_endpoint_info_set_node_namespace(
+        topic_endpoint_info, d_namespace_it->second.c_str(), allocator);
+    } else {
+      ret = rmw_topic_endpoint_info_set_node_namespace(
+        topic_endpoint_info, "_NODE_NAMESPACE_UNKNOWN_", allocator);
+    }
   }
   return ret;
 }


### PR DESCRIPTION
Fixes https://github.com/ros2/rmw_fastrtps/issues/344
Fixes https://github.com/ros-security/aws-oncall/issues/52

This PR fixes the warnings in the clang thread safety analysis build by adding a lock guard around use of the `discovered_names` variable in `rmw_get_topic_endpoint_info.cpp`

Signed-off-by: Emerson Knapp <emerson.b.knapp@gmail.com>