### PR TITLE
Make service/client construction/destruction implementation compliant

### DIFF
--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -14,10 +14,14 @@
 
 #include <string>
 
+#include "rcpputils/scope_exit.hpp"
 #include "rcutils/logging_macros.h"
 
 #include "rmw/allocators.h"
+#include "rmw/error_handling.h"
+#include "rmw/impl/cpp/macros.hpp"
 #include "rmw/rmw.h"
+#include "rmw/validate_full_topic_name.h"
 
 #include "rmw_fastrtps_shared_cpp/custom_client_info.hpp"
 #include "rmw_fastrtps_shared_cpp/custom_participant_info.hpp"
@@ -43,39 +47,36 @@ rmw_create_client(
   const rosidl_service_type_support_t * type_supports,
   const char * service_name, const rmw_qos_profile_t * qos_policies)
 {
-  if (!node) {
-    RMW_SET_ERROR_MSG("node handle is null");
+  RMW_CHECK_ARGUMENT_FOR_NULL(node, nullptr);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    node,
+    node->implementation_identifier,
+    eprosima_fastrtps_identifier,
+    return nullptr);
+  RMW_CHECK_ARGUMENT_FOR_NULL(type_supports, nullptr);
+  RMW_CHECK_ARGUMENT_FOR_NULL(service_name, nullptr);
+  if (0 == strlen(service_name)) {
+    RMW_SET_ERROR_MSG("service_name argument is an empty string");
     return nullptr;
   }
-
-  if (node->implementation_identifier != eprosima_fastrtps_identifier) {
-    RMW_SET_ERROR_MSG("node handle not from this implementation");
-    return nullptr;
-  }
-
-  if (!service_name || strlen(service_name) == 0) {
-    RMW_SET_ERROR_MSG("client topic is null or empty string");
-    return nullptr;
-  }
-
-  if (!qos_policies) {
-    RMW_SET_ERROR_MSG("qos_profile is null");
-    return nullptr;
+  RMW_CHECK_ARGUMENT_FOR_NULL(qos_policies, nullptr);
+  if (!qos_policies->avoid_ros_namespace_conventions) {
+    int validation_result = RMW_TOPIC_VALID;
+    rmw_ret_t ret = rmw_validate_full_topic_name(service_name, &validation_result, nullptr);
+    if (RMW_RET_OK != ret) {
+      return nullptr;
+    }
+    if (RMW_TOPIC_VALID != validation_result) {
+      const char * reason = rmw_full_topic_name_validation_result_string(validation_result);
+      RMW_SET_ERROR_MSG_WITH_FORMAT_STRING("service_name argument is invalid: %s", reason);
+      return nullptr;
+    }
   }
 
   auto common_context = static_cast<rmw_dds_common::Context *>(node->context->impl->common);
   auto participant_info =
     static_cast<CustomParticipantInfo *>(node->context->impl->participant_info);
-  if (!participant_info) {
-    RMW_SET_ERROR_MSG("participant info is null");
-    return nullptr;
-  }
-
   Participant * participant = participant_info->participant;
-  if (!participant) {
-    RMW_SET_ERROR_MSG("participant handle is null");
-    return nullptr;
-  }
 
   const rosidl_service_type_support_t * type_support = get_service_typesupport_handle(
     type_supports, RMW_FASTRTPS_CPP_TYPESUPPORT_C);
@@ -88,12 +89,21 @@ rmw_create_client(
     }
   }
 
-  CustomClientInfo * info = nullptr;
-  eprosima::fastrtps::SubscriberAttributes subscriberParam;
-  eprosima::fastrtps::PublisherAttributes publisherParam;
-  rmw_client_t * rmw_client = nullptr;
-
-  info = new CustomClientInfo();
+  CustomClientInfo * info = new (std::nothrow) CustomClientInfo();
+  if (!info) {
+    RMW_SET_ERROR_MSG("failed to allocate client info");
+    return nullptr;
+  }
+  auto cleanup_base_info = rcpputils::make_scope_exit(
+    [info, participant]() {
+      if (info->request_type_support_) {
+        rmw_fastrtps_shared_cpp::_unregister_type(participant, info->request_type_support_);
+      }
+      if (info->response_type_support_) {
+        rmw_fastrtps_shared_cpp::_unregister_type(participant, info->response_type_support_);
+      }
+      delete info;
+    });
   info->participant_ = participant;
   info->typesupport_identifier_ = type_support->typesupport_identifier;
   info->request_publisher_matched_count_ = 0;
@@ -120,7 +130,11 @@ rmw_create_client(
       participant, request_type_name.c_str(),
       reinterpret_cast<TopicDataType **>(&info->request_type_support_)))
   {
-    info->request_type_support_ = new RequestTypeSupport_cpp(service_members);
+    info->request_type_support_ = new (std::nothrow) RequestTypeSupport_cpp(service_members);
+    if (!info->request_type_support_) {
+      RMW_SET_ERROR_MSG("failed to allocate request typesupport");
+      return nullptr;
+    }
     _register_type(participant, info->request_type_support_);
   }
 
@@ -129,9 +143,16 @@ rmw_create_client(
       participant, response_type_name.c_str(),
       reinterpret_cast<TopicDataType **>(&info->response_type_support_)))
   {
-    info->response_type_support_ = new ResponseTypeSupport_cpp(service_members);
+    info->response_type_support_ = new (std::nothrow) ResponseTypeSupport_cpp(service_members);
+    if (!info->response_type_support_) {
+      RMW_SET_ERROR_MSG("failed to allocate response typesupport");
+      return nullptr;
+    }
     _register_type(participant, info->response_type_support_);
   }
