### PR TITLE
New environment variable to change easily the publication mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,15 @@ You have two ways of telling you ROS 2 application which XML to use:
 Another way to change easily the publication mode is to use the environment variable `RMW_FASTRTPS_PUBLICATION_MODE`.
 The admissible values are:
 * `ASYNCHRONOUS`: asynchronous publication mode.
-This implies that when the publisher calls the write operation, the data is copied in a queue and control is returned to the user thread before the data is actually sent.
-The asynchronous thread is in charge of consuming the queue and send the data to any matched reader.
+Setting this mode implies that when the publisher invoques the write operation, the data is copied into a queue, a notification about the addition to the queue is performed, and control of the thread is returned to the user before the data is actually sent.
+A background thread (asynchronous thread) is in turn in charge of consuming the queue and sending the data to every matched reader.
 * `SYNCHRONOUS`: synchronous publication mode.
-This implies that the data is sent directly in the context of the user thread.
+Setting this mode implies that the data is sent directly within the context of the user thread.
+This entails that any blocking call occurring during the write operation would block the user thread, thus preventing the application with continuing its operation.
+It is important to note that this mode typically yields higher throughput rates at lower latencies, since the notification and context switching between threads is not present.
 * `AUTO`: let Fast DDS select the publication mode. This implies using the publication mode set in the XML file or, failing that, the default value set in Fast DDS (which currently is set to `SYNCHRONOUS`).
 
-By default, `rmw_fastrtps` assumes this variable to be `ASYNCHRONOUS` and it is the publication mode in use if this environment variable is not set.
+By default, `rmw_fastrtps` assumes this variable to be `ASYNCHRONOUS`, which is the publication mode in use if this environment variable is not set.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ You have two ways of telling you ROS 2 application which XML to use:
 1. Placing your XML file in the running directory under the name `DEFAULT_FASTRTPS_PROFILES.xml`.
 2. Setting environment variable `FASTRTPS_DEFAULT_PROFILES_FILE` to your XML file.
 
+### Change publication mode
+
+Another way to change easily the publication mode is to use the environment variable `ROS_PUBLICATION_MODE`.
+The admissible values are:
+* `ASYNCHRONOUS`: asynchronous publication mode
+* `SYNCHRONOUS`: synchronous publication mode
+* `AUTO`: let the rmw implementation select the publication mode.
+
+By default, `rmw_fastrtps` assumes this variable to be `ASYNCHRONOUS`.
+Also, if you set the variable to `AUTO`, `rmw_fastrtps` will use the publication mode set in the XML file or, failing that, the default value set in Fast DDS (currently set to `SYNCHRONOUS`).
+
 ## Example
 
 The following example configures Fast DDS to publish synchronously, and to have a pre-allocated history that can be expanded whenever it gets filled.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You have two ways of telling you ROS 2 application which XML to use:
 
 ### Change publication mode
 
