### PR TITLE
Fix unused variabled warning

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/rmw_security_logging.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_security_logging.cpp
@@ -209,6 +209,7 @@ bool apply_security_logging_configuration(eprosima::fastrtps::rtps::PropertyPoli
 
   return true;
 #else
+  (void)policy;
   RMW_SET_ERROR_MSG(
     "This Fast-RTPS version doesn't have the security libraries\n"
     "Please compile Fast-RTPS using the -DSECURITY=ON CMake option");


### PR DESCRIPTION
Follow-up from https://github.com/ros2/rmw_fastrtps/pull/362

This warning is showing up on build.ros2.org: http://build.ros2.org/view/Fci/job/Fci__nightly-fastrtps_ubuntu_focal_amd64/106/gcc/new/