### PR TITLE
Remove unexpected template name being passed to TypeSupport class

### DIFF
--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/MessageTypeSupport.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/MessageTypeSupport.hpp
@@ -27,7 +27,7 @@ namespace rmw_fastrtps_shared_cpp
 {
 
 template<typename MembersType>
-class MessageTypeSupport : public TypeSupport<MembersType>
+class MessageTypeSupport : public TypeSupport
 {
 public:
   explicit MessageTypeSupport(const MembersType * members);

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/ServiceTypeSupport.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/ServiceTypeSupport.hpp
@@ -27,7 +27,7 @@ namespace rmw_fastrtps_shared_cpp
 {
 
 template<typename MembersType>
-class ServiceTypeSupport : public TypeSupport<MembersType>
+class ServiceTypeSupport : public TypeSupport
 {
 protected:
   ServiceTypeSupport();


### PR DESCRIPTION
The [TypeSupport class](https://github.com/ros2/rmw_fastrtps/blob/4e0fce977c993f840b013c444d603842fb39ad64/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/TypeSupport.hpp#L41) is not a template class.

To be honest, I'm not sure how the code was compiling before this change as I would have expected there to be an error "expected template-name before ‘<’ token".
I noticed this suddenly appearing during the ABI check for Foxy, for example:

http://build.ros2.org/job/Fpr__rmw_fastrtps__ubuntu_focal_amd64/75/API_5fABI_20report/