### PR TITLE
Improve __rmw_create_wait_set() implementation.

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/rmw_wait_set.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_wait_set.cpp
@@ -50,13 +50,13 @@ __rmw_create_wait_set(const char * identifier, rmw_context_t * context, size_t m
     goto fail;
   }
   // This should default-construct the fields of CustomWaitsetInfo
-  // cppcheck-suppress syntaxError
   RMW_TRY_PLACEMENT_NEW(
     wait_set_info,
     wait_set->data,
     goto fail,
-    CustomWaitsetInfo, )
-  (void)wait_set_info;
+    // cppcheck-suppress syntaxError
+    CustomWaitsetInfo, );
+  (void) wait_set_info;
 
   return wait_set;
 


### PR DESCRIPTION
Handle errors consistently. Do not assume allocation will always succeed.