### PR TITLE
Correct error message when event is not supported

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/rmw_event.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_event.cpp
@@ -56,7 +56,7 @@ __rmw_init_event(
     identifier,
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
   if (!internal::is_event_supported(event_type)) {
-    RMW_SET_ERROR_MSG("provided event_type is not supported by rmw_fastrtps_cpp");
+    RMW_SET_ERROR_MSG_WITH_FORMAT_STRING("provided event_type is not supported by %s", identifier);
     return RMW_RET_UNSUPPORTED;
   }
 


### PR DESCRIPTION
Follow up of https://github.com/ros2/rmw_fastrtps/pull/354.

In this way, it prints `rmw_fastrtps_cpp` or `rmw_fastrtps_dynamic_cpp` accordingly.