### PR TITLE
Add support for taking a sequence of messages

### DIFF
--- a/rmw_fastrtps_cpp/src/rmw_take.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_take.cpp
@@ -47,6 +47,20 @@ rmw_take_with_info(
 }
 
 rmw_ret_t
+rmw_take_sequence(
+  const rmw_subscription_t * subscription,
+  size_t count,
+  rmw_message_sequence_t * message_sequence,
+  rmw_message_info_sequence_t * message_info_sequence,
+  size_t * taken,
+  rmw_subscription_allocation_t * allocation)
+{
+  return rmw_fastrtps_shared_cpp::__rmw_take_sequence(
+    eprosima_fastrtps_identifier, subscription, count, message_sequence, message_info_sequence,
+    taken, allocation);
+}
+
+rmw_ret_t
 rmw_take_serialized_message(
   const rmw_subscription_t * subscription,
   rmw_serialized_message_t * serialized_message,

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_take.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_take.cpp
@@ -47,6 +47,20 @@ rmw_take_with_info(
 }
 
 rmw_ret_t
+rmw_take_sequence(
+  const rmw_subscription_t * subscription,
+  size_t count,
+  rmw_message_sequence_t * message_sequence,
+  rmw_message_info_sequence_t * message_info_sequence,
+  size_t * taken,
+  rmw_subscription_allocation_t * allocation)
+{
+  return rmw_fastrtps_shared_cpp::__rmw_take_sequence(
+    eprosima_fastrtps_identifier, subscription, count, message_sequence, message_info_sequence,
+    taken, allocation);
+}
+
+rmw_ret_t
 rmw_take_serialized_message(
   const rmw_subscription_t * subscription,
   rmw_serialized_message_t * serialized_message,

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/rmw_common.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/rmw_common.hpp
@@ -303,6 +303,17 @@ __rmw_take(
 
 RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_ret_t
+__rmw_take_sequence(
+  const char * identifier,
+  const rmw_subscription_t * subscription,
+  size_t count,
+  rmw_message_sequence_t * message_sequencxe,
+  rmw_message_info_sequence_t * message_info_sequence,
+  size_t * taken,
+  rmw_subscription_allocation_t * allocation);
+
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
+rmw_ret_t
 __rmw_take_event(
   const char * identifier,
   const rmw_event_t * event_handle,

--- a/rmw_fastrtps_shared_cpp/src/rmw_take.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_take.cpp
@@ -195,13 +195,13 @@ __rmw_take_sequence(
   rmw_subscription_allocation_t * allocation)
 {
   RCUTILS_CHECK_FOR_NULL_WITH_MSG(
-    subscription, "subscription pointer is null", return RMW_RET_ERROR);
+    subscription, "subscription pointer is null", return RMW_RET_INVALID_ARGUMENT);
   RCUTILS_CHECK_FOR_NULL_WITH_MSG(
-    message_sequence, "message_sequence pointer is null", return RMW_RET_ERROR);
+    message_sequence, "message_sequence pointer is null", return RMW_RET_INVALID_ARGUMENT);
   RCUTILS_CHECK_FOR_NULL_WITH_MSG(
-    message_info_sequence, "message_info_sequence pointer is null", return RMW_RET_ERROR);
+    message_info_sequence, "message_info_sequence pointer is null", return RMW_RET_INVALID_ARGUMENT);
   RCUTILS_CHECK_FOR_NULL_WITH_MSG(
-    taken, "size_t flag for count is null", return RMW_RET_ERROR);
+    taken, "size_t flag for count is null", return RMW_RET_INVALID_ARGUMENT);
 
   if (count > message_sequence->capacity) {
     RMW_SET_ERROR_MSG("Insufficient capacity in message_sequence");

--- a/rmw_fastrtps_shared_cpp/src/rmw_take.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_take.cpp
@@ -199,7 +199,8 @@ __rmw_take_sequence(
   RCUTILS_CHECK_FOR_NULL_WITH_MSG(
     message_sequence, "message_sequence pointer is null", return RMW_RET_INVALID_ARGUMENT);
   RCUTILS_CHECK_FOR_NULL_WITH_MSG(
-    message_info_sequence, "message_info_sequence pointer is null", return RMW_RET_INVALID_ARGUMENT);
+    message_info_sequence, "message_info_sequence pointer is null",
+    return RMW_RET_INVALID_ARGUMENT);
   RCUTILS_CHECK_FOR_NULL_WITH_MSG(
     taken, "size_t flag for count is null", return RMW_RET_INVALID_ARGUMENT);
 

--- a/rmw_fastrtps_shared_cpp/src/rmw_take.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_take.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <algorithm>
-
 #include "rmw/allocators.h"
 #include "rmw/error_handling.h"
 #include "rmw/serialized_message.h"
@@ -116,7 +114,9 @@ _take_sequence(
   // This prevents any samples that are added after the beginning of the
   // _take_sequence call from being read.
   auto unread_count = info->subscriber_->get_unread_count();
-  count = std::min(count, unread_count);
+  if (unread_count < count){
+    count = unread_count;
+  }
 
   for (size_t ii = 0; ii < count; ++ii) {
     taken_flag = false;

--- a/rmw_fastrtps_shared_cpp/src/rmw_take.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_take.cpp
@@ -114,7 +114,7 @@ _take_sequence(
   // This prevents any samples that are added after the beginning of the
   // _take_sequence call from being read.
   auto unread_count = info->subscriber_->get_unread_count();
-  if (unread_count < count){
+  if (unread_count < count) {
     count = unread_count;
   }
 


### PR DESCRIPTION
FastRTPS doesn't have built-in support for taking multiple samples, so
this implementation utilizes a loop over the `take` function multiple
times.

Implementation of ros2/rmw#212.

Signed-off-by: Michael Carroll <michael@openrobotics.org>