### PR TITLE
[dashing] Support for API break on Fast DDS 2.0

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
@@ -232,7 +232,12 @@ __rmw_create_node(
   // Load default XML profile.
   Domain::getDefaultParticipantAttributes(participantAttrs);
 
+#if FASTRTPS_VERSION_MAJOR < 2
   participantAttrs.rtps.builtin.domainId = static_cast<uint32_t>(domain_id);
+#else
+  participantAttrs.domainId = static_cast<uint32_t>(domain_id);
+#endif
+
   // since the participant name is not part of the DDS spec
   participantAttrs.rtps.setName(name);
 


### PR DESCRIPTION
Some users are trying to build dashing from sources using Fast DDS 2.0.x.

This PR contains changes equivalent to the ones in #370 to support that.

Signed-off-by: Miguel Company <miguelcompany@eProsima.com>