### PR TITLE
Make service wait for response reader

### DIFF
--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -192,6 +192,7 @@ rmw_create_client(
   }
 
   info->writer_guid_ = info->request_publisher_->getGuid();
+  info->reader_guid_ = info->response_subscriber_->getGuid();
 
   rmw_client = rmw_client_allocate();
   if (!rmw_client) {

--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -192,8 +192,9 @@ rmw_create_service(
     RMW_SET_ERROR_MSG("failed to get datawriter qos");
     goto fail;
   }
+  info->pub_listener_ = new ServicePubListener();
   info->response_publisher_ =
-    Domain::createPublisher(participant, publisherParam, nullptr);
+    Domain::createPublisher(participant, publisherParam, info->pub_listener_);
   if (!info->response_publisher_) {
     RMW_SET_ERROR_MSG("create_service() could not create publisher");
     goto fail;
@@ -253,6 +254,10 @@ fail:
         node->name,
         node->namespace_);
       Domain::removePublisher(info->response_publisher_);
+    }
+
+    if (info->pub_listener_) {
+      delete info->pub_listener_;
     }
 
     if (info->request_subscriber_) {

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
@@ -217,11 +217,12 @@ rmw_create_client(
   info->request_publisher_ =
     Domain::createPublisher(participant, publisherParam, info->pub_listener_);
   if (!info->request_publisher_) {
-    RMW_SET_ERROR_MSG("create_publisher() could not create publisher");
+    RMW_SET_ERROR_MSG("create_client() could not create publisher");
     goto fail;
   }
 
   info->writer_guid_ = info->request_publisher_->getGuid();
+  info->reader_guid_ = info->response_subscriber_->getGuid();
 
   rmw_client = rmw_client_allocate();
   if (!rmw_client) {

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
@@ -222,8 +222,9 @@ rmw_create_service(
     RMW_SET_ERROR_MSG("failed to get datawriter qos");
     goto fail;
   }
+  info->pub_listener_ = new ServicePubListener();
   info->response_publisher_ =
-    Domain::createPublisher(participant, publisherParam, nullptr);
+    Domain::createPublisher(participant, publisherParam, info->pub_listener_);
   if (!info->response_publisher_) {
     RMW_SET_ERROR_MSG("create_publisher() could not create publisher");
     goto fail;
@@ -283,6 +284,10 @@ fail:
         node->name,
         node->namespace_);
       Domain::removePublisher(info->response_publisher_);
+    }
+
+    if (info->pub_listener_) {
+      delete info->pub_listener_;
     }
 
     if (info->request_subscriber_) {

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_client_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_client_info.hpp
@@ -49,6 +49,7 @@ typedef struct CustomClientInfo
   eprosima::fastrtps::Publisher * request_publisher_;
   ClientListener * listener_;
   eprosima::fastrtps::rtps::GUID_t writer_guid_;
+  eprosima::fastrtps::rtps::GUID_t reader_guid_;
   eprosima::fastrtps::Participant * participant_;
   const char * typesupport_identifier_;
   ClientPubListener * pub_listener_;
@@ -88,7 +89,8 @@ public:
       if (eprosima::fastrtps::rtps::ALIVE == response.sample_info_.sampleKind) {
         response.sample_identity_ = response.sample_info_.related_sample_identity;
 
-        if (response.sample_identity_.writer_guid() == info_->writer_guid_) {
+        if (response.sample_identity_.writer_guid() == info_->reader_guid_ ||
+            response.sample_identity_.writer_guid() == info_->writer_guid_) {
           std::lock_guard<std::mutex> lock(internalMutex_);
 
           if (conditionMutex_ != nullptr) {

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_client_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_client_info.hpp
@@ -90,7 +90,8 @@ public:
         response.sample_identity_ = response.sample_info_.related_sample_identity;
 
         if (response.sample_identity_.writer_guid() == info_->reader_guid_ ||
-            response.sample_identity_.writer_guid() == info_->writer_guid_) {
+          response.sample_identity_.writer_guid() == info_->writer_guid_)
+        {
           std::lock_guard<std::mutex> lock(internalMutex_);
 
           if (conditionMutex_ != nullptr) {

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
@@ -84,6 +84,12 @@ public:
     if (sub->takeNextData(&data, &request.sample_info_)) {
       if (eprosima::fastrtps::rtps::ALIVE == request.sample_info_.sampleKind) {
         request.sample_identity_ = request.sample_info_.sample_identity;
+        // Use response subscriber guid (on related_sample_identity) when present.
+        const eprosima::fastrtps::rtps::GUID_t& reader_guid =
+          request.sample_info_.related_sample_identity.writer_guid();
+        if (reader_guid != eprosima::fastrtps::rtps::GUID_t::unknown() ) {
+          request.sample_identity_.writer_guid() = reader_guid;
+        }
 
         std::lock_guard<std::mutex> lock(internalMutex_);
 

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
@@ -19,6 +19,7 @@
 #include <condition_variable>
 #include <list>
 #include <mutex>
+#include <set>
 
 #include "fastcdr/FastBuffer.h"
 
@@ -87,7 +88,7 @@ public:
       if (eprosima::fastrtps::rtps::ALIVE == request.sample_info_.sampleKind) {
         request.sample_identity_ = request.sample_info_.sample_identity;
         // Use response subscriber guid (on related_sample_identity) when present.
-        const eprosima::fastrtps::rtps::GUID_t& reader_guid =
+        const eprosima::fastrtps::rtps::GUID_t & reader_guid =
           request.sample_info_.related_sample_identity.writer_guid();
         if (reader_guid != eprosima::fastrtps::rtps::GUID_t::unknown() ) {
           request.sample_identity_.writer_guid() = reader_guid;
@@ -170,18 +171,18 @@ private:
 class ServicePubListener : public eprosima::fastrtps::PublisherListener
 {
 public:
-  explicit ServicePubListener() = default;
-  
-  template< class Rep, class Period >
+  ServicePubListener() = default;
+
+  template<class Rep, class Period>
   bool wait_for_subscription(
     const eprosima::fastrtps::rtps::GUID_t & guid,
     const std::chrono::duration<Rep, Period> & rel_time)
   {
     auto guid_is_present = [this, guid]() -> bool
-    {
-      return subscriptions_.find(guid) != subscriptions_.end();
-    };
-    
+      {
+        return subscriptions_.find(guid) != subscriptions_.end();
+      };
+
     std::unique_lock<std::mutex> lock(mutex_);
     return cv_.wait_for(lock, rel_time, guid_is_present);
   }

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
@@ -19,7 +19,7 @@
 #include <condition_variable>
 #include <list>
 #include <mutex>
-#include <set>
+#include <unordered_set>
 
 #include "fastcdr/FastBuffer.h"
 
@@ -33,6 +33,7 @@
 #include "rcpputils/thread_safety_annotations.hpp"
 
 #include "rmw_fastrtps_shared_cpp/TypeSupport.hpp"
+#include "rmw_fastrtps_shared_cpp/guid_utils.hpp"
 
 class ServiceListener;
 class ServicePubListener;
@@ -204,8 +205,12 @@ public:
   }
 
 private:
+  using subscriptions_set_t =
+    std::unordered_set<eprosima::fastrtps::rtps::GUID_t,
+      rmw_fastrtps_shared_cpp::hash_fastrtps_guid>;
+
   std::mutex mutex_;
-  std::set<eprosima::fastrtps::rtps::GUID_t> subscriptions_ RCPPUTILS_TSA_GUARDED_BY(mutex_);
+  subscriptions_set_t subscriptions_ RCPPUTILS_TSA_GUARDED_BY(mutex_);
   std::condition_variable cv_;
 };
 

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/guid_utils.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/guid_utils.hpp
@@ -62,13 +62,14 @@ struct hash_fastrtps_guid
   {
     union u_convert {
       uint8_t plain_value[sizeof(guid)];
-      uint32_t plain_ints[4];
+      uint32_t plain_ints[sizeof(guid)/sizeof(uint32_t)];
     } u;
 
     static_assert(
+      sizeof(guid) == 16 &&
       sizeof(u.plain_value) == sizeof(u.plain_ints) &&
       offsetof(u_convert, plain_value) == offsetof(u_convert, plain_ints),
-      "ByteT should be either int8_t or uint8_t");
+      "Plain guid should be easily convertible to uint32_t[4]");
 
     copy_from_fastrtps_guid_to_byte_array(guid, u.plain_value);
 

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/guid_utils.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/guid_utils.hpp
@@ -60,8 +60,7 @@ struct hash_fastrtps_guid
 {
   std::size_t operator()(const eprosima::fastrtps::rtps::GUID_t & guid) const
   {
-    union u_convert
-    {
+    union u_convert {
       uint8_t plain_value[sizeof(guid)];
       uint32_t plain_ints[4];
     } u;

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/guid_utils.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/guid_utils.hpp
@@ -62,7 +62,7 @@ struct hash_fastrtps_guid
   {
     union u_convert {
       uint8_t plain_value[sizeof(guid)];
-      uint32_t plain_ints[sizeof(guid)/sizeof(uint32_t)];
+      uint32_t plain_ints[sizeof(guid) / sizeof(uint32_t)];
     } u;
 
     static_assert(

--- a/rmw_fastrtps_shared_cpp/src/rmw_request.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_request.cpp
@@ -57,6 +57,7 @@ __rmw_send_request(
   data.is_cdr_buffer = false;
   data.data = const_cast<void *>(ros_request);
   data.impl = info->request_type_support_impl_;
+  wparams.related_sample_identity().writer_guid() = info->reader_guid_;
   if (info->request_publisher_->write(&data, wparams)) {
     returnedValue = RMW_RET_OK;
     *sequence_id = ((int64_t)wparams.sample_identity().sequence_number().high) << 32 |

--- a/rmw_fastrtps_shared_cpp/src/rmw_response.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_response.cpp
@@ -104,6 +104,12 @@ __rmw_send_response(
   wparams.related_sample_identity().sequence_number().low =
     (int32_t)(request_header->sequence_number & 0xFFFFFFFF);
 
+  // TODO(MiguelCompany) The following block is a workaround for the race on the
+  // discovery of services. It is (ab)using a related_sample_identity on the request
+  // with the GUID of the response reader, so we can wait here for it to be matched to
+  // the server response writer. In the future, this should be done with the mechanism
+  // explained on OMG DDS-RPC 1.0 spec under section 7.6.2 (Enhanced Service Mapping)
+
   // According to the list of possible entity kinds in section 9.3.1.2 of RTPS
   // readers will have this bit on, while writers will not. We use this to know
   // if the related guid is the request writer or the response reader.

--- a/rmw_fastrtps_shared_cpp/src/rmw_response.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_response.cpp
@@ -110,11 +110,11 @@ __rmw_send_response(
   constexpr uint8_t entity_id_is_reader_bit = 0x04;
   const eprosima::fastrtps::rtps::GUID_t & related_guid =
     wparams.related_sample_identity().writer_guid();
-  if((related_guid.entityId.value[3] & entity_id_is_reader_bit) != 0)
-  {
+  if ((related_guid.entityId.value[3] & entity_id_is_reader_bit) != 0) {
     // Related guid is a reader, so it is the response subscription guid.
     // Wait for the response writer to be matched with it.
-    if(!info->pub_listener_->wait_for_subscription(related_guid, std::chrono::milliseconds(100))) {
+    auto listener = info->pub_listener_;
+    if (!listener->wait_for_subscription(related_guid, std::chrono::milliseconds(100))) {
       RMW_SET_ERROR_MSG("client will not receive response");
       return RMW_RET_ERROR;
     }

--- a/rmw_fastrtps_shared_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_service.cpp
@@ -97,6 +97,9 @@ __rmw_destroy_service(
     if (info->response_publisher_ != nullptr) {
       Domain::removePublisher(info->response_publisher_);
     }
+    if (info->pub_listener_ != nullptr) {
+      delete info->pub_listener_;
+    }
     if (info->listener_ != nullptr) {
       delete info->listener_;
     }

--- a/rmw_fastrtps_shared_cpp/src/rmw_service_server_is_available.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_service_server_is_available.cpp
@@ -100,11 +100,22 @@ __rmw_service_server_is_available(
     return RMW_RET_OK;
   }
 
-  if (0 == client_info->request_publisher_matched_count_.load()) {
+  if (number_of_request_subscribers != number_of_response_publishers) {
     // not ready
     return RMW_RET_OK;
   }
-  if (0 == client_info->response_subscriber_matched_count_.load()) {
+
+  size_t matched_request_pubs = client_info->request_publisher_matched_count_.load();
+  if (0 == matched_request_pubs) {
+    // not ready
+    return RMW_RET_OK;
+  }
+  size_t matched_response_subs = client_info->response_subscriber_matched_count_.load();
+  if (0 == matched_response_subs) {
+    // not ready
+    return RMW_RET_OK;
+  }
+  if (matched_request_pubs != matched_response_subs) {
     // not ready
     return RMW_RET_OK;
   }


### PR DESCRIPTION
This addresses ros2/ros2#922

The idea is to send the GUID of the response subscription on each request (using related_sample_identity), so the service could check if that reader is already matched to the response publisher when sending the response.

I've made the changes so they are backwards compatible. The service will only use and check the related guid when received. The client will check the received related guid against both the response reader and the request writer, in case an old service answers with the latter.