-Another way to change easily the publication mode is to use the environment variable `ROS_PUBLICATION_MODE`.
+Another way to change easily the publication mode is to use the environment variable `RMW_FASTRTPS_PUBLICATION_MODE`.
 The admissible values are:
 * `ASYNCHRONOUS`: asynchronous publication mode
 * `SYNCHRONOUS`: synchronous publication mode

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You can however set it to `rmw_fastrtps_dynamic_cpp` using the environment varia
 * Publication mode: `ASYNCHRONOUS_PUBLISH_MODE`
 
 However, it is possible to fully configure Fast DDS (including the history memory policy and the publication mode) using an XML file as described in [Fast DDS documentation](https://fast-dds.docs.eprosima.com/en/latest/fastdds/xml_configuration/xml_configuration.html).
-If you want to modify the history memory policy or the publication mode you must set environment variable `RMW_FASTRTPS_USE_QOS_FROM_XML` to 1 (it is set to 0 by default).
+Bear in mind that if you want to modify the history memory policy or the publication mode you must set environment variable `RMW_FASTRTPS_USE_QOS_FROM_XML` to 1 (it is set to 0 by default) besides defining the XML file.
 This tells `rmw_fastrtps` that it should override both the history memory policy and the publication mode using the XML.
 Bear in mind that if you set this environment variable but do not give a value to either of these policies, defaults will be used.
 Current Fast-DDS defaults are:
@@ -46,7 +46,9 @@ You have two ways of telling you ROS 2 application which XML to use:
 
 ### Change publication mode
 
-Another way to change easily the publication mode is to use the environment variable `RMW_FASTRTPS_PUBLICATION_MODE`.
+Another way to change easily the publication mode without the need of defining a XML file is to use the environment variable `RMW_FASTRTPS_PUBLICATION_MODE`.
+This variable has lower precedence than `RMW_FASTRTPS_USE_QOS_FROM_XML`.
+Therefore, it is only taken into account when `RMW_FASTRTPS_USE_QOS_FROM_XML` is not set (or given a value different than `1`).
 The admissible values are:
 * `ASYNCHRONOUS`: asynchronous publication mode.
 Setting this mode implies that when the publisher invokes the write operation, the data is copied into a queue, a notification about the addition to the queue is performed, and control of the thread is returned to the user before the data is actually sent.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ This entails that any blocking call occurring during the write operation would b
 It is important to note that this mode typically yields higher throughput rates at lower latencies, since the notification and context switching between threads is not present.
 * `AUTO`: let Fast DDS select the publication mode. This implies using the publication mode set in the XML file or, failing that, the default value set in Fast DDS (which currently is set to `SYNCHRONOUS`).
 
-By default, `rmw_fastrtps` assumes this variable to be `ASYNCHRONOUS`, which is the publication mode in use if this environment variable is not set.
+If `RMW_FASTRTPS_PUBLICATION_MODE` is not set, then `rmw_fastrtps_cpp` and `rmw_fastrtps_dynamic_cpp` behave as if it were set to `ASYNCHRONOUS`.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -48,12 +48,14 @@ You have two ways of telling you ROS 2 application which XML to use:
 
 Another way to change easily the publication mode is to use the environment variable `RMW_FASTRTPS_PUBLICATION_MODE`.
 The admissible values are:
-* `ASYNCHRONOUS`: asynchronous publication mode
-* `SYNCHRONOUS`: synchronous publication mode
-* `AUTO`: let the rmw implementation select the publication mode.
+* `ASYNCHRONOUS`: asynchronous publication mode.
+This implies that when the publisher calls the write operation, the data is copied in a queue and control is returned to the user thread before the data is actually sent.
+The asynchronous thread is in charge of consuming the queue and send the data to any matched reader.
+* `SYNCHRONOUS`: synchronous publication mode.
+This implies that the data is sent directly in the context of the user thread.
+* `AUTO`: let Fast DDS select the publication mode. This implies using the publication mode set in the XML file or, failing that, the default value set in Fast DDS (which currently is set to `SYNCHRONOUS`).
 
-By default, `rmw_fastrtps` assumes this variable to be `ASYNCHRONOUS`.
-Also, if you set the variable to `AUTO`, `rmw_fastrtps` will use the publication mode set in the XML file or, failing that, the default value set in Fast DDS (currently set to `SYNCHRONOUS`).
+By default, `rmw_fastrtps` assumes this variable to be `ASYNCHRONOUS` and it is the publication mode in use if this environment variable is not set.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You have two ways of telling you ROS 2 application which XML to use:
 Another way to change easily the publication mode is to use the environment variable `RMW_FASTRTPS_PUBLICATION_MODE`.
 The admissible values are:
 * `ASYNCHRONOUS`: asynchronous publication mode.
-Setting this mode implies that when the publisher invoques the write operation, the data is copied into a queue, a notification about the addition to the queue is performed, and control of the thread is returned to the user before the data is actually sent.
+Setting this mode implies that when the publisher invokes the write operation, the data is copied into a queue, a notification about the addition to the queue is performed, and control of the thread is returned to the user before the data is actually sent.
 A background thread (asynchronous thread) is in turn in charge of consuming the queue and sending the data to every matched reader.
 * `SYNCHRONOUS`: synchronous publication mode.
 Setting this mode implies that the data is sent directly within the context of the user thread.

--- a/rmw_fastrtps_cpp/src/publisher.cpp
+++ b/rmw_fastrtps_cpp/src/publisher.cpp
@@ -135,9 +135,13 @@ rmw_fastrtps_cpp::create_publisher(
   }
 
   if (!participant_info->leave_middleware_default_qos) {
-    publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
     publisherParam.historyMemoryPolicy =
       eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+    if (participant_info->publishing_mode == publishing_mode_t::ASYNCHRONOUS) {
+      publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
+    } else if (participant_info->publishing_mode == publishing_mode_t::SYNCHRONOUS) {
+      publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::SYNCHRONOUS_PUBLISH_MODE;
+    }
   }
 
   publisherParam.topic.topicKind =

--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -165,9 +165,13 @@ rmw_create_client(
     qos_policies, ros_service_response_prefix, service_name, "Reply");
 
   if (!participant_info->leave_middleware_default_qos) {
-    publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
     publisherParam.historyMemoryPolicy =
       eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+    if (participant_info->publishing_mode == publishing_mode_t::ASYNCHRONOUS) {
+      publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
+    } else if (participant_info->publishing_mode == publishing_mode_t::SYNCHRONOUS) {
+      publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::SYNCHRONOUS_PUBLISH_MODE;
+    }
   }
 
   publisherParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;

--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -174,9 +174,13 @@ rmw_create_service(
     qos_policies, ros_service_requester_prefix, service_name, "Request");
 
   if (!impl->leave_middleware_default_qos) {
-    publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
     publisherParam.historyMemoryPolicy =
       eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+    if (impl->publishing_mode == publishing_mode_t::ASYNCHRONOUS) {
+      publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
+    } else if (impl->publishing_mode == publishing_mode_t::SYNCHRONOUS) {
+      publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::SYNCHRONOUS_PUBLISH_MODE;
+    }
   }
 
   publisherParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;

--- a/rmw_fastrtps_dynamic_cpp/src/publisher.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/publisher.cpp
@@ -145,9 +145,13 @@ rmw_fastrtps_dynamic_cpp::create_publisher(
   }
 
   if (!participant_info->leave_middleware_default_qos) {
-    publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
     publisherParam.historyMemoryPolicy =
       eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+    if (participant_info->publishing_mode == publishing_mode_t::ASYNCHRONOUS) {
+      publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
+    } else if (participant_info->publishing_mode == publishing_mode_t::SYNCHRONOUS) {
+      publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::SYNCHRONOUS_PUBLISH_MODE;
+    }
   }
 
   publisherParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
@@ -183,9 +183,13 @@ rmw_create_client(
     qos_policies, ros_service_response_prefix, service_name, "Reply");
 
   if (!participant_info->leave_middleware_default_qos) {
-    publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
     publisherParam.historyMemoryPolicy =
       eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+    if (participant_info->publishing_mode == publishing_mode_t::ASYNCHRONOUS) {
+      publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
+    } else if (participant_info->publishing_mode == publishing_mode_t::SYNCHRONOUS) {
+      publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::SYNCHRONOUS_PUBLISH_MODE;
+    }
   }
 
   publisherParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
@@ -192,9 +192,13 @@ rmw_create_service(
     qos_policies, ros_service_requester_prefix, service_name, "Request");
 
   if (!impl->leave_middleware_default_qos) {
-    publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
     publisherParam.historyMemoryPolicy =
       eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+    if (impl->publishing_mode == publishing_mode_t::ASYNCHRONOUS) {
+      publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE;
+    } else if (impl->publishing_mode == publishing_mode_t::SYNCHRONOUS) {
+      publisherParam.qos.m_publishMode.kind = eprosima::fastrtps::SYNCHRONOUS_PUBLISH_MODE;
+    }
   }
 
   publisherParam.topic.topicKind = eprosima::fastrtps::rtps::NO_KEY;

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
@@ -42,6 +42,13 @@ using rmw_dds_common::operator<<;
 
 class ParticipantListener;
 
+enum class publishing_mode_t
+{
+  ASYNCHRONOUS,  // Asynchronous publishing mode
+  SYNCHRONOUS,   // Synchronous publishing mode
+  AUTO           // Use publishing mode set in XML file or Fast DDS default
+};
+
 typedef struct CustomParticipantInfo
 {
   eprosima::fastrtps::Participant * participant;
@@ -53,6 +60,7 @@ typedef struct CustomParticipantInfo
   // their settings are going to be overwritten by code
   // with the default configuration.
   bool leave_middleware_default_qos;
+  publishing_mode_t publishing_mode;
 } CustomParticipantInfo;
 
 class ParticipantListener : public eprosima::fastrtps::ParticipantListener

--- a/rmw_fastrtps_shared_cpp/src/participant.cpp
+++ b/rmw_fastrtps_shared_cpp/src/participant.cpp
@@ -197,7 +197,7 @@ rmw_fastrtps_shared_cpp::create_participant(
   }
   if (env_value != nullptr) {
     leave_middleware_default_qos = strcmp(env_value, "1") == 0;
-  } else if (env_value == nullptr || !leave_middleware_default_qos){
+  } else if (env_value == nullptr || !leave_middleware_default_qos) {
     error_str = rcutils_get_env("ROS_PUBLICATION_MODE", &env_value);
     if (error_str != NULL) {
       RCUTILS_LOG_DEBUG_NAMED("rmw_fastrtps_shared_cpp", "Error getting env var: %s\n", error_str);

--- a/rmw_fastrtps_shared_cpp/src/participant.cpp
+++ b/rmw_fastrtps_shared_cpp/src/participant.cpp
@@ -197,7 +197,7 @@ rmw_fastrtps_shared_cpp::create_participant(
   }
   if (env_value != nullptr) {
     leave_middleware_default_qos = strcmp(env_value, "1") == 0;
-  } 
+  }
   if (!leave_middleware_default_qos) {
     error_str = rcutils_get_env("RMW_FASTRTPS_PUBLICATION_MODE", &env_value);
     if (error_str != NULL) {
@@ -211,7 +211,8 @@ rmw_fastrtps_shared_cpp::create_participant(
       } else if (strcmp(env_value, "AUTO") == 0) {
         publishing_mode = publishing_mode_t::AUTO;
       } else if (strcmp(env_value, "ASYNCHRONOUS") != 0 && strcmp(env_value, "") != 0) {
-        RCUTILS_LOG_WARN_NAMED("rmw_fastrtps_shared_cpp",
+        RCUTILS_LOG_WARN_NAMED(
+          "rmw_fastrtps_shared_cpp",
           "Value %s unknown for environment variable RMW_FASTRTPS_PUBLICATION_MODE"
           ". Using default ASYNCHRONOUS publishing mode.", env_value);
       }

--- a/rmw_fastrtps_shared_cpp/src/participant.cpp
+++ b/rmw_fastrtps_shared_cpp/src/participant.cpp
@@ -197,10 +197,11 @@ rmw_fastrtps_shared_cpp::create_participant(
   }
   if (env_value != nullptr) {
     leave_middleware_default_qos = strcmp(env_value, "1") == 0;
-  } else if (env_value == nullptr || !leave_middleware_default_qos) {
-    error_str = rcutils_get_env("ROS_PUBLICATION_MODE", &env_value);
+  } 
+  if (!leave_middleware_default_qos) {
+    error_str = rcutils_get_env("RMW_FASTRTPS_PUBLICATION_MODE", &env_value);
     if (error_str != NULL) {
-      RCUTILS_LOG_DEBUG_NAMED("rmw_fastrtps_shared_cpp", "Error getting env var: %s\n", error_str);
+      RMW_SET_ERROR_MSG_WITH_FORMAT_STRING("Error getting env var: %s\n", error_str);
       return nullptr;
     }
     if (env_value != nullptr) {
@@ -209,6 +210,10 @@ rmw_fastrtps_shared_cpp::create_participant(
         publishing_mode = publishing_mode_t::SYNCHRONOUS;
       } else if (strcmp(env_value, "AUTO") == 0) {
         publishing_mode = publishing_mode_t::AUTO;
+      } else if (strcmp(env_value, "ASYNCHRONOUS") != 0 && strcmp(env_value, "") != 0) {
+        RCUTILS_LOG_WARN_NAMED("rmw_fastrtps_shared_cpp",
+          "Value %s unknown for environment variable RMW_FASTRTPS_PUBLICATION_MODE"
+          ". Using default ASYNCHRONOUS publishing mode.", env_value);
       }
     }
   }


### PR DESCRIPTION
Several issues are related to the default publication mode set in `rmw_fastrtps` which is `ASYNCHRONOUS` publish mode.
This configuration can be changed only if the user defines a XML file and also sets the environment variable `RMW_FASTRTPS_USE_QOS_FROM_XML` to 1. This could be cumbersome to the user and also, as the issues show, prone to errors.

This pull request uses a new environment variable `RMW_FASTRTPS_PUBLICATION_MODE` so the user can change easily the publishing mode without needing to define a XML file.
This new environment variable can be used also in other RMW implementations and the values that have been considered are the following (this is open to discussion and more values can be given to this new environment variable):
* `ASYNCHRONOUS`: asynchronous publishing mode (default option in `rmw_fastrtps`).
* `SYNCHRONOUS`: synchronous publishing mode.
* `AUTO`: leave the rmw implementation to configure this parameter. In the case of `rmw_fastrtps` this value will take the value defined in the XML file or, failing this, the default value given in Fast DDS (`SYNCHRONOUS`).