### PR TITLE
Use new time_utils function to limit rmw_time_t values to 32-bits

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/qos.cpp
+++ b/rmw_fastrtps_shared_cpp/src/qos.cpp
@@ -26,7 +26,7 @@ static
 eprosima::fastrtps::Duration_t
 rmw_time_to_fastrtps(const rmw_time_t & time)
 {
-  auto clamped_time = rmw_dds_common::clamp_rmw_time_to_dds_time(time);
+  rmw_time_t clamped_time = rmw_dds_common::clamp_rmw_time_to_dds_time(time);
   return eprosima::fastrtps::Duration_t(
     static_cast<int32_t>(clamped_time.sec),
     static_cast<uint32_t>(clamped_time.nsec));

--- a/rmw_fastrtps_shared_cpp/src/qos.cpp
+++ b/rmw_fastrtps_shared_cpp/src/qos.cpp
@@ -20,14 +20,16 @@
 #include "fastrtps/attributes/SubscriberAttributes.h"
 
 #include "rmw/error_handling.h"
+#include "rmw_dds_common/time_utils.hpp"
 
 static
 eprosima::fastrtps::Duration_t
 rmw_time_to_fastrtps(const rmw_time_t & time)
 {
+  auto clamped_time = rmw_dds_common::clamp_rmw_time_to_dds_time(time);
   return eprosima::fastrtps::Duration_t(
-    static_cast<int32_t>(time.sec),
-    static_cast<uint32_t>(time.nsec));
+    static_cast<int32_t>(clamped_time.sec),
+    static_cast<uint32_t>(clamped_time.nsec));
 }
 
 static


### PR DESCRIPTION
Full description and discussion here:

https://github.com/ros2/rmw_dds_common/pull/37

Signed-off-by: Michael Jeronimo <michael.jeronimo@openrobotics.org>