### PR TITLE
Fill in timestamps.

### DIFF
--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_client_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_client_info.hpp
@@ -1,4 +1,5 @@
 // Copyright 2016-2018 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2020 Robert Bosch GmbH
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
@@ -1,4 +1,5 @@
 // Copyright 2016-2018 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2020 Robert Bosch GmbH
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rmw_fastrtps_shared_cpp/src/listener_thread.cpp
+++ b/rmw_fastrtps_shared_cpp/src/listener_thread.cpp
@@ -125,6 +125,8 @@ node_listener(rmw_context_t * context)
     rmw_guard_conditions_t guard_conditions;
     subscriptions.subscriber_count = 1;
     subscriptions.subscribers = subscriptions_buffer;
+    rcutils_time_point_value_t sub_timestamps[1] = { 0 };
+    subscriptions.timestamps = sub_timestamps;
     guard_conditions.guard_condition_count = 1;
     guard_conditions.guard_conditions = guard_conditions_buffer;
     // number of conditions of a subscription is 2

--- a/rmw_fastrtps_shared_cpp/src/rmw_wait.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_wait.cpp
@@ -201,20 +201,10 @@ __rmw_wait(
       custom_subscriber_info->listener_->detachCondition();
       if (!custom_subscriber_info->listener_->hasData()) {
         subscriptions->subscribers[i] = 0;
-<<<<<<< HEAD
         subscriptions->timestamps[i] = 0;
       } else {
         subscriptions->timestamps[i] = custom_subscriber_info->subscriber_->\
           get_first_untaken_info(&si) ? si.receptionTimestamp.to_ns() : 0;
-=======
-      } else {
-        bool success = custom_subscriber_info->subscriber_->get_first_untaken_info(&si);
-        if(success) {
-          subscriptions->timestamps[i] = si.receptionTimestamp.to_ns();
-        } else {
-          subscriptions->timestamps[i] = 0;
-        }
->>>>>>> Fill in timestamps for subscriptions.
       }
     }
   }

--- a/rmw_fastrtps_shared_cpp/src/rmw_wait.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_wait.cpp
@@ -201,10 +201,20 @@ __rmw_wait(
       custom_subscriber_info->listener_->detachCondition();
       if (!custom_subscriber_info->listener_->hasData()) {
         subscriptions->subscribers[i] = 0;
+<<<<<<< HEAD
         subscriptions->timestamps[i] = 0;
       } else {
         subscriptions->timestamps[i] = custom_subscriber_info->subscriber_->\
           get_first_untaken_info(&si) ? si.receptionTimestamp.to_ns() : 0;
+=======
+      } else {
+        bool success = custom_subscriber_info->subscriber_->get_first_untaken_info(&si);
+        if(success) {
+          subscriptions->timestamps[i] = si.receptionTimestamp.to_ns();
+        } else {
+          subscriptions->timestamps[i] = 0;
+        }
+>>>>>>> Fill in timestamps for subscriptions.
       }
     }
   }

--- a/rmw_fastrtps_shared_cpp/src/rmw_wait.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_wait.cpp
@@ -218,8 +218,8 @@ __rmw_wait(
         clients->clients[i] = 0;
         clients->timestamps[i] = 0;
       } else {
-        clients->timestamps[i] = custom_client_info->response_subscriber_->\
-          get_first_untaken_info(&si) ? si.receptionTimestamp.to_ns() : 0;
+        clients->timestamps[i] = custom_client_info->listener_->\
+          peekSampleInfo().receptionTimestamp.to_ns();
       }
     }
   }

--- a/rmw_fastrtps_shared_cpp/src/rmw_wait.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_wait.cpp
@@ -200,13 +200,10 @@ __rmw_wait(
       custom_subscriber_info->listener_->detachCondition();
       if (!custom_subscriber_info->listener_->hasData()) {
         subscriptions->subscribers[i] = 0;
+        subscriptions->timestamps[i] = 0;
       } else {
-        bool success = custom_subscriber_info->subscriber_->get_first_untaken_info(&si);
-        if(success) {
-          subscriptions->timestamps[i] = si.receptionTimestamp.to_ns();
-        } else {
-          subscriptions->timestamps[i] = 0;
-        }
+        subscriptions->timestamps[i] = custom_subscriber_info->subscriber_->\
+          get_first_untaken_info(&si) ? si.receptionTimestamp.to_ns() : 0;
       }
     }
   }
@@ -218,6 +215,10 @@ __rmw_wait(
       custom_client_info->listener_->detachCondition();
       if (!custom_client_info->listener_->hasData()) {
         clients->clients[i] = 0;
+        clients->timestamps[i] = 0;
+      } else {
+        clients->timestamps[i] = custom_client_info->response_subscriber_->\
+          get_first_untaken_info(&si) ? si.receptionTimestamp.to_ns() : 0;
       }
     }
   }
@@ -229,6 +230,10 @@ __rmw_wait(
       custom_service_info->listener_->detachCondition();
       if (!custom_service_info->listener_->hasData()) {
         services->services[i] = 0;
+        services->timestamps[i] = 0;
+      } else {
+        services->timestamps[i] = custom_service_info->request_subscriber_->\
+          get_first_untaken_info(&si) ? si.receptionTimestamp.to_ns() : 0;
       }
     }
   }

--- a/rmw_fastrtps_shared_cpp/src/rmw_wait.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_wait.cpp
@@ -232,8 +232,8 @@ __rmw_wait(
         services->services[i] = 0;
         services->timestamps[i] = 0;
       } else {
-        services->timestamps[i] = custom_service_info->request_subscriber_->\
-          get_first_untaken_info(&si) ? si.receptionTimestamp.to_ns() : 0;
+        services->timestamps[i] = custom_service_info->listener_->\
+          peekSampleInfo().receptionTimestamp.to_ns();
       }
     }
   }

--- a/rmw_fastrtps_shared_cpp/src/rmw_wait.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_wait.cpp
@@ -1,4 +1,5 @@
 // Copyright 2016-2018 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Coypyright 2020 Robert Bosch GmbH
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Start of timestamp support for rmw_fastrtps. Goes together with https://github.com/ros2/rcl/pull/591 and https://github.com/ros2/rmw/pull/200 to implement https://github.com/ros2/design/issues/259.

For the "get_first_untaken_sampleinfo" function, at least https://github.com/eProsima/Fast-RTPS/commit/d368993d3ffb2db9b0d8a449a23d096fd24835f9, or current master, is required.

~*Note* This is a draft, because it currently only implements and tests timestamps for subscriptions. Services and clients are missing.~

Signed-off-by: Luetkebohle Ingo (CR/AEX3) <ingo.luetkebohle@de.bosch.com>