### PR TITLE
Avoid unused identifier variable warnings.

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/subscription.cpp
+++ b/rmw_fastrtps_shared_cpp/src/subscription.cpp
@@ -45,6 +45,7 @@ destroy_subscription(
   rmw_subscription_t * subscription)
 {
   assert(subscription->implementation_identifier == identifier);
+  static_cast<void>(identifier);
 
   rmw_ret_t ret = RMW_RET_OK;
   auto info = static_cast<CustomSubscriberInfo *>(subscription->data);


### PR DESCRIPTION
Fixes regression introduced by 94b379e9245d31c2c1ed8344751674c0dfd6e26c / #419.

CI up to `rmw_fastrtps_shared_cpp` in `Release` mode:

* Linux [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11802)](https://ci.ros2.org/job/ci_linux/11802/)