### PR TITLE
Add rmw_*_event_init() functions

### DIFF
--- a/rmw_fastrtps_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_cpp/CMakeLists.txt
@@ -57,7 +57,6 @@ add_library(rmw_fastrtps_cpp
   src/rmw_client.cpp
   src/rmw_compare_gids_equal.cpp
   src/rmw_count.cpp
-  src/rmw_event.cpp
   src/rmw_get_gid_for_publisher.cpp
   src/rmw_get_implementation_identifier.cpp
   src/rmw_get_serialization_format.cpp

--- a/rmw_fastrtps_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_cpp/CMakeLists.txt
@@ -57,6 +57,7 @@ add_library(rmw_fastrtps_cpp
   src/rmw_client.cpp
   src/rmw_compare_gids_equal.cpp
   src/rmw_count.cpp
+  src/rmw_event.cpp
   src/rmw_get_gid_for_publisher.cpp
   src/rmw_get_implementation_identifier.cpp
   src/rmw_get_serialization_format.cpp

--- a/rmw_fastrtps_cpp/src/rmw_event.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_event.cpp
@@ -16,11 +16,37 @@
 
 #include "rmw_fastrtps_shared_cpp/rmw_common.hpp"
 
+#include "rmw_fastrtps_cpp/identifier.hpp"
+
 extern "C"
 {
-bool
-rmw_event_type_is_supported(rmw_event_type_t event_type)
+
+rmw_ret_t
+rmw_publisher_event_init(
+  rmw_event_t * rmw_event,
+  const rmw_publisher_t * publisher,
+  rmw_event_type_t event_type)
 {
-  return rmw_fastrtps_shared_cpp::__rmw_event_type_is_supported(event_type);
+  return rmw_fastrtps_shared_cpp::__rmw_init_event(
+    eprosima_fastrtps_identifier,
+    rmw_event,
+    publisher->implementation_identifier,
+    publisher->data,
+    event_type);
 }
+
+rmw_ret_t
+rmw_subscription_event_init(
+  rmw_event_t * rmw_event,
+  const rmw_subscription_t * subscription,
+  rmw_event_type_t event_type)
+{
+  return rmw_fastrtps_shared_cpp::__rmw_init_event(
+    eprosima_fastrtps_identifier,
+    rmw_event,
+    subscription->implementation_identifier,
+    subscription->data,
+    event_type);
+}
+
 }  // extern "C"

--- a/rmw_fastrtps_cpp/src/rmw_event.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_event.cpp
@@ -20,7 +20,6 @@
 
 extern "C"
 {
-
 rmw_ret_t
 rmw_publisher_event_init(
   rmw_event_t * rmw_event,
@@ -48,5 +47,4 @@ rmw_subscription_event_init(
     subscription->data,
     event_type);
 }
-
 }  // extern "C"

--- a/rmw_fastrtps_cpp/src/rmw_event.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_event.cpp
@@ -1,0 +1,26 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rmw/rmw.h"
+
+#include "rmw_fastrtps_shared_cpp/rmw_common.hpp"
+
+extern "C"
+{
+bool
+rmw_event_type_is_supported(rmw_event_type_t event_type)
+{
+  return rmw_fastrtps_shared_cpp::__rmw_event_type_is_supported(event_type);
+}
+}  // extern "C"

--- a/rmw_fastrtps_dynamic_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_dynamic_cpp/CMakeLists.txt
@@ -61,6 +61,7 @@ add_library(rmw_fastrtps_dynamic_cpp
   src/rmw_client.cpp
   src/rmw_compare_gids_equal.cpp
   src/rmw_count.cpp
+  src/rmw_event.cpp
   src/rmw_get_gid_for_publisher.cpp
   src/rmw_get_implementation_identifier.cpp
   src/rmw_get_serialization_format.cpp

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_event.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_event.cpp
@@ -1,0 +1,50 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rmw/rmw.h"
+
+#include "rmw_fastrtps_shared_cpp/rmw_common.hpp"
+
+#include "rmw_fastrtps_dynamic_cpp/identifier.hpp"
+
+extern "C"
+{
+rmw_ret_t
+rmw_publisher_event_init(
+  rmw_event_t * rmw_event,
+  const rmw_publisher_t * publisher,
+  rmw_event_type_t event_type)
+{
+  return rmw_fastrtps_shared_cpp::__rmw_init_event(
+    eprosima_fastrtps_identifier,
+    rmw_event,
+    publisher->implementation_identifier,
+    publisher->data,
+    event_type);
+}
+
+rmw_ret_t
+rmw_subscription_event_init(
+  rmw_event_t * rmw_event,
+  const rmw_subscription_t * subscription,
+  rmw_event_type_t event_type)
+{
+  return rmw_fastrtps_shared_cpp::__rmw_init_event(
+    eprosima_fastrtps_identifier,
+    rmw_event,
+    subscription->implementation_identifier,
+    subscription->data,
+    event_type);
+}
+}  // extern "C"

--- a/rmw_fastrtps_shared_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_shared_cpp/CMakeLists.txt
@@ -55,6 +55,7 @@ add_library(rmw_fastrtps_shared_cpp
   src/rmw_client.cpp
   src/rmw_compare_gids_equal.cpp
   src/rmw_count.cpp
+  src/rmw_event.cpp
   src/rmw_get_gid_for_publisher.cpp
   src/rmw_get_topic_endpoint_info.cpp
   src/rmw_guard_condition.cpp

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/rmw_common.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/rmw_common.hpp
@@ -118,6 +118,10 @@ __rmw_get_node_names(
   rcutils_string_array_t * node_namespaces);
 
 RMW_FASTRTPS_SHARED_CPP_PUBLIC
+bool
+__rmw_event_type_is_supported(rmw_event_type_t event_type);
+
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
 __rmw_publish(
   const char * identifier,

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/rmw_common.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/rmw_common.hpp
@@ -118,8 +118,13 @@ __rmw_get_node_names(
   rcutils_string_array_t * node_namespaces);
 
 RMW_FASTRTPS_SHARED_CPP_PUBLIC
-bool
-__rmw_event_type_is_supported(rmw_event_type_t event_type);
+rmw_ret_t
+__rmw_init_event(
+  const char * identifier,
+  rmw_event_t * rmw_event,
+  const char * topic_endpoint_impl_identifier,
+  void * data,
+  rmw_event_type_t event_type);
 
 RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t

--- a/rmw_fastrtps_shared_cpp/src/custom_publisher_info.cpp
+++ b/rmw_fastrtps_shared_cpp/src/custom_publisher_info.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "rmw_fastrtps_shared_cpp/custom_publisher_info.hpp"
-#include "rmw_fastrtps_shared_cpp/rmw_common.hpp"
+#include "types/event_types.hpp"
 
 EventListenerInterface *
 CustomPublisherInfo::getListener() const
@@ -60,7 +60,7 @@ void PubListener::on_liveliness_lost(
 
 bool PubListener::hasEvent(rmw_event_type_t event_type) const
 {
-  assert(rmw_fastrtps_shared_cpp::__rmw_event_type_is_supported(event_type));
+  assert(is_event_supported(event_type));
   switch (event_type) {
     case RMW_EVENT_LIVELINESS_LOST:
       return liveliness_changes_.load(std::memory_order_relaxed);
@@ -74,7 +74,7 @@ bool PubListener::hasEvent(rmw_event_type_t event_type) const
 
 bool PubListener::takeNextEvent(rmw_event_type_t event_type, void * event_info)
 {
-  assert(rmw_fastrtps_shared_cpp::__rmw_event_type_is_supported(event_type));
+  assert(is_event_supported(event_type));
   std::lock_guard<std::mutex> lock(internalMutex_);
   switch (event_type) {
     case RMW_EVENT_LIVELINESS_LOST:

--- a/rmw_fastrtps_shared_cpp/src/custom_publisher_info.cpp
+++ b/rmw_fastrtps_shared_cpp/src/custom_publisher_info.cpp
@@ -60,7 +60,7 @@ void PubListener::on_liveliness_lost(
 
 bool PubListener::hasEvent(rmw_event_type_t event_type) const
 {
-  assert(rmw_fastrtps_shared_cpp_internal::is_event_supported(event_type));
+  assert(rmw_fastrtps_shared_cpp::internal::is_event_supported(event_type));
   switch (event_type) {
     case RMW_EVENT_LIVELINESS_LOST:
       return liveliness_changes_.load(std::memory_order_relaxed);
@@ -74,7 +74,7 @@ bool PubListener::hasEvent(rmw_event_type_t event_type) const
 
 bool PubListener::takeNextEvent(rmw_event_type_t event_type, void * event_info)
 {
-  assert(rmw_fastrtps_shared_cpp_internal::is_event_supported(event_type));
+  assert(rmw_fastrtps_shared_cpp::internal::is_event_supported(event_type));
   std::lock_guard<std::mutex> lock(internalMutex_);
   switch (event_type) {
     case RMW_EVENT_LIVELINESS_LOST:

--- a/rmw_fastrtps_shared_cpp/src/custom_publisher_info.cpp
+++ b/rmw_fastrtps_shared_cpp/src/custom_publisher_info.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "rmw_fastrtps_shared_cpp/custom_publisher_info.hpp"
+#include "rmw_fastrtps_shared_cpp/rmw_common.hpp"
 
 EventListenerInterface *
 CustomPublisherInfo::getListener() const
@@ -59,6 +60,7 @@ void PubListener::on_liveliness_lost(
 
 bool PubListener::hasEvent(rmw_event_type_t event_type) const
 {
+  assert(rmw_fastrtps_shared_cpp::__rmw_event_type_is_supported(event_type));
   switch (event_type) {
     case RMW_EVENT_LIVELINESS_LOST:
       return liveliness_changes_.load(std::memory_order_relaxed);
@@ -72,6 +74,7 @@ bool PubListener::hasEvent(rmw_event_type_t event_type) const
 
 bool PubListener::takeNextEvent(rmw_event_type_t event_type, void * event_info)
 {
+  assert(rmw_fastrtps_shared_cpp::__rmw_event_type_is_supported(event_type));
   std::lock_guard<std::mutex> lock(internalMutex_);
   switch (event_type) {
     case RMW_EVENT_LIVELINESS_LOST:

--- a/rmw_fastrtps_shared_cpp/src/custom_publisher_info.cpp
+++ b/rmw_fastrtps_shared_cpp/src/custom_publisher_info.cpp
@@ -60,7 +60,7 @@ void PubListener::on_liveliness_lost(
 
 bool PubListener::hasEvent(rmw_event_type_t event_type) const
 {
-  assert(is_event_supported(event_type));
+  assert(rmw_fastrtps_shared_cpp_internal::is_event_supported(event_type));
   switch (event_type) {
     case RMW_EVENT_LIVELINESS_LOST:
       return liveliness_changes_.load(std::memory_order_relaxed);
@@ -74,7 +74,7 @@ bool PubListener::hasEvent(rmw_event_type_t event_type) const
 
 bool PubListener::takeNextEvent(rmw_event_type_t event_type, void * event_info)
 {
-  assert(is_event_supported(event_type));
+  assert(rmw_fastrtps_shared_cpp_internal::is_event_supported(event_type));
   std::lock_guard<std::mutex> lock(internalMutex_);
   switch (event_type) {
     case RMW_EVENT_LIVELINESS_LOST:

--- a/rmw_fastrtps_shared_cpp/src/custom_subscriber_info.cpp
+++ b/rmw_fastrtps_shared_cpp/src/custom_subscriber_info.cpp
@@ -62,7 +62,7 @@ void SubListener::on_liveliness_changed(
 
 bool SubListener::hasEvent(rmw_event_type_t event_type) const
 {
-  assert(is_event_supported(event_type));
+  assert(rmw_fastrtps_shared_cpp_internal::is_event_supported(event_type));
   switch (event_type) {
     case RMW_EVENT_LIVELINESS_CHANGED:
       return liveliness_changes_.load(std::memory_order_relaxed);
@@ -76,7 +76,7 @@ bool SubListener::hasEvent(rmw_event_type_t event_type) const
 
 bool SubListener::takeNextEvent(rmw_event_type_t event_type, void * event_info)
 {
-  assert(is_event_supported(event_type));
+  assert(rmw_fastrtps_shared_cpp_internal::is_event_supported(event_type));
   std::lock_guard<std::mutex> lock(internalMutex_);
   switch (event_type) {
     case RMW_EVENT_LIVELINESS_CHANGED:

--- a/rmw_fastrtps_shared_cpp/src/custom_subscriber_info.cpp
+++ b/rmw_fastrtps_shared_cpp/src/custom_subscriber_info.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp"
-#include "rmw_fastrtps_shared_cpp/rmw_common.hpp"
+#include "types/event_types.hpp"
 
 EventListenerInterface *
 CustomSubscriberInfo::getListener() const
@@ -62,7 +62,7 @@ void SubListener::on_liveliness_changed(
 
 bool SubListener::hasEvent(rmw_event_type_t event_type) const
 {
-  assert(rmw_fastrtps_shared_cpp::__rmw_event_type_is_supported(event_type));
+  assert(is_event_supported(event_type));
   switch (event_type) {
     case RMW_EVENT_LIVELINESS_CHANGED:
       return liveliness_changes_.load(std::memory_order_relaxed);
@@ -76,7 +76,7 @@ bool SubListener::hasEvent(rmw_event_type_t event_type) const
 
 bool SubListener::takeNextEvent(rmw_event_type_t event_type, void * event_info)
 {
-  assert(rmw_fastrtps_shared_cpp::__rmw_event_type_is_supported(event_type));
+  assert(is_event_supported(event_type));
   std::lock_guard<std::mutex> lock(internalMutex_);
   switch (event_type) {
     case RMW_EVENT_LIVELINESS_CHANGED:

--- a/rmw_fastrtps_shared_cpp/src/custom_subscriber_info.cpp
+++ b/rmw_fastrtps_shared_cpp/src/custom_subscriber_info.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp"
+#include "rmw_fastrtps_shared_cpp/rmw_common.hpp"
 
 EventListenerInterface *
 CustomSubscriberInfo::getListener() const
@@ -61,6 +62,7 @@ void SubListener::on_liveliness_changed(
 
 bool SubListener::hasEvent(rmw_event_type_t event_type) const
 {
+  assert(rmw_fastrtps_shared_cpp::__rmw_event_type_is_supported(event_type));
   switch (event_type) {
     case RMW_EVENT_LIVELINESS_CHANGED:
       return liveliness_changes_.load(std::memory_order_relaxed);
@@ -74,6 +76,7 @@ bool SubListener::hasEvent(rmw_event_type_t event_type) const
 
 bool SubListener::takeNextEvent(rmw_event_type_t event_type, void * event_info)
 {
+  assert(rmw_fastrtps_shared_cpp::__rmw_event_type_is_supported(event_type));
   std::lock_guard<std::mutex> lock(internalMutex_);
   switch (event_type) {
     case RMW_EVENT_LIVELINESS_CHANGED:

--- a/rmw_fastrtps_shared_cpp/src/custom_subscriber_info.cpp
+++ b/rmw_fastrtps_shared_cpp/src/custom_subscriber_info.cpp
@@ -62,7 +62,7 @@ void SubListener::on_liveliness_changed(
 
 bool SubListener::hasEvent(rmw_event_type_t event_type) const
 {
-  assert(rmw_fastrtps_shared_cpp_internal::is_event_supported(event_type));
+  assert(rmw_fastrtps_shared_cpp::internal::is_event_supported(event_type));
   switch (event_type) {
     case RMW_EVENT_LIVELINESS_CHANGED:
       return liveliness_changes_.load(std::memory_order_relaxed);
@@ -76,7 +76,7 @@ bool SubListener::hasEvent(rmw_event_type_t event_type) const
 
 bool SubListener::takeNextEvent(rmw_event_type_t event_type, void * event_info)
 {
-  assert(rmw_fastrtps_shared_cpp_internal::is_event_supported(event_type));
+  assert(rmw_fastrtps_shared_cpp::internal::is_event_supported(event_type));
   std::lock_guard<std::mutex> lock(internalMutex_);
   switch (event_type) {
     case RMW_EVENT_LIVELINESS_CHANGED:

--- a/rmw_fastrtps_shared_cpp/src/rmw_event.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_event.cpp
@@ -26,7 +26,9 @@ static const std::unordered_set<rmw_event_type_t> g_rmw_event_type_set{
   RMW_EVENT_OFFERED_DEADLINE_MISSED
 };
 
-namespace rmw_fastrtps_shared_cpp_internal
+namespace rmw_fastrtps_shared_cpp
+{
+namespace internal
 {
 
 bool is_event_supported(rmw_event_type_t event_type)
@@ -34,10 +36,7 @@ bool is_event_supported(rmw_event_type_t event_type)
   return g_rmw_event_type_set.count(event_type) == 1;
 }
 
-}  // namespace rmw_fastrtps_shared_cpp_internal
-
-namespace rmw_fastrtps_shared_cpp
-{
+}  // namespace internal
 
 rmw_ret_t
 __rmw_init_event(
@@ -56,7 +55,7 @@ __rmw_init_event(
     topic_endpoint_impl_identifier,
     identifier,
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
-  if (!rmw_fastrtps_shared_cpp_internal::is_event_supported(event_type)) {
+  if (!internal::is_event_supported(event_type)) {
     RMW_SET_ERROR_MSG("provided event_type is not supported by rmw_fastrtps_cpp");
     return RMW_RET_UNSUPPORTED;
   }

--- a/rmw_fastrtps_shared_cpp/src/rmw_event.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_event.cpp
@@ -26,10 +26,15 @@ static const std::unordered_set<rmw_event_type_t> g_rmw_event_type_set{
   RMW_EVENT_OFFERED_DEADLINE_MISSED
 };
 
+namespace rmw_fastrtps_shared_cpp_internal
+{
+
 bool is_event_supported(rmw_event_type_t event_type)
 {
-  return g_rmw_event_type_set.count(event_type) > 0;
+  return g_rmw_event_type_set.count(event_type) == 1;
 }
+
+}  // namespace rmw_fastrtps_shared_cpp_internal
 
 namespace rmw_fastrtps_shared_cpp
 {
@@ -51,7 +56,7 @@ __rmw_init_event(
     topic_endpoint_impl_identifier,
     identifier,
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
-  if (!::is_event_supported(event_type)) {
+  if (!rmw_fastrtps_shared_cpp_internal::is_event_supported(event_type)) {
     RMW_SET_ERROR_MSG("provided event_type is not supported by rmw_fastrtps_cpp");
     return RMW_RET_UNSUPPORTED;
   }

--- a/rmw_fastrtps_shared_cpp/src/rmw_event.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_event.cpp
@@ -1,0 +1,35 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <unordered_set>
+
+#include "rmw_fastrtps_shared_cpp/rmw_common.hpp"
+
+static const std::unordered_set<rmw_event_type_t> __rmw_event_type_set{
+  RMW_EVENT_LIVELINESS_CHANGED,
+  RMW_EVENT_REQUESTED_DEADLINE_MISSED,
+  RMW_EVENT_LIVELINESS_LOST,
+  RMW_EVENT_OFFERED_DEADLINE_MISSED
+};
+
+namespace rmw_fastrtps_shared_cpp
+{
+
+bool
+__rmw_event_type_is_supported(rmw_event_type_t event_type)
+{
+  return __rmw_event_type_set.count(event_type) > 0;
+}
+
+}  // namespace rmw_fastrtps_shared_cpp

--- a/rmw_fastrtps_shared_cpp/src/rmw_event.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_event.cpp
@@ -19,7 +19,7 @@
 #include "rmw_fastrtps_shared_cpp/rmw_common.hpp"
 #include "types/event_types.hpp"
 
-static const std::unordered_set<rmw_event_type_t> __rmw_event_type_set{
+static const std::unordered_set<rmw_event_type_t> g_rmw_event_type_set{
   RMW_EVENT_LIVELINESS_CHANGED,
   RMW_EVENT_REQUESTED_DEADLINE_MISSED,
   RMW_EVENT_LIVELINESS_LOST,
@@ -28,7 +28,7 @@ static const std::unordered_set<rmw_event_type_t> __rmw_event_type_set{
 
 bool is_event_supported(rmw_event_type_t event_type)
 {
-  return __rmw_event_type_set.count(event_type) > 0;
+  return g_rmw_event_type_set.count(event_type) > 0;
 }
 
 namespace rmw_fastrtps_shared_cpp

--- a/rmw_fastrtps_shared_cpp/src/types/event_types.hpp
+++ b/rmw_fastrtps_shared_cpp/src/types/event_types.hpp
@@ -17,6 +17,11 @@
 
 #include "rmw/event.h"
 
+namespace rmw_fastrtps_shared_cpp_internal
+{
+
 bool is_event_supported(rmw_event_type_t event_type);
+
+}  // namespace rmw_fastrtps_shared_cpp_internal
 
 #endif  // TYPES__EVENT_TYPES_HPP_

--- a/rmw_fastrtps_shared_cpp/src/types/event_types.hpp
+++ b/rmw_fastrtps_shared_cpp/src/types/event_types.hpp
@@ -1,0 +1,22 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TYPES__EVENT_TYPES_HPP_
+#define TYPES__EVENT_TYPES_HPP_
+
+#include "rmw/event.h"
+
+bool is_event_supported(rmw_event_type_t event_type);
+
+#endif  // TYPES__EVENT_TYPES_HPP_

--- a/rmw_fastrtps_shared_cpp/src/types/event_types.hpp
+++ b/rmw_fastrtps_shared_cpp/src/types/event_types.hpp
@@ -17,11 +17,14 @@
 
 #include "rmw/event.h"
 
-namespace rmw_fastrtps_shared_cpp_internal
+namespace rmw_fastrtps_shared_cpp
+{
+namespace internal
 {
 
 bool is_event_supported(rmw_event_type_t event_type);
 
-}  // namespace rmw_fastrtps_shared_cpp_internal
+}  // namespace internal
+}  // namespace rmw_fastrtps_shared_cpp
 
 #endif  // TYPES__EVENT_TYPES_HPP_


### PR DESCRIPTION
Related to https://github.com/ros2/ros2/issues/822

This adds the `rmw_publisher_event_init()` and `rmw_subscription_event_init()` functions to `rmw_fastrtps`, moved from `rmw`, so that these functions will be able to check for whether or not the given type of `rmw_event_type_t` is supported by the chosen middleware.