### PR TITLE
Set rmw_dds_common::GraphCache callback after init succeeds.

### DIFF
--- a/rmw_fastrtps_cpp/src/init_rmw_context_impl.cpp
+++ b/rmw_fastrtps_cpp/src/init_rmw_context_impl.cpp
@@ -151,13 +151,6 @@ init_context_impl(rmw_context_t * context)
     return RMW_RET_BAD_ALLOC;
   }
 
-  common_context->graph_cache.set_on_change_callback(
-    [guard_condition = graph_guard_condition.get()]() {
-      rmw_fastrtps_shared_cpp::__rmw_trigger_guard_condition(
-        eprosima_fastrtps_identifier,
-        guard_condition);
-    });
-
   common_context->gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
     eprosima_fastrtps_identifier, participant_info->participant->getGuid());
   common_context->pub = publisher.get();
@@ -171,6 +164,14 @@ init_context_impl(rmw_context_t * context)
   if (RMW_RET_OK != ret) {
     return ret;
   }
+
+  common_context->graph_cache.set_on_change_callback(
+    [guard_condition = graph_guard_condition.get()]() {
+      rmw_fastrtps_shared_cpp::__rmw_trigger_guard_condition(
+        eprosima_fastrtps_identifier,
+        guard_condition);
+    });
+
   common_context->graph_cache.add_participant(
     common_context->gid,
     context->options.enclave);

--- a/rmw_fastrtps_dynamic_cpp/src/init_rmw_context_impl.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/init_rmw_context_impl.cpp
@@ -151,14 +151,6 @@ init_context_impl(rmw_context_t * context)
     return RMW_RET_BAD_ALLOC;
   }
 
-  common_context->graph_cache.set_on_change_callback(
-    [guard_condition = graph_guard_condition.get()]() {
-      rmw_fastrtps_shared_cpp::__rmw_trigger_guard_condition(
-        eprosima_fastrtps_identifier,
-        guard_condition);
-    });
-
-
   common_context->gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
     eprosima_fastrtps_identifier, participant_info->participant->getGuid());
   common_context->pub = publisher.get();
@@ -172,6 +164,14 @@ init_context_impl(rmw_context_t * context)
   if (RMW_RET_OK != ret) {
     return ret;
   }
+
+  common_context->graph_cache.set_on_change_callback(
+    [guard_condition = graph_guard_condition.get()]() {
+      rmw_fastrtps_shared_cpp::__rmw_trigger_guard_condition(
+        eprosima_fastrtps_identifier,
+        guard_condition);
+    });
+
   common_context->graph_cache.add_participant(
     common_context->gid,
     context->options.enclave);


### PR DESCRIPTION
Otherwise, during stack unwinding, the graph cache may end up with a callback that captures and uses an already destroyed guard condition.

This patch (hopefully) fixes #491. 

Ci up `test_rmw_implementation`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13277)](http://ci.ros2.org/job/ci_linux/13277/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8209)](http://ci.ros2.org/job/ci_linux-aarch64/8209/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11008)](http://ci.ros2.org/job/ci_osx/11008/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13311)](http://ci.ros2.org/job/ci_windows/13311/)