+
+  eprosima::fastrtps::SubscriberAttributes subscriberParam;
+  eprosima::fastrtps::PublisherAttributes publisherParam;
 
   if (!participant_info->leave_middleware_default_qos) {
     subscriberParam.historyMemoryPolicy =
@@ -167,38 +188,75 @@ rmw_create_client(
 
   // Create Client Subscriber and set QoS
   if (!get_datareader_qos(*qos_policies, subscriberParam)) {
-    RMW_SET_ERROR_MSG("failed to get datareader qos");
-    goto fail;
+    return nullptr;
   }
-  info->listener_ = new ClientListener(info);
+  auto cleanup_response_subscriber = rcpputils::make_scope_exit(
+    [info]() {
+      if (info->response_subscriber_) {
+        if (!Domain::removeSubscriber(info->response_subscriber_)) {
+          RMW_SAFE_FWRITE_TO_STDERR(
+            "Failed to remove response subscriber after '"
+            RCUTILS_STRINGIFY(__function__) "' failed.\n");
+        }
+      }
+      if (info->listener_) {
+        delete info->listener_;
+      }
+    });
+  info->listener_ = new (std::nothrow) ClientListener(info);
+  if (!info->listener_) {
+    RMW_SET_ERROR_MSG("failed to create client response subscriber listener");
+    return nullptr;
+  }
   info->response_subscriber_ =
     Domain::createSubscriber(participant, subscriberParam, info->listener_);
   if (!info->response_subscriber_) {
-    RMW_SET_ERROR_MSG("create_client() could not create subscriber");
-    goto fail;
+    RMW_SET_ERROR_MSG("failed to create client response subscriber");
+    return nullptr;
   }
 
   // Create Client Publisher and set QoS
   if (!get_datawriter_qos(*qos_policies, publisherParam)) {
-    RMW_SET_ERROR_MSG("failed to get datawriter qos");
-    goto fail;
+    return nullptr;
   }
-  info->pub_listener_ = new ClientPubListener(info);
+  auto cleanup_request_publisher = rcpputils::make_scope_exit(
+    [info]() {
+      if (info->request_publisher_) {
+        if (!Domain::removePublisher(info->request_publisher_)) {
+          RMW_SAFE_FWRITE_TO_STDERR(
+              "Failed to remove request publisher after '"
+              RCUTILS_STRINGIFY(__function__) "' failed.\n");
+        }
+      }
+      if (info->pub_listener_) {
+        delete info->pub_listener_;
+      }
+    });
+  info->pub_listener_ = new (std::nothrow) ClientPubListener(info);
+  if (!info->pub_listener_) {
+    RMW_SET_ERROR_MSG("failed to create client request publisher listener");
+    return nullptr;
+  }
   info->request_publisher_ =
     Domain::createPublisher(participant, publisherParam, info->pub_listener_);
   if (!info->request_publisher_) {
-    RMW_SET_ERROR_MSG("create_client() could not create publisher");
-    goto fail;
+    RMW_SET_ERROR_MSG("failed to create client request publisher");
+    return nullptr;
   }
 
   info->writer_guid_ = info->request_publisher_->getGuid();
   info->reader_guid_ = info->response_subscriber_->getGuid();
 
-  rmw_client = rmw_client_allocate();
+  rmw_client_t * rmw_client = rmw_client_allocate();
   if (!rmw_client) {
     RMW_SET_ERROR_MSG("failed to allocate memory for client");
-    goto fail;
+    return nullptr;
   }
+  auto cleanup_rmw_client = rcpputils::make_scope_exit(
+    [rmw_client]() {
+      rmw_free(const_cast<char *>(rmw_client->service_name));
+      rmw_free(rmw_client);
+    });
 
   rmw_client->implementation_identifier = eprosima_fastrtps_identifier;
   rmw_client->data = info;
@@ -206,101 +264,71 @@ rmw_create_client(
     rmw_allocate(strlen(service_name) + 1));
   if (!rmw_client->service_name) {
     RMW_SET_ERROR_MSG("failed to allocate memory for client name");
-    goto fail;
+    return nullptr;
   }
   memcpy(const_cast<char *>(rmw_client->service_name), service_name, strlen(service_name) + 1);
 
   {
     // Update graph
     std::lock_guard<std::mutex> guard(common_context->node_update_mutex);
-    rmw_gid_t gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
+    rmw_gid_t request_publisher_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
       eprosima_fastrtps_identifier, info->request_publisher_->getGuid());
     common_context->graph_cache.associate_writer(
-      gid,
+      request_publisher_gid,
       common_context->gid,
       node->name,
       node->namespace_);
-    gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
+    rmw_gid_t response_subscriber_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
       eprosima_fastrtps_identifier, info->response_subscriber_->getGuid());
     rmw_dds_common::msg::ParticipantEntitiesInfo msg =
       common_context->graph_cache.associate_reader(
-      gid, common_context->gid, node->name, node->namespace_);
-    rmw_ret_t rmw_ret = rmw_fastrtps_shared_cpp::__rmw_publish(
+        response_subscriber_gid,
+        common_context->gid,
+        node->name,
+        node->namespace_);
+    rmw_ret_t ret = rmw_fastrtps_shared_cpp::__rmw_publish(
       eprosima_fastrtps_identifier,
       common_context->pub,
       static_cast<void *>(&msg),
       nullptr);
-    if (RMW_RET_OK != rmw_ret) {
-      goto fail;
-    }
-  }
-
-  return rmw_client;
-
-fail:
-  if (info != nullptr) {
-    if (info->request_publisher_ != nullptr) {
-      rmw_gid_t gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
-        eprosima_fastrtps_identifier, info->request_publisher_->getGuid());
-      common_context->graph_cache.dissociate_writer(
-        gid,
-        common_context->gid,
-        node->name,
-        node->namespace_);
-      Domain::removePublisher(info->request_publisher_);
-    }
-
-    if (info->response_subscriber_ != nullptr) {
-      rmw_gid_t gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
-        eprosima_fastrtps_identifier, info->response_subscriber_->getGuid());
+    if (RMW_RET_OK != ret) {
       common_context->graph_cache.dissociate_reader(
-        gid,
+        response_subscriber_gid,
         common_context->gid,
         node->name,
         node->namespace_);
-      Domain::removeSubscriber(info->response_subscriber_);
+      common_context->graph_cache.dissociate_writer(
+        request_publisher_gid,
+        common_context->gid,
+        node->name,
+        node->namespace_);
+      return nullptr;
     }
