### PR TITLE
Make service wait for response reader (#390)

### DIFF
--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -192,6 +192,7 @@ rmw_create_client(
   }
 
   info->writer_guid_ = info->request_publisher_->getGuid();
+  info->reader_guid_ = info->response_subscriber_->getGuid();
 
   rmw_client = rmw_client_allocate();
   if (!rmw_client) {

--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -192,8 +192,9 @@ rmw_create_service(
     RMW_SET_ERROR_MSG("failed to get datawriter qos");
     goto fail;
   }
+  info->pub_listener_ = new ServicePubListener();
   info->response_publisher_ =
-    Domain::createPublisher(participant, publisherParam, nullptr);
+    Domain::createPublisher(participant, publisherParam, info->pub_listener_);
   if (!info->response_publisher_) {
     RMW_SET_ERROR_MSG("create_service() could not create publisher");
     goto fail;
@@ -253,6 +254,10 @@ fail:
         node->name,
         node->namespace_);
       Domain::removePublisher(info->response_publisher_);
+    }
+
+    if (info->pub_listener_) {
+      delete info->pub_listener_;
     }
 
     if (info->request_subscriber_) {

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
@@ -217,11 +217,12 @@ rmw_create_client(
   info->request_publisher_ =
     Domain::createPublisher(participant, publisherParam, info->pub_listener_);
   if (!info->request_publisher_) {
-    RMW_SET_ERROR_MSG("create_publisher() could not create publisher");
+    RMW_SET_ERROR_MSG("create_client() could not create publisher");
     goto fail;
   }
 
   info->writer_guid_ = info->request_publisher_->getGuid();
+  info->reader_guid_ = info->response_subscriber_->getGuid();
 
   rmw_client = rmw_client_allocate();
   if (!rmw_client) {

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
@@ -222,8 +222,9 @@ rmw_create_service(
     RMW_SET_ERROR_MSG("failed to get datawriter qos");
     goto fail;
   }
+  info->pub_listener_ = new ServicePubListener();
   info->response_publisher_ =
-    Domain::createPublisher(participant, publisherParam, nullptr);
+    Domain::createPublisher(participant, publisherParam, info->pub_listener_);
   if (!info->response_publisher_) {
     RMW_SET_ERROR_MSG("create_publisher() could not create publisher");
     goto fail;
@@ -283,6 +284,10 @@ fail:
         node->name,
         node->namespace_);
       Domain::removePublisher(info->response_publisher_);
+    }
+
+    if (info->pub_listener_) {
+      delete info->pub_listener_;
     }
 
     if (info->request_subscriber_) {

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_client_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_client_info.hpp
@@ -49,6 +49,7 @@ typedef struct CustomClientInfo
   eprosima::fastrtps::Publisher * request_publisher_;
   ClientListener * listener_;
   eprosima::fastrtps::rtps::GUID_t writer_guid_;
+  eprosima::fastrtps::rtps::GUID_t reader_guid_;
   eprosima::fastrtps::Participant * participant_;
   const char * typesupport_identifier_;
   ClientPubListener * pub_listener_;
@@ -88,7 +89,9 @@ public:
       if (eprosima::fastrtps::rtps::ALIVE == response.sample_info_.sampleKind) {
         response.sample_identity_ = response.sample_info_.related_sample_identity;
 
-        if (response.sample_identity_.writer_guid() == info_->writer_guid_) {
+        if (response.sample_identity_.writer_guid() == info_->reader_guid_ ||
+          response.sample_identity_.writer_guid() == info_->writer_guid_)
+        {
           std::lock_guard<std::mutex> lock(internalMutex_);
 
           if (conditionMutex_ != nullptr) {

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/guid_utils.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/guid_utils.hpp
@@ -16,6 +16,7 @@
 #define RMW_FASTRTPS_SHARED_CPP__GUID_UTILS_HPP_
 
 #include <cassert>
+#include <cstddef>
 #include <cstring>
 #include <type_traits>
 
@@ -54,6 +55,36 @@ copy_from_fastrtps_guid_to_byte_array(
   memcpy(guid_byte_array, &guid.guidPrefix, prefix_size);
   memcpy(&guid_byte_array[prefix_size], &guid.entityId, guid.entityId.size);
 }
+
+struct hash_fastrtps_guid
+{
+  std::size_t operator()(const eprosima::fastrtps::rtps::GUID_t & guid) const
+  {
+    union u_convert {
+      uint8_t plain_value[sizeof(guid)];
+      uint32_t plain_ints[sizeof(guid) / sizeof(uint32_t)];
+    } u;
+
+    static_assert(
+      sizeof(guid) == 16 &&
+      sizeof(u.plain_value) == sizeof(u.plain_ints) &&
+      offsetof(u_convert, plain_value) == offsetof(u_convert, plain_ints),
+      "Plain guid should be easily convertible to uint32_t[4]");
+
+    copy_from_fastrtps_guid_to_byte_array(guid, u.plain_value);
+
+    constexpr std::size_t prime_1 = 7;
+    constexpr std::size_t prime_2 = 31;
+    constexpr std::size_t prime_3 = 59;
+
+    size_t ret_val = prime_1 * u.plain_ints[0];
+    ret_val = prime_2 * (u.plain_ints[1] + ret_val);
+    ret_val = prime_3 * (u.plain_ints[2] + ret_val);
+    ret_val = u.plain_ints[3] + ret_val;
+
+    return ret_val;
+  }
+};
 
 }  // namespace rmw_fastrtps_shared_cpp
 

--- a/rmw_fastrtps_shared_cpp/src/rmw_request.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_request.cpp
@@ -57,6 +57,7 @@ __rmw_send_request(
   data.is_cdr_buffer = false;
   data.data = const_cast<void *>(ros_request);
   data.impl = info->request_type_support_impl_;
+  wparams.related_sample_identity().writer_guid() = info->reader_guid_;
   if (info->request_publisher_->write(&data, wparams)) {
     returnedValue = RMW_RET_OK;
     *sequence_id = ((int64_t)wparams.sample_identity().sequence_number().high) << 32 |

--- a/rmw_fastrtps_shared_cpp/src/rmw_response.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_response.cpp
@@ -104,6 +104,28 @@ __rmw_send_response(
   wparams.related_sample_identity().sequence_number().low =
     (int32_t)(request_header->sequence_number & 0xFFFFFFFF);
 
+  // TODO(MiguelCompany) The following block is a workaround for the race on the
+  // discovery of services. It is (ab)using a related_sample_identity on the request
+  // with the GUID of the response reader, so we can wait here for it to be matched to
+  // the server response writer. In the future, this should be done with the mechanism
+  // explained on OMG DDS-RPC 1.0 spec under section 7.6.2 (Enhanced Service Mapping)
+
+  // According to the list of possible entity kinds in section 9.3.1.2 of RTPS
+  // readers will have this bit on, while writers will not. We use this to know
+  // if the related guid is the request writer or the response reader.
+  constexpr uint8_t entity_id_is_reader_bit = 0x04;
+  const eprosima::fastrtps::rtps::GUID_t & related_guid =
+    wparams.related_sample_identity().writer_guid();
+  if ((related_guid.entityId.value[3] & entity_id_is_reader_bit) != 0) {
+    // Related guid is a reader, so it is the response subscription guid.
+    // Wait for the response writer to be matched with it.
+    auto listener = info->pub_listener_;
+    if (!listener->wait_for_subscription(related_guid, std::chrono::milliseconds(100))) {
+      RMW_SET_ERROR_MSG("client will not receive response");
+      return RMW_RET_ERROR;
+    }
+  }
+
   rmw_fastrtps_shared_cpp::SerializedData data;
   data.is_cdr_buffer = false;
   data.data = const_cast<void *>(ros_response);

--- a/rmw_fastrtps_shared_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_service.cpp
@@ -97,6 +97,9 @@ __rmw_destroy_service(
     if (info->response_publisher_ != nullptr) {
       Domain::removePublisher(info->response_publisher_);
     }
+    if (info->pub_listener_ != nullptr) {
+      delete info->pub_listener_;
+    }
     if (info->listener_ != nullptr) {
       delete info->listener_;
     }

--- a/rmw_fastrtps_shared_cpp/src/rmw_service_server_is_available.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_service_server_is_available.cpp
@@ -100,11 +100,22 @@ __rmw_service_server_is_available(
     return RMW_RET_OK;
   }
 
-  if (0 == client_info->request_publisher_matched_count_.load()) {
+  if (number_of_request_subscribers != number_of_response_publishers) {
     // not ready
     return RMW_RET_OK;
   }
-  if (0 == client_info->response_subscriber_matched_count_.load()) {
+
+  size_t matched_request_pubs = client_info->request_publisher_matched_count_.load();
+  if (0 == matched_request_pubs) {
+    // not ready
+    return RMW_RET_OK;
+  }
+  size_t matched_response_subs = client_info->response_subscriber_matched_count_.load();
+  if (0 == matched_response_subs) {
+    // not ready
+    return RMW_RET_OK;
+  }
+  if (matched_request_pubs != matched_response_subs) {
     // not ready
     return RMW_RET_OK;
   }


### PR DESCRIPTION
Backport #390 to Foxy.

Note, this breaks ABI compatibility, but only below the RMW layer. IMO, the breakage is acceptable considering the improvement to service discovery.

I'm still checking if this change is backports compatible over the wire.