### PR TITLE
Do not compile assert death tests in Release builds.

### DIFF
--- a/rmw_fastrtps_shared_cpp/test/test_guid_utils.cpp
+++ b/rmw_fastrtps_shared_cpp/test/test_guid_utils.cpp
@@ -25,14 +25,18 @@ static constexpr size_t byte_array_size =
   eprosima::fastrtps::rtps::GuidPrefix_t::size +
   eprosima::fastrtps::rtps::EntityId_t::size;
 
+
 TEST(GUIDUtilsTest, bad_arguments) {
+#ifndef NDEBUG
   eprosima::fastrtps::rtps::GUID_t guid;
   uint8_t byte_array[byte_array_size] = {0};
   uint8_t * null_byte_array = nullptr;
   EXPECT_DEATH(copy_from_byte_array_to_fastrtps_guid(byte_array, nullptr), "");
   EXPECT_DEATH(copy_from_byte_array_to_fastrtps_guid(null_byte_array, &guid), "");
   EXPECT_DEATH(copy_from_fastrtps_guid_to_byte_array(guid, null_byte_array), "");
+#endif
 }
+
 
 TEST(GUIDUtilsTest, byte_array_to_guid_and_back) {
   uint8_t input_byte_array[byte_array_size] = {0};

--- a/rmw_fastrtps_shared_cpp/test/test_guid_utils.cpp
+++ b/rmw_fastrtps_shared_cpp/test/test_guid_utils.cpp
@@ -25,7 +25,6 @@ static constexpr size_t byte_array_size =
   eprosima::fastrtps::rtps::GuidPrefix_t::size +
   eprosima::fastrtps::rtps::EntityId_t::size;
 
-
 TEST(GUIDUtilsTest, bad_arguments) {
 #ifndef NDEBUG
   eprosima::fastrtps::rtps::GUID_t guid;
@@ -36,7 +35,6 @@ TEST(GUIDUtilsTest, bad_arguments) {
   EXPECT_DEATH(copy_from_fastrtps_guid_to_byte_array(guid, null_byte_array), "");
 #endif
 }
-
 
 TEST(GUIDUtilsTest, byte_array_to_guid_and_back) {
   uint8_t input_byte_array[byte_array_size] = {0};

--- a/rmw_fastrtps_shared_cpp/test/test_names.cpp
+++ b/rmw_fastrtps_shared_cpp/test/test_names.cpp
@@ -67,9 +67,11 @@ TEST(NamespaceTest, name_mangling) {
   rmw_qos_profile_t qos_profile = rmw_qos_profile_unknown;
   qos_profile.avoid_ros_namespace_conventions = false;
 
+#ifndef NDEBUG
   EXPECT_DEATH(_create_topic_name(nullptr, "", "", ""), "");
 
   EXPECT_DEATH(_create_topic_name(&qos_profile, "", nullptr, ""), "");
+#endif
 
   EXPECT_STREQ(
     "some_ros_prefix/test__suffix", _create_topic_name(


### PR DESCRIPTION
Fixes a regression introduced by https://github.com/ros2/rmw_fastrtps/pull/388.

CI up to `rmw_fastrtps_shared_cpp`, building for Release:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=10932)](http://ci.ros2.org/job/ci_linux/10932/)