### PR TITLE
Improved return error in __rmw_destroy_client

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_client.cpp
@@ -39,7 +39,10 @@ __rmw_destroy_client(
   rmw_node_t * node,
   rmw_client_t * client)
 {
-  (void)node;
+  if (!node){
+    RMW_SET_ERROR_MSG("node handle is null");
+    return RMW_RET_ERROR;
+  }
   if (!client) {
     RMW_SET_ERROR_MSG("client handle is null");
     return RMW_RET_ERROR;


### PR DESCRIPTION
Check node var in __rmw_destroy_client and return an error if it's a nullptr

Signed-off-by: ahcorde <ahcorde@gmail.com>