### PR TITLE
Add missing thread-safety annotation in ServicePubListener

### DIFF
--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
@@ -180,9 +180,9 @@ public:
     const std::chrono::duration<Rep, Period> & rel_time)
   {
     auto guid_is_present = [this, guid]() RCPPUTILS_TSA_REQUIRES(mutex_) -> bool
-      {
-        return subscriptions_.find(guid) != subscriptions_.end();
-      };
+    {
+      return subscriptions_.find(guid) != subscriptions_.end();
+    };
 
     std::unique_lock<std::mutex> lock(mutex_);
     return cv_.wait_for(lock, rel_time, guid_is_present);

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
@@ -179,7 +179,7 @@ public:
     const eprosima::fastrtps::rtps::GUID_t & guid,
     const std::chrono::duration<Rep, Period> & rel_time)
   {
-    auto guid_is_present = [this, guid]() RCPPUTILS_TSA_REQUIRES(mutex_) -> bool
+    auto guid_is_present = [this, guid]() RCPPUTILS_TSA_REQUIRES(mutex_)->bool
     {
       return subscriptions_.find(guid) != subscriptions_.end();
     };

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
@@ -181,7 +181,6 @@ public:
   {
     auto guid_is_present = [this, guid]() RCPPUTILS_TSA_REQUIRES(mutex_) -> bool
       {
-
         return subscriptions_.find(guid) != subscriptions_.end();
       };
 

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
@@ -179,12 +179,11 @@ public:
     const eprosima::fastrtps::rtps::GUID_t & guid,
     const std::chrono::duration<Rep, Period> & rel_time)
   {
+    std::unique_lock<std::mutex> lock(mutex_);
     auto guid_is_present = [this, guid]() -> bool
       {
         return subscriptions_.find(guid) != subscriptions_.end();
       };
-
-    std::unique_lock<std::mutex> lock(mutex_);
     return cv_.wait_for(lock, rel_time, guid_is_present);
   }
 

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
@@ -179,11 +179,13 @@ public:
     const eprosima::fastrtps::rtps::GUID_t & guid,
     const std::chrono::duration<Rep, Period> & rel_time)
   {
-    std::unique_lock<std::mutex> lock(mutex_);
-    auto guid_is_present = [this, guid]() -> bool
+    auto guid_is_present = [this, guid]() RCPPUTILS_TSA_REQUIRES(mutex_) -> bool
       {
+
         return subscriptions_.find(guid) != subscriptions_.end();
       };
+
+    std::unique_lock<std::mutex> lock(mutex_);
     return cv_.wait_for(lock, rel_time, guid_is_present);
   }
 


### PR DESCRIPTION
Addresses https://github.com/ros2/rmw_fastrtps/pull/390#discussion_r455136217. Looks like thread safety analysis isn't smart enough. 