### PR TITLE
Fix rmw_time to Duration_t conversion

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/qos.cpp
+++ b/rmw_fastrtps_shared_cpp/src/qos.cpp
@@ -31,7 +31,7 @@ rmw_time_to_fastrtps(const rmw_time_t & time)
 
   // TODO(mjeronimo): Since we're going to truncate the 64-bit values
   // down to 32-bit, make sure at least that the seconds value does
-  // not overflow. If the coming value is greater than INT_MAX, move
+  // not overflow. If the incoming value is greater than INT_MAX, move
   // the excess seconds over to the nanoseconds field.
   if (t.sec > INT_MAX) {
     uint64_t diff = t.sec - INT_MAX;

--- a/rmw_fastrtps_shared_cpp/src/qos.cpp
+++ b/rmw_fastrtps_shared_cpp/src/qos.cpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <limits>
 #include <limits.h>
+#include <limits>
 
 #include "rmw_fastrtps_shared_cpp/qos.hpp"
 


### PR DESCRIPTION
The rmw_time_t uses 64-bit fields for seconds and nanoseconds. These
values are truncated to the eprosima::fastrtps::Duration_t's fields
which are int32 and uint32. This truncation causes problems when
the seconds value is greater than INT_MAX. For example, when attempting
to create a subscriber with a QoS policy that has a Duration field
(such as lifespan, deadline, or liveliness_leas_duration) where
seconds = INT_MAX and nanoseconds = UINT_MAX.

As a work-around (until Fast-DDS supports 64-bit seconds and nanoseconds)
this change ensures that the seconds value can be represented with a
32-bit integer.

Signed-off-by: Michael Jeronimo <michael.jeronimo@openrobotics.org>