-
-    if (info->pub_listener_ != nullptr) {
-      delete info->pub_listener_;
-    }
-
-    if (info->listener_ != nullptr) {
-      delete info->listener_;
-    }
-
-    if (participant_info) {
-      if (info->request_type_support_ != nullptr) {
-        rmw_fastrtps_shared_cpp::_unregister_type(participant, info->request_type_support_);
-      }
-
-      if (info->response_type_support_ != nullptr) {
-        rmw_fastrtps_shared_cpp::_unregister_type(participant, info->response_type_support_);
-      }
-    } else {
-      RCUTILS_LOG_ERROR_NAMED(
-        "rmw_fastrtps_cpp",
-        "leaking type support objects because node impl is null");
-    }
-
-    delete info;
-    info = nullptr;
   }
 
-  if (nullptr != rmw_client) {
-    if (rmw_client->service_name != nullptr) {
-      rmw_free(const_cast<char *>(rmw_client->service_name));
-      rmw_client->service_name = nullptr;
-    }
-    rmw_client_free(rmw_client);
-  }
-
-  return nullptr;
+  cleanup_rmw_client.cancel();
+  cleanup_response_subscriber.cancel();
+  cleanup_request_publisher.cancel();
+  cleanup_base_info.cancel();
+  return rmw_client;
 }
 
 rmw_ret_t
 rmw_destroy_client(rmw_node_t * node, rmw_client_t * client)
 {
+  RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+                                   node,
+                                   node->implementation_identifier,
+                                   eprosima_fastrtps_identifier,
+                                   return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RMW_CHECK_ARGUMENT_FOR_NULL(client, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+                                   client,
+                                   client->implementation_identifier,
+                                   eprosima_fastrtps_identifier,
+                                   return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+
   return rmw_fastrtps_shared_cpp::__rmw_destroy_client(
     eprosima_fastrtps_identifier, node, client);
 }

--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -224,8 +224,8 @@ rmw_create_client(
       if (info->request_publisher_) {
         if (!Domain::removePublisher(info->request_publisher_)) {
           RMW_SAFE_FWRITE_TO_STDERR(
-              "Failed to remove request publisher after '"
-              RCUTILS_STRINGIFY(__function__) "' failed.\n");
+            "Failed to remove request publisher after '"
+            RCUTILS_STRINGIFY(__function__) "' failed.\n");
         }
       }
       if (info->pub_listener_) {
@@ -282,10 +282,10 @@ rmw_create_client(
       eprosima_fastrtps_identifier, info->response_subscriber_->getGuid());
     rmw_dds_common::msg::ParticipantEntitiesInfo msg =
       common_context->graph_cache.associate_reader(
-        response_subscriber_gid,
-        common_context->gid,
-        node->name,
-        node->namespace_);
+      response_subscriber_gid,
+      common_context->gid,
+      node->name,
+      node->namespace_);
     rmw_ret_t ret = rmw_fastrtps_shared_cpp::__rmw_publish(
       eprosima_fastrtps_identifier,
       common_context->pub,
@@ -318,16 +318,16 @@ rmw_destroy_client(rmw_node_t * node, rmw_client_t * client)
 {
   RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
-                                   node,
-                                   node->implementation_identifier,
-                                   eprosima_fastrtps_identifier,
-                                   return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+    node,
+    node->implementation_identifier,
+    eprosima_fastrtps_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
   RMW_CHECK_ARGUMENT_FOR_NULL(client, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
-                                   client,
-                                   client->implementation_identifier,
-                                   eprosima_fastrtps_identifier,
-                                   return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+    client,
+    client->implementation_identifier,
+    eprosima_fastrtps_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
 
   return rmw_fastrtps_shared_cpp::__rmw_destroy_client(
     eprosima_fastrtps_identifier, node, client);

--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -233,8 +233,8 @@ rmw_create_service(
       if (info->response_publisher_) {
         if (!Domain::removePublisher(info->response_publisher_)) {
           RMW_SAFE_FWRITE_TO_STDERR(
-              "Failed to remove response publisher after '"
-              RCUTILS_STRINGIFY(__function__) "' failed.\n");
+            "Failed to remove response publisher after '"
+            RCUTILS_STRINGIFY(__function__) "' failed.\n");
         }
       }
       if (info->pub_listener_) {
@@ -242,7 +242,7 @@ rmw_create_service(
       }
     });
   info->pub_listener_ = new (std::nothrow) ServicePubListener();
-  if(!info->pub_listener_) {
+  if (!info->pub_listener_) {
     RMW_SET_ERROR_MSG("failed to create service response publisher listener");
     return nullptr;
   }
@@ -288,10 +288,10 @@ rmw_create_service(
       eprosima_fastrtps_identifier, info->response_publisher_->getGuid());
     rmw_dds_common::msg::ParticipantEntitiesInfo msg =
       common_context->graph_cache.associate_writer(
-          response_publisher_gid,
-          common_context->gid,
-          node->name,
-          node->namespace_);
+      response_publisher_gid,
+      common_context->gid,
+      node->name,
+      node->namespace_);
     rmw_ret_t ret = rmw_fastrtps_shared_cpp::__rmw_publish(
       eprosima_fastrtps_identifier,
       common_context->pub,
@@ -299,15 +299,15 @@ rmw_create_service(
       nullptr);
     if (RMW_RET_OK != ret) {
       common_context->graph_cache.dissociate_writer(
-         response_publisher_gid,
-         common_context->gid,
-         node->name,
-         node->namespace_);
+        response_publisher_gid,
+        common_context->gid,
+        node->name,
+        node->namespace_);
       common_context->graph_cache.dissociate_reader(
-         request_subscriber_gid,
-         common_context->gid,
-         node->name,
-         node->namespace_);
+        request_subscriber_gid,
+        common_context->gid,
+        node->name,
+        node->namespace_);
       return nullptr;
     }
   }
@@ -324,16 +324,16 @@ rmw_destroy_service(rmw_node_t * node, rmw_service_t * service)
 {
   RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
-                                   node,
-                                   node->implementation_identifier,
-                                   eprosima_fastrtps_identifier,
-                                   return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+    node,
+    node->implementation_identifier,
+    eprosima_fastrtps_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
   RMW_CHECK_ARGUMENT_FOR_NULL(service, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
-                                   service,
-                                   service->implementation_identifier,
-                                   eprosima_fastrtps_identifier,
-                                   return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+    service,
+    service->implementation_identifier,
+    eprosima_fastrtps_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
 
   return rmw_fastrtps_shared_cpp::__rmw_destroy_service(
     eprosima_fastrtps_identifier, node, service);

--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -25,10 +25,14 @@
 #include <string>
 #include <vector>
 
+#include "rcpputils/scope_exit.hpp"
 #include "rcutils/logging_macros.h"
 
 #include "rmw/allocators.h"
+#include "rmw/error_handling.h"
+#include "rmw/impl/cpp/macros.hpp"
 #include "rmw/rmw.h"
+#include "rmw/validate_full_topic_name.h"
 
 #include "rmw_fastrtps_shared_cpp/custom_participant_info.hpp"
 #include "rmw_fastrtps_shared_cpp/custom_service_info.hpp"
@@ -55,39 +59,36 @@ rmw_create_service(
   const rosidl_service_type_support_t * type_supports,
   const char * service_name, const rmw_qos_profile_t * qos_policies)
 {
-  if (!node) {
-    RMW_SET_ERROR_MSG("node handle is null");
+  RMW_CHECK_ARGUMENT_FOR_NULL(node, nullptr);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    node,
+    node->implementation_identifier,
+    eprosima_fastrtps_identifier,
+    return nullptr);
+  RMW_CHECK_ARGUMENT_FOR_NULL(type_supports, nullptr);
+  RMW_CHECK_ARGUMENT_FOR_NULL(service_name, nullptr);
+  if (0 == strlen(service_name)) {
+    RMW_SET_ERROR_MSG("service_name argument is an empty string");
     return nullptr;
   }
-
-  if (node->implementation_identifier != eprosima_fastrtps_identifier) {
-    RMW_SET_ERROR_MSG("node handle not from this implementation");
-    return nullptr;
-  }
-
-  if (!service_name || strlen(service_name) == 0) {
-    RMW_SET_ERROR_MSG("service topic is null or empty string");
-    return nullptr;
-  }
-
-  if (!qos_policies) {
-    RMW_SET_ERROR_MSG("qos_profile is null");
-    return nullptr;
+  RMW_CHECK_ARGUMENT_FOR_NULL(qos_policies, nullptr);
+  if (!qos_policies->avoid_ros_namespace_conventions) {
+    int validation_result = RMW_TOPIC_VALID;
+    rmw_ret_t ret = rmw_validate_full_topic_name(service_name, &validation_result, nullptr);
+    if (RMW_RET_OK != ret) {
+      return nullptr;
+    }
+    if (RMW_TOPIC_VALID != validation_result) {
+      const char * reason = rmw_full_topic_name_validation_result_string(validation_result);
+      RMW_SET_ERROR_MSG_WITH_FORMAT_STRING("service_name argument is invalid: %s", reason);
+      return nullptr;
+    }
   }
 
   const CustomParticipantInfo * impl =
     static_cast<CustomParticipantInfo *>(node->context->impl->participant_info);
   auto common_context = static_cast<rmw_dds_common::Context *>(node->context->impl->common);
-  if (!impl) {
-    RMW_SET_ERROR_MSG("node impl is null");
-    return nullptr;
-  }
-
   Participant * participant = impl->participant;
-  if (!participant) {
-    RMW_SET_ERROR_MSG("participant handle is null");
-    return nullptr;
-  }
 
   const rosidl_service_type_support_t * type_support = get_service_typesupport_handle(
     type_supports, RMW_FASTRTPS_CPP_TYPESUPPORT_C);
@@ -100,12 +101,21 @@ rmw_create_service(
     }
   }
 
-  CustomServiceInfo * info = nullptr;
-  eprosima::fastrtps::SubscriberAttributes subscriberParam;
-  eprosima::fastrtps::PublisherAttributes publisherParam;
-  rmw_service_t * rmw_service = nullptr;
-
-  info = new CustomServiceInfo();
+  CustomServiceInfo * info = new (std::nothrow) CustomServiceInfo();
+  if (!info) {
+    RMW_SET_ERROR_MSG("failed to allocate service info");
+    return nullptr;
+  }
+  auto cleanup_base_info = rcpputils::make_scope_exit(
+    [info, participant]() {
+      if (info->request_type_support_) {
+        rmw_fastrtps_shared_cpp::_unregister_type(participant, info->request_type_support_);
+      }
+      if (info->response_type_support_) {
+        rmw_fastrtps_shared_cpp::_unregister_type(participant, info->response_type_support_);
+      }
+      delete info;
+    });
   info->participant_ = participant;
   info->typesupport_identifier_ = type_support->typesupport_identifier;
 
@@ -130,7 +140,11 @@ rmw_create_service(
       participant, request_type_name.c_str(),
       reinterpret_cast<TopicDataType **>(&info->request_type_support_)))
   {
-    info->request_type_support_ = new RequestTypeSupport_cpp(service_members);
+    info->request_type_support_ = new (std::nothrow) RequestTypeSupport_cpp(service_members);
+    if (!info->request_type_support_) {
+      RMW_SET_ERROR_MSG("failed to allocate request typesupport");
+      return nullptr;
+    }
     _register_type(participant, info->request_type_support_);
   }
 
@@ -139,9 +153,16 @@ rmw_create_service(
       participant, response_type_name.c_str(),
       reinterpret_cast<TopicDataType **>(&info->response_type_support_)))
   {
-    info->response_type_support_ = new ResponseTypeSupport_cpp(service_members);
+    info->response_type_support_ = new (std::nothrow) ResponseTypeSupport_cpp(service_members);
+    if (!info->response_type_support_) {
+      RMW_SET_ERROR_MSG("failed to allocate response typesupport");
+      return nullptr;
+    }
     _register_type(participant, info->response_type_support_);
   }
+
+  eprosima::fastrtps::SubscriberAttributes subscriberParam;
+  eprosima::fastrtps::PublisherAttributes publisherParam;
 
   if (!impl->leave_middleware_default_qos) {
     subscriberParam.historyMemoryPolicy =
@@ -176,128 +197,144 @@ rmw_create_service(
 
   // Create Service Subscriber and set QoS
   if (!get_datareader_qos(*qos_policies, subscriberParam)) {
-    RMW_SET_ERROR_MSG("failed to get datareader qos");
-    goto fail;
+    return nullptr;
   }
-  info->listener_ = new ServiceListener(info);
+  auto cleanup_request_subscriber = rcpputils::make_scope_exit(
+    [info]() {
+      if (info->request_subscriber_) {
+        if (!Domain::removeSubscriber(info->request_subscriber_)) {
+          RMW_SAFE_FWRITE_TO_STDERR(
+            "Failed to remove request subscriber after '"
+            RCUTILS_STRINGIFY(__function__) "' failed.\n");
+        }
+      }
+      if (info->listener_) {
+        delete info->listener_;
+      }
+    });
+  info->listener_ = new (std::nothrow) ServiceListener(info);
+  if (!info->listener_) {
+    RMW_SET_ERROR_MSG("failed to create service request subscriber listener");
+    return nullptr;
+  }
   info->request_subscriber_ =
     Domain::createSubscriber(participant, subscriberParam, info->listener_);
   if (!info->request_subscriber_) {
-    RMW_SET_ERROR_MSG("create_service() could not create subscriber");
-    goto fail;
+    RMW_SET_ERROR_MSG("failed to create service request subscriber");
+    return nullptr;
   }
 
   // Create Service Publisher and set QoS
   if (!get_datawriter_qos(*qos_policies, publisherParam)) {
-    RMW_SET_ERROR_MSG("failed to get datawriter qos");
-    goto fail;
+    return nullptr;
   }
-  info->pub_listener_ = new ServicePubListener();
+  auto cleanup_response_publisher = rcpputils::make_scope_exit(
+    [info]() {
+      if (info->response_publisher_) {
+        if (!Domain::removePublisher(info->response_publisher_)) {
+          RMW_SAFE_FWRITE_TO_STDERR(
+              "Failed to remove response publisher after '"
+              RCUTILS_STRINGIFY(__function__) "' failed.\n");
+        }
+      }
+      if (info->pub_listener_) {
+        delete info->pub_listener_;
+      }
+    });
+  info->pub_listener_ = new (std::nothrow) ServicePubListener();
+  if(!info->pub_listener_) {
+    RMW_SET_ERROR_MSG("failed to create service response publisher listener");
+    return nullptr;
+  }
   info->response_publisher_ =
     Domain::createPublisher(participant, publisherParam, info->pub_listener_);
   if (!info->response_publisher_) {
-    RMW_SET_ERROR_MSG("create_service() could not create publisher");
-    goto fail;
+    RMW_SET_ERROR_MSG("failed to create service response publisher");
+    return nullptr;
   }
 
-  rmw_service = rmw_service_allocate();
+  rmw_service_t * rmw_service = rmw_service_allocate();
   if (!rmw_service) {
     RMW_SET_ERROR_MSG("failed to allocate memory for service");
-    goto fail;
+    return nullptr;
   }
+  auto cleanup_rmw_service = rcpputils::make_scope_exit(
+    [rmw_service]() {
+      rmw_free(const_cast<char *>(rmw_service->service_name));
+      rmw_free(rmw_service);
+    });
+
   rmw_service->implementation_identifier = eprosima_fastrtps_identifier;
   rmw_service->data = info;
   rmw_service->service_name = reinterpret_cast<const char *>(
     rmw_allocate(strlen(service_name) + 1));
   if (!rmw_service->service_name) {
     RMW_SET_ERROR_MSG("failed to allocate memory for service name");
-    goto fail;
+    return nullptr;
   }
   memcpy(const_cast<char *>(rmw_service->service_name), service_name, strlen(service_name) + 1);
 
   {
     // Update graph
     std::lock_guard<std::mutex> guard(common_context->node_update_mutex);
-    rmw_gid_t gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
+    rmw_gid_t request_subscriber_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
       eprosima_fastrtps_identifier, info->request_subscriber_->getGuid());
     common_context->graph_cache.associate_reader(
-      gid,
+      request_subscriber_gid,
       common_context->gid,
       node->name,
       node->namespace_);
-    gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
+    rmw_gid_t response_publisher_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
       eprosima_fastrtps_identifier, info->response_publisher_->getGuid());
     rmw_dds_common::msg::ParticipantEntitiesInfo msg =
       common_context->graph_cache.associate_writer(
-      gid, common_context->gid, node->name, node->namespace_);
-    rmw_ret_t rmw_ret = rmw_fastrtps_shared_cpp::__rmw_publish(
+          response_publisher_gid,
+          common_context->gid,
+          node->name,
+          node->namespace_);
+    rmw_ret_t ret = rmw_fastrtps_shared_cpp::__rmw_publish(
       eprosima_fastrtps_identifier,
       common_context->pub,
       static_cast<void *>(&msg),
       nullptr);
-    if (RMW_RET_OK != rmw_ret) {
-      goto fail;
-    }
-  }
-
-  return rmw_service;
-
-fail:
-
-  if (info) {
-    if (info->response_publisher_) {
-      rmw_gid_t gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
-        eprosima_fastrtps_identifier, info->response_publisher_->getGuid());
+    if (RMW_RET_OK != ret) {
       common_context->graph_cache.dissociate_writer(
-        gid,
-        common_context->gid,
-        node->name,
-        node->namespace_);
-      Domain::removePublisher(info->response_publisher_);
-    }
-
-    if (info->pub_listener_) {
-      delete info->pub_listener_;
-    }
-
-    if (info->request_subscriber_) {
-      rmw_gid_t gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
-        eprosima_fastrtps_identifier, info->request_subscriber_->getGuid());
+         response_publisher_gid,
+         common_context->gid,
+         node->name,
+         node->namespace_);
       common_context->graph_cache.dissociate_reader(
-        gid,
-        common_context->gid,
-        node->name,
-        node->namespace_);
-      Domain::removeSubscriber(info->request_subscriber_);
+         request_subscriber_gid,
+         common_context->gid,
+         node->name,
+         node->namespace_);
+      return nullptr;
     }
