### PR TITLE
Fix memory leak that wait_set might be not destroyed in some case.

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/listener_thread.cpp
+++ b/rmw_fastrtps_shared_cpp/src/listener_thread.cpp
@@ -144,6 +144,11 @@ node_listener(rmw_context_t * context)
     {
       TERMINATE_THREAD("rmw_wait failed");
     }
+    if (RMW_RET_OK != rmw_fastrtps_shared_cpp::__rmw_destroy_wait_set(
+        context->implementation_identifier, wait_set))
+    {
+      TERMINATE_THREAD("failed to destroy wait set");
+    }
     if (subscriptions_buffer[0]) {
       rmw_dds_common::msg::ParticipantEntitiesInfo msg;
       bool taken;
@@ -167,11 +172,6 @@ node_listener(rmw_context_t * context)
         }
         common_context->graph_cache.update_participant_entities(msg);
       }
-    }
-    if (RMW_RET_OK != rmw_fastrtps_shared_cpp::__rmw_destroy_wait_set(
-        context->implementation_identifier, wait_set))
-    {
-      TERMINATE_THREAD("failed to destroy wait set");
     }
   }
 }


### PR DESCRIPTION
Related to https://github.com/ros2/rcl/issues/721

<details><summary>memory leak log </summary>
<p>

```shell
==23229== 784 (168 direct, 616 indirect) bytes in 7 blocks are definitely lost in loss record 15 of 16
==23229==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==23229==    by 0x5CFD615: __default_allocate (allocator.c:35)
==23229==    by 0x797FF24: rmw_allocate (allocators.c:29)
==23229==    by 0x79800C0: rmw_wait_set_allocate (allocators.c:133)
==23229==    by 0x84254B9: rmw_fastrtps_shared_cpp::__rmw_create_wait_set(char const*, rmw_context_t*, unsigned long) (rmw_wait_set.cpp:38)
==23229==    by 0x83EEAEA: node_listener(rmw_context_t*) (listener_thread.cpp:132)
==23229==    by 0x83EF3B6: void std::__invoke_impl<void, void (*)(rmw_context_t*), rmw_context_t*>(std::__invoke_other, void (*&&)(rmw_context_t*), rmw_context_t*&&) (invoke.h:60)
==23229==    by 0x83EEFDA: std::__invoke_result<void (*)(rmw_context_t*), rmw_context_t*>::type std::__invoke<void (*)(rmw_context_t*), rmw_context_t*>(void (*&&)(rmw_context_t*), rmw_context_t*&&) (invoke.h:95)
==23229==    by 0x83EFA48: decltype (__invoke((_S_declval<0ul>)(), (_S_declval<1ul>)())) std::thread::_Invoker<std::tuple<void (*)(rmw_context_t*), rmw_context_t*> >::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) (thread:234)
==23229==    by 0x83EF9E9: std::thread::_Invoker<std::tuple<void (*)(rmw_context_t*), rmw_context_t*> >::operator()() (thread:243)
==23229==    by 0x83EF9B9: std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(rmw_context_t*), rmw_context_t*> > >::_M_run() (thread:186)
==23229==    by 0x64656DE: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.25)

```

</p>
</details>


Signed-off-by: Chen.Lihui <lihui.chen@sony.com>