### PR TITLE
Ensure compliant publisher QoS queries.

### DIFF
--- a/rmw_fastrtps_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publisher.cpp
@@ -139,6 +139,14 @@ rmw_publisher_get_actual_qos(
   const rmw_publisher_t * publisher,
   rmw_qos_profile_t * qos)
 {
+  RMW_CHECK_ARGUMENT_FOR_NULL(publisher, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    publisher,
+    publisher->implementation_identifier,
+    eprosima_fastrtps_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RMW_CHECK_ARGUMENT_FOR_NULL(qos, RMW_RET_INVALID_ARGUMENT);
+
   return rmw_fastrtps_shared_cpp::__rmw_publisher_get_actual_qos(
     publisher, qos);
 }

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_publisher.cpp
@@ -143,6 +143,14 @@ rmw_publisher_get_actual_qos(
   const rmw_publisher_t * publisher,
   rmw_qos_profile_t * qos)
 {
+  RMW_CHECK_ARGUMENT_FOR_NULL(publisher, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    publisher,
+    publisher->implementation_identifier,
+    eprosima_fastrtps_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RMW_CHECK_ARGUMENT_FOR_NULL(qos, RMW_RET_INVALID_ARGUMENT);
+
   return rmw_fastrtps_shared_cpp::__rmw_publisher_get_actual_qos(
     publisher, qos);
 }

--- a/rmw_fastrtps_shared_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_publisher.cpp
@@ -125,13 +125,13 @@ __rmw_publisher_get_actual_qos(
   const rmw_publisher_t * publisher,
   rmw_qos_profile_t * qos)
 {
- auto info = static_cast<CustomPublisherInfo *>(publisher->data);
- eprosima::fastrtps::Publisher * fastrtps_pub = info->publisher_;
- const eprosima::fastrtps::PublisherAttributes & attributes =
-   fastrtps_pub->getAttributes();
+  auto info = static_cast<CustomPublisherInfo *>(publisher->data);
+  eprosima::fastrtps::Publisher * fastrtps_pub = info->publisher_;
+  const eprosima::fastrtps::PublisherAttributes & attributes =
+    fastrtps_pub->getAttributes();
 
- dds_attributes_to_rmw_qos(attributes, qos);
+  dds_attributes_to_rmw_qos(attributes, qos);
 
- return RMW_RET_OK;
+  return RMW_RET_OK;
 }
 }  // namespace rmw_fastrtps_shared_cpp

--- a/rmw_fastrtps_shared_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_publisher.cpp
@@ -125,22 +125,13 @@ __rmw_publisher_get_actual_qos(
   const rmw_publisher_t * publisher,
   rmw_qos_profile_t * qos)
 {
-  RMW_CHECK_ARGUMENT_FOR_NULL(publisher, RMW_RET_INVALID_ARGUMENT);
-  RMW_CHECK_ARGUMENT_FOR_NULL(qos, RMW_RET_INVALID_ARGUMENT);
+ auto info = static_cast<CustomPublisherInfo *>(publisher->data);
+ eprosima::fastrtps::Publisher * fastrtps_pub = info->publisher_;
+ const eprosima::fastrtps::PublisherAttributes & attributes =
+   fastrtps_pub->getAttributes();
 
-  auto info = static_cast<CustomPublisherInfo *>(publisher->data);
-  if (info == nullptr) {
-    return RMW_RET_ERROR;
-  }
-  eprosima::fastrtps::Publisher * fastrtps_pub = info->publisher_;
-  if (fastrtps_pub == nullptr) {
-    return RMW_RET_ERROR;
-  }
-  const eprosima::fastrtps::PublisherAttributes & attributes =
-    fastrtps_pub->getAttributes();
+ dds_attributes_to_rmw_qos(attributes, qos);
 
-  dds_attributes_to_rmw_qos(attributes, qos);
-
-  return RMW_RET_OK;
+ return RMW_RET_OK;
 }
 }  // namespace rmw_fastrtps_shared_cpp


### PR DESCRIPTION
Follow-up after 8fc9ca3d98a64118590a205b2162559e17309a27 (#414).
