### PR TITLE
Revert "Discriminate when the Client has gone from when the Client has not completely matched (#479)"

### DIFF
--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -241,7 +241,7 @@ rmw_create_service(
         delete info->pub_listener_;
       }
     });
-  info->pub_listener_ = new (std::nothrow) PatchedServicePubListener();
+  info->pub_listener_ = new (std::nothrow) ServicePubListener();
   if (!info->pub_listener_) {
     RMW_SET_ERROR_MSG("failed to create service response publisher listener");
     return nullptr;

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
@@ -20,7 +20,6 @@
 #include <list>
 #include <mutex>
 #include <unordered_set>
-#include <unordered_map>
 
 #include "fastcdr/FastBuffer.h"
 
@@ -38,15 +37,6 @@
 
 class ServiceListener;
 class ServicePubListener;
-class PatchedServicePubListener;
-
-enum class client_present_t
-{
-  FAILURE,  // an error occurred when checking
-  MAYBE,    // reader not matched, writer still present
-  YES,      // reader matched
-  GONE      // neither reader nor writer
-};
 
 typedef struct CustomServiceInfo
 {
@@ -72,132 +62,6 @@ typedef struct CustomServiceRequest
   : buffer_(nullptr) {}
 } CustomServiceRequest;
 
-class ServicePubListener : public eprosima::fastrtps::PublisherListener
-{
-public:
-  ServicePubListener() = default;
-
-  template<class Rep, class Period>
-  bool wait_for_subscription(
-    const eprosima::fastrtps::rtps::GUID_t & guid,
-    const std::chrono::duration<Rep, Period> & rel_time)
-  {
-    auto guid_is_present = [this, guid]() RCPPUTILS_TSA_REQUIRES(mutex_)->bool
-    {
-      return subscriptions_.find(guid) != subscriptions_.end();
-    };
-
-    std::unique_lock<std::mutex> lock(mutex_);
-    return cv_.wait_for(lock, rel_time, guid_is_present);
-  }
-
-  void onPublicationMatched(
-    eprosima::fastrtps::Publisher * pub,
-    eprosima::fastrtps::rtps::MatchingInfo & matchingInfo)
-  {
-    (void) pub;
-    std::lock_guard<std::mutex> lock(mutex_);
-    if (eprosima::fastrtps::rtps::MATCHED_MATCHING == matchingInfo.status) {
-      subscriptions_.insert(matchingInfo.remoteEndpointGuid);
-    } else if (eprosima::fastrtps::rtps::REMOVED_MATCHING == matchingInfo.status) {
-      subscriptions_.erase(matchingInfo.remoteEndpointGuid);
-    } else {
-      return;
-    }
-    cv_.notify_all();
-  }
-
-protected:
-  std::mutex & getMutex()
-  {
-    return mutex_;
-  }
-
-  std::unordered_set<
-    eprosima::fastrtps::rtps::GUID_t,
-    rmw_fastrtps_shared_cpp::hash_fastrtps_guid> &
-  getSubscriptions()
-  {
-    return subscriptions_;
-  }
-
-  std::condition_variable & getConditionVariable()
-  {
-    return cv_;
-  }
-
-private:
-  using subscriptions_set_t =
-    std::unordered_set<eprosima::fastrtps::rtps::GUID_t,
-      rmw_fastrtps_shared_cpp::hash_fastrtps_guid>;
-
-  std::mutex mutex_;
-  subscriptions_set_t subscriptions_ RCPPUTILS_TSA_GUARDED_BY(mutex_);
-  std::condition_variable cv_;
-};
-
-// Wrapper around ServicePubListener to fix issue when matching clients in an ABI compatible way
-// See original patch: https://github.com/ros2/rmw_fastrtps/pull/467
-class PatchedServicePubListener : public ServicePubListener
-{
-public:
-  using clients_endpoints_map_t =
-    std::unordered_map<eprosima::fastrtps::rtps::GUID_t,
-      eprosima::fastrtps::rtps::GUID_t,
-      rmw_fastrtps_shared_cpp::hash_fastrtps_guid>;
-
-  void onPublicationMatched(
-    eprosima::fastrtps::Publisher * pub,
-    eprosima::fastrtps::rtps::MatchingInfo & matchingInfo)
-  {
-    (void) pub;
-    std::lock_guard<std::mutex> lock(getMutex());
-    std::unordered_set<
-      eprosima::fastrtps::rtps::GUID_t,
-      rmw_fastrtps_shared_cpp::hash_fastrtps_guid> & subscriptions_ = getSubscriptions();
-    std::condition_variable & cv_ = getConditionVariable();
-    if (eprosima::fastrtps::rtps::MATCHED_MATCHING == matchingInfo.status) {
-      subscriptions_.insert(matchingInfo.remoteEndpointGuid);
-    } else if (eprosima::fastrtps::rtps::REMOVED_MATCHING == matchingInfo.status) {
-      subscriptions_.erase(matchingInfo.remoteEndpointGuid);
-      auto endpoint = clients_endpoints_.find(matchingInfo.remoteEndpointGuid);
-      if (endpoint != clients_endpoints_.end()) {
-        clients_endpoints_.erase(endpoint->second);
-        clients_endpoints_.erase(matchingInfo.remoteEndpointGuid);
-      }
-    } else {
-      return;
-    }
-    cv_.notify_all();
-  }
-
-  client_present_t
-  check_for_subscription(
-    const eprosima::fastrtps::rtps::GUID_t & guid)
-  {
-    // Check if the guid is still in the map
-    if (clients_endpoints_.find(guid) == clients_endpoints_.end()) {
-      // Client is gone
-      return client_present_t::GONE;
-    }
-    // Wait for subscription
-    if (!wait_for_subscription(guid, std::chrono::milliseconds(100))) {
-      return client_present_t::MAYBE;
-    }
-    return client_present_t::YES;
-  }
-
-  // Accesors
-  clients_endpoints_map_t & clients_endpoints()
-  {
-    std::lock_guard<std::mutex> lock(getMutex());
-    return clients_endpoints_;
-  }
-
-private:
-  clients_endpoints_map_t clients_endpoints_;
-};
-
 class ServiceListener : public eprosima::fastrtps::SubscriberListener
 {
 public:
@@ -208,23 +72,6 @@ public:
     (void)info_;
   }
 
-  void
-  onSubscriptionMatched(
-    eprosima::fastrtps::Subscriber * sub,
-    eprosima::fastrtps::rtps::MatchingInfo & matchingInfo)
-  {
-    (void) sub;
-    PatchedServicePubListener * pub_listener = static_cast<PatchedServicePubListener *>(
-      info_->pub_listener_);
-    if (eprosima::fastrtps::rtps::REMOVED_MATCHING == matchingInfo.status) {
-      auto endpoint = pub_listener->clients_endpoints().find(
-        matchingInfo.remoteEndpointGuid);
-      if (endpoint != pub_listener->clients_endpoints().end()) {
-        pub_listener->clients_endpoints().erase(endpoint->second);
-        pub_listener->clients_endpoints().erase(matchingInfo.remoteEndpointGuid);
-      }
-    }
-  }
 
   void
   onNewDataMessage(eprosima::fastrtps::Subscriber * sub)
@@ -247,14 +94,6 @@ public:
         if (reader_guid != eprosima::fastrtps::rtps::GUID_t::unknown() ) {
           request.sample_identity_.writer_guid() = reader_guid;
         }
-
-        // Save both guids in the clients_endpoints map
-        PatchedServicePubListener * pub_listener =
-          static_cast<PatchedServicePubListener *>(info_->pub_listener_);
-        const eprosima::fastrtps::rtps::GUID_t & writer_guid =
-          request.sample_info_.sample_identity.writer_guid();
-        pub_listener->clients_endpoints().emplace(reader_guid, writer_guid);
-        pub_listener->clients_endpoints().emplace(writer_guid, reader_guid);
 
         std::lock_guard<std::mutex> lock(internalMutex_);
 
@@ -328,6 +167,51 @@ private:
   std::atomic_bool list_has_data_;
   std::mutex * conditionMutex_ RCPPUTILS_TSA_GUARDED_BY(internalMutex_);
   std::condition_variable * conditionVariable_ RCPPUTILS_TSA_GUARDED_BY(internalMutex_);
+};
+
+class ServicePubListener : public eprosima::fastrtps::PublisherListener
+{
+public:
+  ServicePubListener() = default;
+
+  template<class Rep, class Period>
+  bool wait_for_subscription(
+    const eprosima::fastrtps::rtps::GUID_t & guid,
+    const std::chrono::duration<Rep, Period> & rel_time)
+  {
+    auto guid_is_present = [this, guid]() RCPPUTILS_TSA_REQUIRES(mutex_)->bool
+    {
+      return subscriptions_.find(guid) != subscriptions_.end();
+    };
+
+    std::unique_lock<std::mutex> lock(mutex_);
+    return cv_.wait_for(lock, rel_time, guid_is_present);
+  }
+
+  void onPublicationMatched(
+    eprosima::fastrtps::Publisher * pub,
+    eprosima::fastrtps::rtps::MatchingInfo & matchingInfo)
+  {
+    (void) pub;
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (eprosima::fastrtps::rtps::MATCHED_MATCHING == matchingInfo.status) {
+      subscriptions_.insert(matchingInfo.remoteEndpointGuid);
+    } else if (eprosima::fastrtps::rtps::REMOVED_MATCHING == matchingInfo.status) {
+      subscriptions_.erase(matchingInfo.remoteEndpointGuid);
+    } else {
+      return;
+    }
+    cv_.notify_all();
+  }
+
+private:
+  using subscriptions_set_t =
+    std::unordered_set<eprosima::fastrtps::rtps::GUID_t,
+      rmw_fastrtps_shared_cpp::hash_fastrtps_guid>;
+
+  std::mutex mutex_;
+  subscriptions_set_t subscriptions_ RCPPUTILS_TSA_GUARDED_BY(mutex_);
+  std::condition_variable cv_;
 };
 
 #endif  // RMW_FASTRTPS_SHARED_CPP__CUSTOM_SERVICE_INFO_HPP_

