### PR TITLE
Return RMW_RET_UNSUPPORTED in rmw_get_serialized_message_size

### DIFF
--- a/rmw_fastrtps_cpp/src/rmw_serialize.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_serialize.cpp
@@ -97,6 +97,6 @@ rmw_get_serialized_message_size(
   size_t * /*size*/)
 {
   RMW_SET_ERROR_MSG("unimplemented");
-  return RMW_RET_ERROR;
+  return RMW_RET_UNSUPPORTED;
 }
 }  // extern "C"

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_serialize.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_serialize.cpp
@@ -100,6 +100,6 @@ rmw_get_serialized_message_size(
   size_t * /*size*/)
 {
   RMW_SET_ERROR_MSG("unimplemented");
-  return RMW_RET_ERROR;
+  return RMW_RET_UNSUPPORTED;
 }
 }  // extern "C"


### PR DESCRIPTION
Return the right error code. Related with https://github.com/ros2/rmw/pull/281

Signed-off-by: ahcorde <ahcorde@gmail.com>