### PR TITLE
Revert ServicePubListener API break

### DIFF
--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -241,7 +241,7 @@ rmw_create_service(
         delete info->pub_listener_;
       }
     });
-  info->pub_listener_ = new (std::nothrow) ServicePubListener(info);
+  info->pub_listener_ = new (std::nothrow) ServicePubListener();
   if (!info->pub_listener_) {
     RMW_SET_ERROR_MSG("failed to create service response publisher listener");
     return nullptr;

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
@@ -231,7 +231,7 @@ rmw_create_service(
     RMW_SET_ERROR_MSG("failed to get datawriter qos");
     goto fail;
   }
-  info->pub_listener_ = new ServicePubListener(info);
+  info->pub_listener_ = new ServicePubListener();
   info->response_publisher_ =
     Domain::createPublisher(participant, publisherParam, info->pub_listener_);
   if (!info->response_publisher_) {

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
@@ -82,11 +82,7 @@ class ServicePubListener : public eprosima::fastrtps::PublisherListener
       rmw_fastrtps_shared_cpp::hash_fastrtps_guid>;
 
 public:
-  explicit ServicePubListener(CustomServiceInfo * info)
-  : info_(info)
-  {
-    (void)info_;
-  }
+  ServicePubListener() = default;
 
   void
   onPublicationMatched(

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
@@ -145,7 +145,6 @@ public:
   }
 
 private:
-  CustomServiceInfo * info_;
   std::mutex mutex_;
   subscriptions_set_t subscriptions_ RCPPUTILS_TSA_GUARDED_BY(mutex_);
   clients_endpoints_map_t clients_endpoints_ RCPPUTILS_TSA_GUARDED_BY(mutex_);


### PR DESCRIPTION
#467 introduced an API break that it is not required for the workaround. This pull request reverts that break.

Signed-off-by: JLBuenoLopez-eProsima <joseluisbueno@eprosima.com>