--- a/rmw_fastrtps_shared_cpp/src/rmw_response.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_response.cpp
@@ -118,13 +118,10 @@ __rmw_send_response(
   if ((related_guid.entityId.value[3] & entity_id_is_reader_bit) != 0) {
     // Related guid is a reader, so it is the response subscription guid.
     // Wait for the response writer to be matched with it.
-    auto listener = static_cast<PatchedServicePubListener *>(info->pub_listener_);
-    client_present_t ret = listener->check_for_subscription(related_guid);
-    if (ret == client_present_t::GONE) {
-      return RMW_RET_OK;
-    } else if (ret == client_present_t::MAYBE) {
+    auto listener = info->pub_listener_;
+    if (!listener->wait_for_subscription(related_guid, std::chrono::milliseconds(100))) {
       RMW_SET_ERROR_MSG("client will not receive response");
-      return RMW_RET_TIMEOUT;
+      return RMW_RET_ERROR;
     }
   }
 


### PR DESCRIPTION
This reverts commit c78c31a825932d9cc6682120d06e6fcea733a3bb from #479 @jacobperron FYI

It appears to be the cause of [Foxy CI with `rmw_fastrtps_dynamic_cpp` hanging](http://build.ros2.org/view/Fci/job/Fci__nightly-fastrtps-dynamic_ubuntu_focal_amd64/205/). It causes the rclcpp composable node container to crash, and that causes a test in `test_launch_ros` to hang forever.

A more minimal example is:

```
$ export RMW_IMPLEMENTATION=rmw_fastrtps_dynamic_cpp
$ ./install/rclcpp_components/lib/rclcpp_components/component_container
```

```
$ export RMW_IMPLEMENTATION=rmw_fastrtps_dynamic_cpp
$ ros2 component list
```

When `ros2 component list` is called, the container segfaults.

<details><summary>Crash happens entirely in FastRTPS</summary>

```
#0  0x00007ffff6e9e4c4 in std::_Hashtable<eprosima::fastrtps::rtps::GUID_t, std::pair<eprosima::fastrtps::rtps::GUID_t const, eprosima::fastrtps::rtps::GUID_t>, std::allocator<std::pair<eprosima::fastrtps::rtps::GUID_t const, eprosima::fastrtps::rtps::GUID_t> >, std::__detail::_Select1st, std::equal_to<eprosima::fastrtps::rtps::GUID_t>, rmw_fastrtps_shared_cpp::hash_fastrtps_guid, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true> >::_M_find_before_node(unsigned long, eprosima::fastrtps::rtps::GUID_t const&, unsigned long) const () from /home/sloretz/install/rmw_fastrtps_dynamic_cpp/lib/librmw_fastrtps_dynamic_cpp.so
#1  0x00007ffff6e9d91c in std::_Hashtable<eprosima::fastrtps::rtps::GUID_t, std::pair<eprosima::fastrtps::rtps::GUID_t const, eprosima::fastrtps::rtps::GUID_t>, std::allocator<std::pair<eprosima::fastrtps::rtps::GUID_t const, eprosima::fastrtps::rtps::GUID_t> >, std::__detail::_Select1st, std::equal_to<eprosima::fastrtps::rtps::GUID_t>, rmw_fastrtps_shared_cpp::hash_fastrtps_guid, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true> >::_M_find_node(unsigned long, eprosima::fastrtps::rtps::GUID_t const&, unsigned long) const () from /home/sloretz/install/rmw_fastrtps_dynamic_cpp/lib/librmw_fastrtps_dynamic_cpp.so
#2  0x00007ffff6e9db88 in std::pair<std::__detail::_Node_iterator<std::pair<eprosima::fastrtps::rtps::GUID_t const, eprosima::fastrtps::rtps::GUID_t>, false, true>, bool> std::_Hashtable<eprosima::fastrtps::rtps::GUID_t, std::pair<eprosima::fastrtps::rtps::GUID_t const, eprosima::fastrtps::rtps::GUID_t>, std::allocator<std::pair<eprosima::fastrtps::rtps::GUID_t const, eprosima::fastrtps::rtps::GUID_t> >, std::__detail::_Select1st, std::equal_to<eprosima::fastrtps::rtps::GUID_t>, rmw_fastrtps_shared_cpp::hash_fastrtps_guid, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true> >::_M_emplace<eprosima::fastrtps::rtps::GUID_t const&, eprosima::fastrtps::rtps::GUID_t const&>(std::integral_constant<bool, true>, eprosima::fastrtps::rtps::GUID_t const&, eprosima::fastrtps::rtps::GUID_t const&) () from /home/sloretz/install/rmw_fastrtps_dynamic_cpp/lib/librmw_fastrtps_dynamic_cpp.so
#3  0x00007ffff6e9d4de in std::pair<std::__detail::_Node_iterator<std::pair<eprosima::fastrtps::rtps::GUID_t const, eprosima::fastrtps::rtps::GUID_t>, false, true>, bool> std::_Hashtable<eprosima::fastrtps::rtps::GUID_t, std::pair<eprosima::fastrtps::rtps::GUID_t const, eprosima::fastrtps::rtps::GUID_t>, std::allocator<std::pair<eprosima::fastrtps::rtps::GUID_t const, eprosima::fastrtps::rtps::GUID_t> >, std::__detail::_Select1st, std::equal_to<eprosima::fastrtps::rtps::GUID_t>, rmw_fastrtps_shared_cpp::hash_fastrtps_guid, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true> >::emplace<eprosima::fastrtps::rtps::GUID_t const&, eprosima::fastrtps::rtps::GUID_t const&>(eprosima::fastrtps::rtps::GUID_t const&, eprosima::fastrtps::rtps::GUID_t const&) () from /home/sloretz/install/rmw_fastrtps_dynamic_cpp/lib/librmw_fastrtps_dynamic_cpp.so
#4  0x00007ffff6e9d0ea in std::pair<std::__detail::_Node_iterator<std::pair<eprosima::fastrtps::rtps::GUID_t const, eprosima::fastrtps::rtps::GUID_t>, false, true>, bool> std::unordered_map<eprosima::fastrtps::rtps::GUID_t, eprosima::fastrtps::rtps::GUID_t, rmw_fastrtps_shared_cpp::hash_fastrtps_guid, std::equal_to<eprosima::fastrtps::rtps::GUID_t>, std::allocator<std::pair<eprosima::fastrtps::rtps::GUID_t const, eprosima::fastrtps::rtps::GUID_t> > >::emplace<eprosima::fastrtps::rtps::GUID_t const&, eprosima::fastrtps::rtps::GUID_t const&>(eprosima::fastrtps::rtps::GUID_t const&, eprosima::fastrtps::rtps::GUID_t const&) () from /home/sloretz/install/rmw_fastrtps_dynamic_cpp/lib/librmw_fastrtps_dynamic_cpp.so
#5  0x00007ffff6e9cac2 in ServiceListener::onNewDataMessage(eprosima::fastrtps::Subscriber*) () from /home/sloretz/install/rmw_fastrtps_dynamic_cpp/lib/librmw_fastrtps_dynamic_cpp.so
#6  0x00007ffff68068fa in eprosima::fastrtps::rtps::StatefulReader::NotifyChanges(eprosima::fastrtps::rtps::WriterProxy*) () from /home/sloretz/install/fastrtps/lib/libfastrtps.so.2
#7  0x00007ffff6806b0c in eprosima::fastrtps::rtps::StatefulReader::change_received(eprosima::fastrtps::rtps::CacheChange_t*, eprosima::fastrtps::rtps::WriterProxy*) ()
   from /home/sloretz/install/fastrtps/lib/libfastrtps.so.2
--Type <RET> for more, q to quit, c to continue without paging--
#8  0x00007ffff6807c78 in eprosima::fastrtps::rtps::StatefulReader::processDataMsg(eprosima::fastrtps::rtps::CacheChange_t*) () from /home/sloretz/install/fastrtps/lib/libfastrtps.so.2
#9  0x00007ffff6824cf6 in eprosima::fastrtps::rtps::MessageReceiver::proc_Submsg_Data(eprosima::fastrtps::rtps::CDRMessage_t*, eprosima::fastrtps::rtps::SubmessageHeader_t*) ()
   from /home/sloretz/install/fastrtps/lib/libfastrtps.so.2
#10 0x00007ffff6829579 in eprosima::fastrtps::rtps::MessageReceiver::processCDRMsg(eprosima::fastrtps::rtps::Locator_t const&, eprosima::fastrtps::rtps::CDRMessage_t*) ()
   from /home/sloretz/install/fastrtps/lib/libfastrtps.so.2
#11 0x00007ffff682bd16 in eprosima::fastrtps::rtps::ReceiverResource::OnDataReceived(unsigned char const*, unsigned int, eprosima::fastrtps::rtps::Locator_t const&, eprosima::fastrtps::rtps::Locator_t const&)
    () from /home/sloretz/install/fastrtps/lib/libfastrtps.so.2
#12 0x00007ffff6ae8be7 in eprosima::fastdds::rtps::SharedMemChannelResource::perform_listen_operation(eprosima::fastrtps::rtps::Locator_t) () from /home/sloretz/install/fastrtps/lib/libfastrtps.so.2
#13 0x00007ffff6ad8d8a in std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (eprosima::fastdds::rtps::SharedMemChannelResource::*)(eprosima::fastrtps::rtps::Locator_t), eprosima::fastdds::rtps::SharedMemChannelResource*, eprosima::fastrtps::rtps::Locator_t> > >::_M_run() () from /home/sloretz/install/fastrtps/lib/libfastrtps.so.2
#14 0x00007ffff75c5d84 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#15 0x00007ffff7057609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#16 0x00007ffff7402293 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```
</details>