### PR TITLE
[foxy] Avoid unused identifier variable warnings (#422)

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/subscription.cpp
+++ b/rmw_fastrtps_shared_cpp/src/subscription.cpp
@@ -45,6 +45,7 @@ destroy_subscription(
   rmw_subscription_t * subscription)
 {
   assert(subscription->implementation_identifier == identifier);
+  static_cast<void>(identifier);
 
   rmw_ret_t ret = RMW_RET_OK;
   auto info = static_cast<CustomSubscriberInfo *>(subscription->data);


### PR DESCRIPTION
Backport #422 to Foxy.

This should resolve compiler warnings in release builds, e.g. https://ci.ros2.org/job/ci_packaging_osx/79/clang/