### PR TITLE
[foxy backport] Add missing thread-safety annotation in ServicePubListener (#409)

### DIFF
--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
@@ -179,10 +179,10 @@ public:
     const eprosima::fastrtps::rtps::GUID_t & guid,
     const std::chrono::duration<Rep, Period> & rel_time)
   {
-    auto guid_is_present = [this, guid]() -> bool
-      {
-        return subscriptions_.find(guid) != subscriptions_.end();
-      };
+    auto guid_is_present = [this, guid]() RCPPUTILS_TSA_REQUIRES(mutex_)->bool
+    {
+      return subscriptions_.find(guid) != subscriptions_.end();
+    };
 
     std::unique_lock<std::mutex> lock(mutex_);
     return cv_.wait_for(lock, rel_time, guid_is_present);


### PR DESCRIPTION
Backport #409 to Foxy