### PR TITLE
[foxy] Discriminate when the Client has gone from when the Client has not completely matched

### DIFF
--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -241,7 +241,7 @@ rmw_create_service(
         delete info->pub_listener_;
       }
     });
-  info->pub_listener_ = new (std::nothrow) ServicePubListener();
+  info->pub_listener_ = new (std::nothrow) PatchedServicePubListener();
   if (!info->pub_listener_) {
     RMW_SET_ERROR_MSG("failed to create service response publisher listener");
     return nullptr;

--- a/rmw_fastrtps_shared_cpp/src/rmw_response.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_response.cpp
@@ -118,10 +118,13 @@ __rmw_send_response(
   if ((related_guid.entityId.value[3] & entity_id_is_reader_bit) != 0) {
     // Related guid is a reader, so it is the response subscription guid.
     // Wait for the response writer to be matched with it.
-    auto listener = info->pub_listener_;
-    if (!listener->wait_for_subscription(related_guid, std::chrono::milliseconds(100))) {
+    auto listener = static_cast<PatchedServicePubListener *>(info->pub_listener_);
+    client_present_t ret = listener->check_for_subscription(related_guid);
+    if (ret == client_present_t::GONE) {
+      return RMW_RET_OK;
+    } else if (ret == client_present_t::MAYBE) {
       RMW_SET_ERROR_MSG("client will not receive response");
-      return RMW_RET_ERROR;
+      return RMW_RET_TIMEOUT;
     }
   }
 


### PR DESCRIPTION
Attempt to backport #467 to Foxy in an ABI compatible way.

I *think* this is an ABI compatible port; I'll let the ABI checking tell me otherwise.