### PR TITLE
Inject faults on __rmw_publish() and run_listener_thread() call.

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/listener_thread.cpp
+++ b/rmw_fastrtps_shared_cpp/src/listener_thread.cpp
@@ -44,6 +44,8 @@ node_listener(rmw_context_t * context);
 rmw_ret_t
 rmw_fastrtps_shared_cpp::run_listener_thread(rmw_context_t * context)
 {
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(RMW_RET_ERROR);
+
   auto common_context = static_cast<rmw_dds_common::Context *>(context->impl->common);
   common_context->thread_is_running.store(true);
   common_context->listener_thread_gc = rmw_fastrtps_shared_cpp::__rmw_create_guard_condition(

--- a/rmw_fastrtps_shared_cpp/src/rmw_publish.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_publish.cpp
@@ -33,6 +33,10 @@ __rmw_publish(
   const void * ros_message,
   rmw_publisher_allocation_t * allocation)
 {
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(RMW_RET_INVALID_ARGUMENT);
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(RMW_RET_ERROR);
+
   (void) allocation;
   RMW_CHECK_FOR_NULL_WITH_MSG(
     publisher, "publisher handle is null",
@@ -66,6 +70,10 @@ __rmw_publish_serialized_message(
   const rmw_serialized_message_t * serialized_message,
   rmw_publisher_allocation_t * allocation)
 {
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(RMW_RET_INVALID_ARGUMENT);
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(RMW_RET_ERROR);
+
   (void) allocation;
   RMW_CHECK_FOR_NULL_WITH_MSG(
     publisher, "publisher handle is null",


### PR DESCRIPTION
Precisely what the title says. To bump coverage leveraging fault injection tests in upper layers.

Full CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=12389)](http://ci.ros2.org/job/ci_linux/12389/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=7357)](http://ci.ros2.org/job/ci_linux-aarch64/7357/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=10100)](http://ci.ros2.org/job/ci_osx/10100/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=12301)](http://ci.ros2.org/job/ci_windows/12301/)
