### PR TITLE
Avoid memory leaks and undefined behavior in rmw_fastrtps_dynamic_cpp typesupport code

### DIFF
--- a/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport.hpp
+++ b/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport.hpp
@@ -100,7 +100,7 @@ struct StringHelper<rosidl_typesupport_introspection_c__MessageMembers>
     return std::string(data.data);
   }
 
-  static void assign(eprosima::fastcdr::Cdr & deser, void * field, bool)
+  static void assign(eprosima::fastcdr::Cdr & deser, void * field)
   {
     std::string str;
     deser >> str;
@@ -120,12 +120,9 @@ struct StringHelper<rosidl_typesupport_introspection_cpp::MessageMembers>
     return *(static_cast<std::string *>(data));
   }
 
-  static void assign(eprosima::fastcdr::Cdr & deser, void * field, bool call_new)
+  static void assign(eprosima::fastcdr::Cdr & deser, void * field)
   {
     std::string & str = *(std::string *)field;
-    if (call_new) {
-      new(&str) std::string;
-    }
     deser >> str;
   }
 };
@@ -195,8 +192,7 @@ private:
   bool deserializeROSmessage(
     eprosima::fastcdr::Cdr & deser,
     const MembersType * members,
-    void * ros_message,
-    bool call_new) const;
+    void * ros_message) const;
 };
 
 }  // namespace rmw_fastrtps_dynamic_cpp

--- a/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport_impl.hpp
+++ b/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport_impl.hpp
@@ -196,7 +196,7 @@ static size_t calculateMaxAlign(const MembersType * members)
           break;
         case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_MESSAGE:
           {
-            auto sub_members = (const MembersType *)member.members_->data;
+            auto sub_members = static_cast<const MembersType *>(member.members_->data);
             alignment = calculateMaxAlign(sub_members);
           }
           break;
