### PR TITLE
add missing export of rmw_dds_common

### DIFF
--- a/rmw_fastrtps_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_cpp/CMakeLists.txt
@@ -119,6 +119,7 @@ ament_export_libraries(rmw_fastrtps_cpp)
 
 ament_export_dependencies(rcutils)
 ament_export_dependencies(rmw)
+ament_export_dependencies(rmw_dds_common)
 ament_export_dependencies(rmw_fastrtps_shared_cpp)
 ament_export_dependencies(rosidl_runtime_c)
 ament_export_dependencies(rosidl_typesupport_fastrtps_c)


### PR DESCRIPTION
Related to ros2/ros2#904.

Usage: https://github.com/ros2/rmw_fastrtps/blob/19745ab1bd5177d32a1b0e034479215180afa384/rmw_fastrtps_cpp/CMakeLists.txt#L99