### PR TITLE
Finalize init options in context.

### DIFF
--- a/rmw_fastrtps_cpp/src/rmw_init.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_init.cpp
@@ -129,6 +129,10 @@ rmw_context_fini(rmw_context_t * context)
     context->implementation_identifier,
     eprosima_fastrtps_identifier,
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  rmw_ret_t ret = rmw_init_options_fini(&context->options);
+  if (RMW_RET_OK != ret) {
+    return ret;
+  }
   delete context->impl;
   *context = rmw_get_zero_initialized_context();
   return RMW_RET_OK;

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_init.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_init.cpp
@@ -129,6 +129,10 @@ rmw_context_fini(rmw_context_t * context)
     context->implementation_identifier,
     eprosima_fastrtps_identifier,
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  rmw_ret_t ret = rmw_init_options_fini(&context->options);
+  if (RMW_RET_OK != ret) {
+    return ret;
+  }
   delete context->impl;
   *context = rmw_get_zero_initialized_context();
   return RMW_RET_OK;


### PR DESCRIPTION
Avoid leaking options when finalizing contexts.