### PR TITLE
Update rmw_topic_endpoint_info_array usage

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/rmw_get_topic_endpoint_info.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_get_topic_endpoint_info.cpp
@@ -292,7 +292,6 @@ _get_info_by_topic(
     for (auto i = 0u; i < count; i++) {
       participants_info->info_array[i] = topic_endpoint_info_vector.at(i);
     }
-    participants_info->count = count;
   }
   return RMW_RET_OK;
 }


### PR DESCRIPTION
Depends on https://github.com/ros2/rmw/pull/196.
Now, `rmw_topic_endpoint_info_array` initializes `size` to the correct value.
So there's not need of doing that again.