### PR TITLE
Update quality declarations on feature testing.

### DIFF
--- a/rmw_fastrtps_cpp/QUALITY_DECLARATION.md
+++ b/rmw_fastrtps_cpp/QUALITY_DECLARATION.md
@@ -85,7 +85,7 @@ The results of the test can be found [here](https://ci.ros2.org/view/nightly/job
 
 ### Feature Testing [4.i]
 
-There is no feature testing in `rmw_fastrtps_cpp`.
+All `rmw_fastrtps_cpp` public features are ROS middleware features. Integration and system tests up the stack provide coverage.
 
 ### Public API Testing [4.ii]
 

--- a/rmw_fastrtps_cpp/QUALITY_DECLARATION.md
+++ b/rmw_fastrtps_cpp/QUALITY_DECLARATION.md
@@ -85,7 +85,7 @@ The results of the test can be found [here](https://ci.ros2.org/view/nightly/job
 
 ### Feature Testing [4.i]
 
-All `rmw_fastrtps_cpp` public features are ROS middleware features. Integration and system tests up the stack provide coverage.
+All `rmw_fastrtps_cpp` public features are ROS middleware features. Integration and system tests up the stack, such as those found in [`test_rclcpp`](https://github.com/ros2/system_tests/tree/master/test_rclcpp) and [`test_communication`](https://github.com/ros2/system_tests/tree/master/test_communication) packages, provide coverage. Nightly CI jobs in [`ci.ros2.org`](https://ci.ros2.org/) and [`build.ros2.org`](https://build.ros2.org/), where `rmw_fastrtps_cpp` is the default `rmw` implementation, thoroughly exercise this middleware.
 
 ### Public API Testing [4.ii]
 

--- a/rmw_fastrtps_shared_cpp/QUALITY_DECLARATION.md
+++ b/rmw_fastrtps_shared_cpp/QUALITY_DECLARATION.md
@@ -85,7 +85,7 @@ The results of the test can be found [here](https://ci.ros2.org/view/nightly/job
 
 ### Feature Testing [4.i]
 
-Many of the features have testing in `rmw_fastrtps_shared_cpp`.
+Many of the features have testing in `rmw_fastrtps_shared_cpp`. Since `rmw_fastrtps_shared_cpp` supports `rmw_fastrtps_cpp` and `rmw_fastrtps_dynamic_cpp`, integration and system tests for ROS middlewares up the stack also provide coverage.
 
 ### Public API Testing [4.ii]
 

--- a/rmw_fastrtps_shared_cpp/QUALITY_DECLARATION.md
+++ b/rmw_fastrtps_shared_cpp/QUALITY_DECLARATION.md
@@ -85,7 +85,7 @@ The results of the test can be found [here](https://ci.ros2.org/view/nightly/job
 
 ### Feature Testing [4.i]
 
-Many of the features have testing in `rmw_fastrtps_shared_cpp`. Since `rmw_fastrtps_shared_cpp` supports `rmw_fastrtps_cpp` and `rmw_fastrtps_dynamic_cpp`, integration and system tests for ROS middlewares up the stack also provide coverage.
+Many of the features have testing in `rmw_fastrtps_shared_cpp`. Since `rmw_fastrtps_shared_cpp` supports `rmw_fastrtps_cpp` and `rmw_fastrtps_dynamic_cpp`, integration and system tests for ROS middlewares up the stack, such as those found in [`test_rclcpp`](https://github.com/ros2/system_tests/tree/master/test_rclcpp) and [`test_communication`](https://github.com/ros2/system_tests/tree/master/test_communication) packages, provide coverage.
 
 ### Public API Testing [4.ii]
 


### PR DESCRIPTION
Precisely what the title says. As discussed offline, we defer unit testing and rely on integration and system tests up the stack (at least for the time being).