-
-    if (info->listener_) {
-      delete info->listener_;
-    }
-
-    if (info->request_type_support_) {
-      rmw_fastrtps_shared_cpp::_unregister_type(participant, info->request_type_support_);
-    }
-
-    if (info->response_type_support_) {
-      rmw_fastrtps_shared_cpp::_unregister_type(participant, info->response_type_support_);
-    }
-
-    delete info;
   }
 
-  if (rmw_service && rmw_service->service_name) {
-    rmw_free(const_cast<char *>(rmw_service->service_name));
-    rmw_service->service_name = nullptr;
-  }
-  rmw_service_free(rmw_service);
-
-  return nullptr;
+  cleanup_rmw_service.cancel();
+  cleanup_request_subscriber.cancel();
+  cleanup_response_publisher.cancel();
+  cleanup_base_info.cancel();
+  return rmw_service;
 }
 
 rmw_ret_t
 rmw_destroy_service(rmw_node_t * node, rmw_service_t * service)
 {
+  RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+                                   node,
+                                   node->implementation_identifier,
+                                   eprosima_fastrtps_identifier,
+                                   return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RMW_CHECK_ARGUMENT_FOR_NULL(service, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+                                   service,
+                                   service->implementation_identifier,
+                                   eprosima_fastrtps_identifier,
+                                   return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+
   return rmw_fastrtps_shared_cpp::__rmw_destroy_service(
     eprosima_fastrtps_identifier, node, service);
 }

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
@@ -17,7 +17,10 @@
 #include "rcutils/logging_macros.h"
 
 #include "rmw/allocators.h"
+#include "rmw/error_handling.h"
+#include "rmw/impl/cpp/macros.hpp"
 #include "rmw/rmw.h"
+#include "rmw/validate_full_topic_name.h"
 
 #include "rosidl_typesupport_introspection_cpp/identifier.hpp"
 
@@ -51,24 +54,30 @@ rmw_create_client(
   const rosidl_service_type_support_t * type_supports,
   const char * service_name, const rmw_qos_profile_t * qos_policies)
 {
-  if (!node) {
-    RMW_SET_ERROR_MSG("node handle is null");
+  RMW_CHECK_ARGUMENT_FOR_NULL(node, nullptr);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    node,
+    node->implementation_identifier,
+    eprosima_fastrtps_identifier,
+    return nullptr);
+  RMW_CHECK_ARGUMENT_FOR_NULL(type_supports, nullptr);
+  RMW_CHECK_ARGUMENT_FOR_NULL(service_name, nullptr);
+  if (0 == strlen(service_name)) {
+    RMW_SET_ERROR_MSG("service_name argument is an empty string");
     return nullptr;
   }
-
-  if (node->implementation_identifier != eprosima_fastrtps_identifier) {
-    RMW_SET_ERROR_MSG("node handle not from this implementation");
-    return nullptr;
-  }
-
-  if (!service_name || strlen(service_name) == 0) {
-    RMW_SET_ERROR_MSG("client topic is null or empty string");
-    return nullptr;
-  }
-
-  if (!qos_policies) {
-    RMW_SET_ERROR_MSG("qos_profile is null");
-    return nullptr;
+  RMW_CHECK_ARGUMENT_FOR_NULL(qos_policies, nullptr);
+  if (!qos_policies->avoid_ros_namespace_conventions) {
+    int validation_result = RMW_TOPIC_VALID;
+    rmw_ret_t ret = rmw_validate_full_topic_name(service_name, &validation_result, nullptr);
+    if (RMW_RET_OK != ret) {
+      return nullptr;
+    }
+    if (RMW_TOPIC_VALID != validation_result) {
+      const char * reason = rmw_full_topic_name_validation_result_string(validation_result);
+      RMW_SET_ERROR_MSG_WITH_FORMAT_STRING("service_name argument is invalid: %s", reason);
+      return nullptr;
+    }
   }
 
   auto common_context = static_cast<rmw_dds_common::Context *>(node->context->impl->common);
@@ -333,27 +342,31 @@ fail:
 rmw_ret_t
 rmw_destroy_client(rmw_node_t * node, rmw_client_t * client)
 {
+  RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+                                   node,
+                                   node->implementation_identifier,
+                                   eprosima_fastrtps_identifier,
+                                   return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RMW_CHECK_ARGUMENT_FOR_NULL(client, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+                                   client,
+                                   client->implementation_identifier,
+                                   eprosima_fastrtps_identifier,
+                                   return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+
+
   auto info = static_cast<CustomClientInfo *>(client->data);
-  RCUTILS_CHECK_FOR_NULL_WITH_MSG(info, "client info pointer is null", return RMW_RET_ERROR);
-
-  auto impl = static_cast<BaseTypeSupport *>(const_cast<void *>(info->request_type_support_impl_));
-  RCUTILS_CHECK_FOR_NULL_WITH_MSG(
-    impl, "client's request type support is null",
-    return RMW_RET_ERROR);
-
-  auto ros_type_support = static_cast<const rosidl_service_type_support_t *>(
-    impl->ros_type_support());
 
   TypeSupportRegistry & type_registry = TypeSupportRegistry::get_instance();
+
+  auto impl = static_cast<BaseTypeSupport *>(const_cast<void *>(info->request_type_support_impl_));
+  auto ros_type_support =
+    static_cast<const rosidl_service_type_support_t *>(impl->ros_type_support());
   type_registry.return_request_type_support(ros_type_support);
 
   impl = static_cast<BaseTypeSupport *>(const_cast<void *>(info->response_type_support_impl_));
-  RCUTILS_CHECK_FOR_NULL_WITH_MSG(
-    impl, "client's response type support is null",
-    return RMW_RET_ERROR);
-
-  ros_type_support = static_cast<const rosidl_service_type_support_t *>(
-    impl->ros_type_support());
+  ros_type_support = static_cast<const rosidl_service_type_support_t *>(impl->ros_type_support());
   type_registry.return_response_type_support(ros_type_support);
 
   return rmw_fastrtps_shared_cpp::__rmw_destroy_client(

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
@@ -344,16 +344,16 @@ rmw_destroy_client(rmw_node_t * node, rmw_client_t * client)
 {
   RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
-                                   node,
-                                   node->implementation_identifier,
-                                   eprosima_fastrtps_identifier,
-                                   return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+    node,
+    node->implementation_identifier,
+    eprosima_fastrtps_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
   RMW_CHECK_ARGUMENT_FOR_NULL(client, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
-                                   client,
-                                   client->implementation_identifier,
-                                   eprosima_fastrtps_identifier,
-                                   return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+    client,
+    client->implementation_identifier,
+    eprosima_fastrtps_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
 
 
   auto info = static_cast<CustomClientInfo *>(client->data);

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
@@ -341,16 +341,16 @@ rmw_destroy_service(rmw_node_t * node, rmw_service_t * service)
 {
   RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
-                                   node,
-                                   node->implementation_identifier,
-                                   eprosima_fastrtps_identifier,
-                                   return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+    node,
+    node->implementation_identifier,
+    eprosima_fastrtps_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
   RMW_CHECK_ARGUMENT_FOR_NULL(service, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
-                                   service,
-                                   service->implementation_identifier,
-                                   eprosima_fastrtps_identifier,
-                                   return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+    service,
+    service->implementation_identifier,
+    eprosima_fastrtps_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
 
   auto info = static_cast<CustomServiceInfo *>(service->data);
 

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
@@ -28,7 +28,10 @@
 #include "rcutils/logging_macros.h"
 
 #include "rmw/allocators.h"
+#include "rmw/error_handling.h"
+#include "rmw/impl/cpp/macros.hpp"
 #include "rmw/rmw.h"
+#include "rmw/validate_full_topic_name.h"
 
 #include "rmw_fastrtps_shared_cpp/rmw_common.hpp"
 
@@ -62,24 +65,30 @@ rmw_create_service(
   const rosidl_service_type_support_t * type_supports,
   const char * service_name, const rmw_qos_profile_t * qos_policies)
 {
-  if (!node) {
-    RMW_SET_ERROR_MSG("node handle is null");
+  RMW_CHECK_ARGUMENT_FOR_NULL(node, nullptr);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    node,
+    node->implementation_identifier,
+    eprosima_fastrtps_identifier,
+    return nullptr);
+  RMW_CHECK_ARGUMENT_FOR_NULL(type_supports, nullptr);
+  RMW_CHECK_ARGUMENT_FOR_NULL(service_name, nullptr);
+  if (0 == strlen(service_name)) {
+    RMW_SET_ERROR_MSG("service_name argument is an empty string");
     return nullptr;
   }
-
-  if (node->implementation_identifier != eprosima_fastrtps_identifier) {
-    RMW_SET_ERROR_MSG("node handle not from this implementation");
-    return nullptr;
-  }
-
-  if (!service_name || strlen(service_name) == 0) {
-    RMW_SET_ERROR_MSG("service topic is null or empty string");
-    return nullptr;
-  }
-
-  if (!qos_policies) {
-    RMW_SET_ERROR_MSG("qos_profile is null");
-    return nullptr;
+  RMW_CHECK_ARGUMENT_FOR_NULL(qos_policies, nullptr);
+  if (!qos_policies->avoid_ros_namespace_conventions) {
+    int validation_result = RMW_TOPIC_VALID;
+    rmw_ret_t ret = rmw_validate_full_topic_name(service_name, &validation_result, nullptr);
+    if (RMW_RET_OK != ret) {
+      return nullptr;
+    }
+    if (RMW_TOPIC_VALID != validation_result) {
+      const char * reason = rmw_full_topic_name_validation_result_string(validation_result);
+      RMW_SET_ERROR_MSG_WITH_FORMAT_STRING("service_name argument is invalid: %s", reason);
+      return nullptr;
+    }
   }
 
   const CustomParticipantInfo * impl =
@@ -330,27 +339,30 @@ fail:
 rmw_ret_t
 rmw_destroy_service(rmw_node_t * node, rmw_service_t * service)
 {
+  RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+                                   node,
+                                   node->implementation_identifier,
+                                   eprosima_fastrtps_identifier,
+                                   return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RMW_CHECK_ARGUMENT_FOR_NULL(service, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+                                   service,
+                                   service->implementation_identifier,
+                                   eprosima_fastrtps_identifier,
+                                   return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+
   auto info = static_cast<CustomServiceInfo *>(service->data);
-  RCUTILS_CHECK_FOR_NULL_WITH_MSG(info, "service info pointer is null", return RMW_RET_ERROR);
-
-  auto impl = static_cast<BaseTypeSupport *>(const_cast<void *>(info->request_type_support_impl_));
-  RCUTILS_CHECK_FOR_NULL_WITH_MSG(
-    impl, "client's request type support is null",
-    return RMW_RET_ERROR);
-
-  auto ros_type_support = static_cast<const rosidl_service_type_support_t *>(
-    impl->ros_type_support());
 
   TypeSupportRegistry & type_registry = TypeSupportRegistry::get_instance();
+
+  auto impl = static_cast<BaseTypeSupport *>(const_cast<void *>(info->request_type_support_impl_));
+  auto ros_type_support =
+    static_cast<const rosidl_service_type_support_t *>(impl->ros_type_support());
   type_registry.return_request_type_support(ros_type_support);
 
   impl = static_cast<BaseTypeSupport *>(const_cast<void *>(info->response_type_support_impl_));
-  RCUTILS_CHECK_FOR_NULL_WITH_MSG(
-    impl, "client's response type support is null",
-    return RMW_RET_ERROR);
-
-  ros_type_support = static_cast<const rosidl_service_type_support_t *>(
-    impl->ros_type_support());
+  ros_type_support = static_cast<const rosidl_service_type_support_t *>(impl->ros_type_support());
   type_registry.return_response_type_support(ros_type_support);
 
   return rmw_fastrtps_shared_cpp::__rmw_destroy_service(

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_client_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_client_info.hpp
@@ -41,18 +41,18 @@ class ClientPubListener;
 
 typedef struct CustomClientInfo
 {
-  rmw_fastrtps_shared_cpp::TypeSupport * request_type_support_;
-  const void * request_type_support_impl_;
-  rmw_fastrtps_shared_cpp::TypeSupport * response_type_support_;
-  const void * response_type_support_impl_;
-  eprosima::fastrtps::Subscriber * response_subscriber_;
-  eprosima::fastrtps::Publisher * request_publisher_;
-  ClientListener * listener_;
+  rmw_fastrtps_shared_cpp::TypeSupport * request_type_support_{nullptr};
+  const void * request_type_support_impl_{nullptr};
+  rmw_fastrtps_shared_cpp::TypeSupport * response_type_support_{nullptr};
+  const void * response_type_support_impl_{nullptr};
+  eprosima::fastrtps::Subscriber * response_subscriber_{nullptr};
+  eprosima::fastrtps::Publisher * request_publisher_{nullptr};
+  ClientListener * listener_{nullptr};
   eprosima::fastrtps::rtps::GUID_t writer_guid_;
   eprosima::fastrtps::rtps::GUID_t reader_guid_;
-  eprosima::fastrtps::Participant * participant_;
-  const char * typesupport_identifier_;
-  ClientPubListener * pub_listener_;
+  eprosima::fastrtps::Participant * participant_{nullptr};
+  const char * typesupport_identifier_{nullptr};
+  ClientPubListener * pub_listener_{nullptr};
   std::atomic_size_t response_subscriber_matched_count_;
   std::atomic_size_t request_publisher_matched_count_;
 } CustomClientInfo;

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
@@ -40,16 +40,16 @@ class ServicePubListener;
 
 typedef struct CustomServiceInfo
 {
-  rmw_fastrtps_shared_cpp::TypeSupport * request_type_support_;
-  const void * request_type_support_impl_;
-  rmw_fastrtps_shared_cpp::TypeSupport * response_type_support_;
-  const void * response_type_support_impl_;
-  eprosima::fastrtps::Subscriber * request_subscriber_;
-  eprosima::fastrtps::Publisher * response_publisher_;
-  ServiceListener * listener_;
-  ServicePubListener * pub_listener_;
-  eprosima::fastrtps::Participant * participant_;
-  const char * typesupport_identifier_;
+  rmw_fastrtps_shared_cpp::TypeSupport * request_type_support_{nullptr};
+  const void * request_type_support_impl_{nullptr};
+  rmw_fastrtps_shared_cpp::TypeSupport * response_type_support_{nullptr};
+  const void * response_type_support_impl_{nullptr};
+  eprosima::fastrtps::Subscriber * request_subscriber_{nullptr};
+  eprosima::fastrtps::Publisher * response_publisher_{nullptr};
+  ServiceListener * listener_{nullptr};
+  ServicePubListener * pub_listener_{nullptr};
+  eprosima::fastrtps::Participant * participant_{nullptr};
+  const char * typesupport_identifier_{nullptr};
 } CustomServiceInfo;
 
 typedef struct CustomServiceRequest


### PR DESCRIPTION
Connected to https://github.com/ros2/rmw/pull/276. This pull request simply updates return codes for `rmw_fastrtps_dynamic_cpp`, but refactors `rmw_fastrtps_cpp` (i.e. `new` expressions cannot be allowed to throw).