@@ -968,7 +968,7 @@ bool TypeSupport<MembersType>::deserializeROSmessage(
         break;
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_MESSAGE:
         {
-          auto sub_members = (const MembersType *)member->members_->data;
+          auto sub_members = static_cast<const MembersType *>(member->members_->data);
           if (!member->is_array_) {
             deserializeROSmessage(deser, sub_members, field);
           } else {

--- a/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport_impl.hpp
+++ b/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport_impl.hpp
@@ -23,6 +23,9 @@
 
 #include "rmw_fastrtps_dynamic_cpp/TypeSupport.hpp"
 #include "rmw_fastrtps_dynamic_cpp/macros.hpp"
+
+#include "rmw/error_handling.h"
+
 #include "rosidl_typesupport_fastrtps_c/wstring_conversion.hpp"
 #include "rosidl_typesupport_fastrtps_cpp/wstring_conversion.hpp"
 #include "rosidl_typesupport_introspection_cpp/field_types.hpp"
@@ -883,41 +886,30 @@ inline void deserialize_field<std::wstring>(
   }
 }
 
-inline size_t get_submessage_array_deserialize(
+inline
+void * get_subros_message(
   const rosidl_typesupport_introspection_cpp::MessageMember * member,
-  eprosima::fastcdr::Cdr & deser,
   void * field,
-  void * & subros_message,
-  size_t sub_members_size,
-  size_t max_align)
+  size_t index,
+  size_t,
+  bool)
 {
-  (void)member;
-  uint32_t vsize = 0;
-  // Deserialize length
-  deser >> vsize;
-  auto vector = reinterpret_cast<std::vector<unsigned char> *>(field);
-  void * ptr = reinterpret_cast<void *>(sub_members_size);
-  vector->resize(vsize * (size_t)align_(max_align, ptr));
-  subros_message = reinterpret_cast<void *>(vector->data());
-  return vsize;
+  return member->get_function(field, index);
 }
 
-inline size_t get_submessage_array_deserialize(
+inline
+void * get_subros_message(
   const rosidl_typesupport_introspection_c__MessageMember * member,
-  eprosima::fastcdr::Cdr & deser,
   void * field,
-  void * & subros_message,
-  size_t sub_members_size,
-  size_t)
+  size_t index,
+  size_t array_size,
+  bool is_upper_bound)
 {
-  (void)member;
-  // Deserialize length
-  uint32_t vsize = 0;
-  deser >> vsize;
-  auto tmpsequence = static_cast<rosidl_runtime_c__void__Sequence *>(field);
-  rosidl_runtime_c__void__Sequence__init(tmpsequence, vsize, sub_members_size);
-  subros_message = reinterpret_cast<void *>(tmpsequence->data);
-  return vsize;
+  if (array_size && !is_upper_bound) {
+    return member->get_function(&field, index);
+  }
+
+  return member->get_function(field, index);
 }
 
 template<typename MembersType>
@@ -980,24 +972,32 @@ bool TypeSupport<MembersType>::deserializeROSmessage(
           if (!member->is_array_) {
             deserializeROSmessage(deser, sub_members, field);
           } else {
-            void * subros_message = nullptr;
             size_t array_size = 0;
-            size_t sub_members_size = sub_members->size_of_;
-            size_t max_align = calculateMaxAlign(sub_members);
 
             if (member->array_size_ && !member->is_upper_bound_) {
-              subros_message = field;
               array_size = member->array_size_;
             } else {
-              array_size = get_submessage_array_deserialize(
-                member, deser, field, subros_message,
-                sub_members_size, max_align);
+              uint32_t num_elems = 0;
+              deser >> num_elems;
+              array_size = static_cast<size_t>(num_elems);
+              
+              if (!member->resize_function) {
+                RMW_SET_ERROR_MSG("unexpected error: resize function is null");
+                return false;
+              }
+              member->resize_function(field, array_size);
             }
 
+            if (array_size != 0 && !member->get_function) {
+              RMW_SET_ERROR_MSG("unexpected error: get_function function is null");
+              return false;
+            }
             for (size_t index = 0; index < array_size; ++index) {
-              deserializeROSmessage(deser, sub_members, subros_message);
-              subros_message = static_cast<char *>(subros_message) + sub_members_size;
-              subros_message = align_(max_align, subros_message);
+              deserializeROSmessage(
+                deser, sub_members,
+                get_subros_message(
+                  member, field, index, member->array_size_,
+                  member->is_upper_bound_));
             }
           }
         }

--- a/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport_impl.hpp
+++ b/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport_impl.hpp
@@ -980,7 +980,7 @@ bool TypeSupport<MembersType>::deserializeROSmessage(
               uint32_t num_elems = 0;
               deser >> num_elems;
               array_size = static_cast<size_t>(num_elems);
-              
+
               if (!member->resize_function) {
                 RMW_SET_ERROR_MSG("unexpected error: resize function is null");
                 return false;

--- a/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport_impl.hpp
+++ b/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport_impl.hpp
@@ -58,157 +58,12 @@ SPECIALIZE_GENERIC_C_SEQUENCE(uint32, uint32_t)
 SPECIALIZE_GENERIC_C_SEQUENCE(int64, int64_t)
 SPECIALIZE_GENERIC_C_SEQUENCE(uint64, uint64_t)
 
-typedef struct rosidl_runtime_c__void__Sequence
-{
-  void * data;
-  /// The number of valid items in data
-  size_t size;
-  /// The number of allocated items in data
-  size_t capacity;
-} rosidl_runtime_c__void__Sequence;
-
-inline
-bool
-rosidl_runtime_c__void__Sequence__init(
-  rosidl_runtime_c__void__Sequence * sequence, size_t size, size_t member_size)
-{
-  if (!sequence) {
-    return false;
-  }
-  void * data = nullptr;
-  if (size) {
-    data = static_cast<void *>(calloc(size, member_size));
-    if (!data) {
-      return false;
-    }
-  }
-  sequence->data = data;
-  sequence->size = size;
-  sequence->capacity = size;
-  return true;
-}
-
-inline
-void
-rosidl_runtime_c__void__Sequence__fini(rosidl_runtime_c__void__Sequence * sequence)
-{
-  if (!sequence) {
-    return;
-  }
-  if (sequence->data) {
-    // ensure that data and capacity values are consistent
-    assert(sequence->capacity > 0);
-    // finalize all sequence elements
-    free(sequence->data);
-    sequence->data = nullptr;
-    sequence->size = 0;
-    sequence->capacity = 0;
-  } else {
-    // ensure that data, size, and capacity values are consistent
-    assert(0 == sequence->size);
-    assert(0 == sequence->capacity);
-  }
-}
-
 template<typename MembersType>
 TypeSupport<MembersType>::TypeSupport(const void * ros_type_support)
 : BaseTypeSupport(ros_type_support)
 {
   m_isGetKeyDefined = false;
   max_size_bound_ = false;
-}
-
-static inline void *
-align_(size_t __align, void * & __ptr) noexcept
-{
-  const auto __intptr = reinterpret_cast<uintptr_t>(__ptr);
-  const auto __aligned = (__intptr - 1u + __align) & ~(__align - 1);
-  return __ptr = reinterpret_cast<void *>(__aligned);
-}
-
-template<typename MembersType>
-static size_t calculateMaxAlign(const MembersType * members)
-{
-  size_t max_align = 0;
-
-  for (uint32_t i = 0; i < members->member_count_; ++i) {
-    size_t alignment = 0;
-    const auto & member = members->members_[i];
-
-    if (member.is_array_ && (!member.array_size_ || member.is_upper_bound_)) {
-      alignment = alignof(std::vector<unsigned char>);
-    } else {
-      switch (member.type_id_) {
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_BOOL:
-          alignment = alignof(bool);
-          break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_BYTE:
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT8:
-          alignment = alignof(uint8_t);
-          break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_CHAR:
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT8:
-          alignment = alignof(char);
-          break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_FLOAT32:
-          alignment = alignof(float);
-          break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_FLOAT64:
-          alignment = alignof(double);
-          break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT16:
-          alignment = alignof(int16_t);
-          break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT16:
-          alignment = alignof(uint16_t);
-          break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT32:
-          alignment = alignof(int32_t);
-          break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT32:
-          alignment = alignof(uint32_t);
-          break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT64:
-          alignment = alignof(int64_t);
-          break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT64:
-          alignment = alignof(uint64_t);
-          break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_STRING:
-          // Note: specialization needed because calculateMaxAlign is called before
-          // casting submembers as std::string, returned value is the same on i386
-          if (std::is_same<MembersType,
-            rosidl_typesupport_introspection_c__MessageMembers>::value)
-          {
-            alignment = alignof(rosidl_runtime_c__String);
-          } else {
-            alignment = alignof(std::string);
-          }
-          break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_WSTRING:
-          if (std::is_same<MembersType,
-            rosidl_typesupport_introspection_c__MessageMembers>::value)
-          {
-            alignment = alignof(rosidl_runtime_c__U16String);
-          } else {
-            alignment = alignof(std::u16string);
-          }
-          break;
-        case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_MESSAGE:
-          {
-            auto sub_members = static_cast<const MembersType *>(member.members_->data);
-            alignment = calculateMaxAlign(sub_members);
-          }
-          break;
-      }
-    }
-
-    if (alignment > max_align) {
-      max_align = alignment;
-    }
-  }
-
-  return max_align;
 }
 
 // C++ specialization
@@ -366,39 +221,6 @@ void * get_subros_message(
   }
 
   return member->get_function(field, index);
-}
-
-inline
-size_t get_array_size_and_assign_field(
-  const rosidl_typesupport_introspection_cpp::MessageMember * member,
-  void * field,
-  void * & subros_message,
-  size_t sub_members_size,
-  size_t max_align)
-{
-  auto vector = reinterpret_cast<std::vector<unsigned char> *>(field);
-  void * ptr = reinterpret_cast<void *>(sub_members_size);
-  size_t vsize = vector->size() / reinterpret_cast<size_t>(align_(max_align, ptr));
-  if (member->is_upper_bound_ && vsize > member->array_size_) {
-    throw std::runtime_error("vector overcomes the maximum length");
-  }
-  subros_message = reinterpret_cast<void *>(vector->data());
-  return vsize;
-}
-
-inline
-size_t get_array_size_and_assign_field(
-  const rosidl_typesupport_introspection_c__MessageMember * member,
-  void * field,
-  void * & subros_message,
-  size_t, size_t)
-{
-  auto tmpsequence = static_cast<rosidl_runtime_c__void__Sequence *>(field);
-  if (member->is_upper_bound_ && tmpsequence->size > member->array_size_) {
-    throw std::runtime_error("vector overcomes the maximum length");
-  }
-  subros_message = reinterpret_cast<void *>(tmpsequence->data);
-  return tmpsequence->size;
 }
 
 template<typename MembersType>


### PR DESCRIPTION
This fixes #428 by using a similar approach to ros2/rmw_cyclonedds#228

It also addresses #219 