### PR TITLE
Check for correct context shutdown

### DIFF
--- a/rmw_fastrtps_cpp/src/rmw_init.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_init.cpp
@@ -134,6 +134,10 @@ rmw_shutdown(rmw_context_t * context)
     context->implementation_identifier,
     eprosima_fastrtps_identifier,
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  if (context->impl->count > 0) {
+    RMW_SET_ERROR_MSG("Shutting down context with active nodes");
+    return RMW_RET_ERROR;
+  }
   context->impl->is_shutdown = true;
   return RMW_RET_OK;
 }

--- a/rmw_fastrtps_cpp/src/rmw_init.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_init.cpp
@@ -134,10 +134,6 @@ rmw_shutdown(rmw_context_t * context)
     context->implementation_identifier,
     eprosima_fastrtps_identifier,
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
-  if (context->impl->count > 0) {
-    RMW_SET_ERROR_MSG("Shutting down context with active nodes");
-    return RMW_RET_ERROR;
-  }
   context->impl->is_shutdown = true;
   return RMW_RET_OK;
 }
@@ -158,6 +154,10 @@ rmw_context_fini(rmw_context_t * context)
   if (!context->impl->is_shutdown) {
     RCUTILS_SET_ERROR_MSG("context has not been shutdown");
     return RMW_RET_INVALID_ARGUMENT;
+  }
+  if (context->impl->count > 0) {
+    RMW_SET_ERROR_MSG("Deleting a context with active nodes");
+    return RMW_RET_ERROR;
   }
   rmw_ret_t ret = rmw_init_options_fini(&context->options);
   delete context->impl;

--- a/rmw_fastrtps_cpp/src/rmw_init.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_init.cpp
@@ -156,7 +156,7 @@ rmw_context_fini(rmw_context_t * context)
     return RMW_RET_INVALID_ARGUMENT;
   }
   if (context->impl->count > 0) {
-    RMW_SET_ERROR_MSG("Deleting a context with active nodes");
+    RMW_SET_ERROR_MSG("Finalizing a context with active nodes");
     return RMW_RET_ERROR;
   }
   rmw_ret_t ret = rmw_init_options_fini(&context->options);

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_init.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_init.cpp
@@ -134,6 +134,10 @@ rmw_shutdown(rmw_context_t * context)
     context->implementation_identifier,
     eprosima_fastrtps_identifier,
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  if (context->impl->count > 0) {
+    RMW_SET_ERROR_MSG("Shutting down context with active nodes");
+    return RMW_RET_ERROR;
+  }
   context->impl->is_shutdown = true;
   return RMW_RET_OK;
 }

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_init.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_init.cpp
@@ -134,10 +134,6 @@ rmw_shutdown(rmw_context_t * context)
     context->implementation_identifier,
     eprosima_fastrtps_identifier,
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
-  if (context->impl->count > 0) {
-    RMW_SET_ERROR_MSG("Shutting down context with active nodes");
-    return RMW_RET_ERROR;
-  }
   context->impl->is_shutdown = true;
   return RMW_RET_OK;
 }
@@ -158,6 +154,10 @@ rmw_context_fini(rmw_context_t * context)
   if (!context->impl->is_shutdown) {
     RCUTILS_SET_ERROR_MSG("context has not been shutdown");
     return RMW_RET_INVALID_ARGUMENT;
+  }
+  if (context->impl->count > 0) {
+    RMW_SET_ERROR_MSG("Deleting a context with active nodes");
+    return RMW_RET_ERROR;
   }
   rmw_ret_t ret = rmw_init_options_fini(&context->options);
   delete context->impl;

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_init.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_init.cpp
@@ -156,7 +156,7 @@ rmw_context_fini(rmw_context_t * context)
     return RMW_RET_INVALID_ARGUMENT;
   }
   if (context->impl->count > 0) {
-    RMW_SET_ERROR_MSG("Deleting a context with active nodes");
+    RMW_SET_ERROR_MSG("Finalizing a context with active nodes");
     return RMW_RET_ERROR;
   }
   rmw_ret_t ret = rmw_init_options_fini(&context->options);

--- a/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
@@ -68,6 +68,10 @@ __rmw_create_node(
     RMW_SET_ERROR_MSG_WITH_FORMAT_STRING("invalid node namespace: %s", reason);
     return nullptr;
   }
+  if (context->impl->is_shutdown) {
+    RMW_SET_ERROR_MSG("Trying to create node in a shutdown context");
+    return nullptr;
+  }
 
   auto common_context = static_cast<rmw_dds_common::Context *>(context->impl->common);
   rmw_dds_common::GraphCache & graph_cache = common_context->graph_cache;

--- a/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
@@ -68,10 +68,6 @@ __rmw_create_node(
     RMW_SET_ERROR_MSG_WITH_FORMAT_STRING("invalid node namespace: %s", reason);
     return nullptr;
   }
-  if (context->impl->is_shutdown) {
-    RMW_SET_ERROR_MSG("Trying to create node in a shutdown context");
-    return nullptr;
-  }
 
   auto common_context = static_cast<rmw_dds_common::Context *>(context->impl->common);
   rmw_dds_common::GraphCache & graph_cache = common_context->graph_cache;


### PR DESCRIPTION
Added checks for the creation of nodes in context which has been shutdown, and for shutdown of a context with active nodes. 

Thess throw a `RMW_RET_ERROR` instead of causing segfaults as seen in ros2/rmw_fastrtps#478

Signed-off-by: Ignacio Montesino <ignaciomontesino@eprosima.com>