### PR TITLE
Use RMW_DURATION_INFINITE constant

### DIFF
--- a/rmw_fastrtps_cpp/src/rmw_wait.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_wait.cpp
@@ -28,7 +28,7 @@ rmw_wait(
   rmw_clients_t * clients,
   rmw_events_t * events,
   rmw_wait_set_t * wait_set,
-  const rmw_time_t * wait_timeout)
+  rmw_duration_t wait_timeout)
 {
   return rmw_fastrtps_shared_cpp::__rmw_wait(
     eprosima_fastrtps_identifier, subscriptions, guard_conditions, services, clients, events,

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_wait.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_wait.cpp
@@ -28,7 +28,7 @@ rmw_wait(
   rmw_clients_t * clients,
   rmw_events_t * events,
   rmw_wait_set_t * wait_set,
-  const rmw_time_t * wait_timeout)
+  rmw_duration_t wait_timeout)
 {
   return rmw_fastrtps_shared_cpp::__rmw_wait(
     eprosima_fastrtps_identifier, subscriptions, guard_conditions, services, clients, events,

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/qos.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/qos.hpp
@@ -51,6 +51,10 @@ get_datawriter_qos(
   const rmw_qos_profile_t & qos_policies,
   eprosima::fastrtps::PublisherAttributes & pattr);
 
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
+rmw_duration_t
+fastrtps_duration_to_rmw(const eprosima::fastrtps::Duration_t & duration);
+
 /*
  * Converts the low-level QOS Policy; of type WriterQos or ReaderQos into rmw_qos_profile_t.
  * Since WriterQos or ReaderQos does not have information about history and depth, these values are not set
@@ -89,10 +93,8 @@ dds_qos_to_rmw_qos(
       break;
   }
 
-  qos->deadline = RCUTILS_S_TO_NS(dds_qos.m_deadline.period.seconds) +
-    dds_qos.m_deadline.period.nanosec;
-  qos->lifespan = RCUTILS_S_TO_NS(dds_qos.m_lifespan.duration.seconds) +
-    dds_qos.m_lifespan.duration.nanosec;
+  qos->deadline = fastrtps_duration_to_rmw(dds_qos.m_deadline.period);
+  qos->lifespan = fastrtps_duration_to_rmw(dds_qos.m_lifespan.duration);
 
   switch (dds_qos.m_liveliness.kind) {
     case eprosima::fastrtps::AUTOMATIC_LIVELINESS_QOS:
@@ -105,8 +107,7 @@ dds_qos_to_rmw_qos(
       qos->liveliness = RMW_QOS_POLICY_LIVELINESS_UNKNOWN;
       break;
   }
-  qos->liveliness_lease_duration = RCUTILS_S_TO_NS(dds_qos.m_liveliness.lease_duration.seconds) +
-    dds_qos.m_liveliness.lease_duration.nanosec;
+  qos->liveliness_lease_duration = fastrtps_duration_to_rmw(dds_qos.m_liveliness.lease_duration);
 }
 
 template<typename AttributeT>

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/qos.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/qos.hpp
@@ -89,11 +89,10 @@ dds_qos_to_rmw_qos(
       break;
   }
 
-  qos->deadline.sec = dds_qos.m_deadline.period.seconds;
-  qos->deadline.nsec = dds_qos.m_deadline.period.nanosec;
-
-  qos->lifespan.sec = dds_qos.m_lifespan.duration.seconds;
-  qos->lifespan.nsec = dds_qos.m_lifespan.duration.nanosec;
+  qos->deadline = RCUTILS_S_TO_NS(dds_qos.m_deadline.period.seconds) +
+    dds_qos.m_deadline.period.nanosec;
+  qos->lifespan = RCUTILS_S_TO_NS(dds_qos.m_lifespan.duration.seconds) +
+    dds_qos.m_lifespan.duration.nanosec;
 
   switch (dds_qos.m_liveliness.kind) {
     case eprosima::fastrtps::AUTOMATIC_LIVELINESS_QOS:
@@ -106,8 +105,8 @@ dds_qos_to_rmw_qos(
       qos->liveliness = RMW_QOS_POLICY_LIVELINESS_UNKNOWN;
       break;
   }
-  qos->liveliness_lease_duration.sec = dds_qos.m_liveliness.lease_duration.seconds;
-  qos->liveliness_lease_duration.nsec = dds_qos.m_liveliness.lease_duration.nanosec;
+  qos->liveliness_lease_duration = RCUTILS_S_TO_NS(dds_qos.m_liveliness.lease_duration.seconds) +
+    dds_qos.m_liveliness.lease_duration.nanosec;
 }
 
 template<typename AttributeT>

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/rmw_common.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/rmw_common.hpp
@@ -362,7 +362,7 @@ __rmw_wait(
   rmw_clients_t * clients,
   rmw_events_t * events,
   rmw_wait_set_t * wait_set,
-  const rmw_time_t * wait_timeout);
+  rmw_duration_t wait_timeout);
 
 RMW_FASTRTPS_SHARED_CPP_PUBLIC
 rmw_wait_set_t *

--- a/rmw_fastrtps_shared_cpp/src/listener_thread.cpp
+++ b/rmw_fastrtps_shared_cpp/src/listener_thread.cpp
@@ -143,7 +143,7 @@ node_listener(rmw_context_t * context)
         nullptr,
         nullptr,
         wait_set,
-        nullptr))
+        -1))
     {
       TERMINATE_THREAD("rmw_wait failed");
     }

--- a/rmw_fastrtps_shared_cpp/src/qos.cpp
+++ b/rmw_fastrtps_shared_cpp/src/qos.cpp
@@ -32,9 +32,9 @@ rmw_duration_to_fastrtps(const rmw_duration_t duration)
 
 static
 bool
-is_time_default(const rmw_duration_t & time)
+is_duration_default(const rmw_duration_t & duration)
 {
-  return time == RMW_DURATION_INFINITE;
+  return duration == 0 || duration == RMW_DURATION_INFINITE;
 }
 
 template<typename DDSEntityQos>
@@ -99,11 +99,11 @@ bool fill_entity_qos_from_profile(
     history_qos.depth = static_cast<int32_t>(qos_policies.depth);
   }
 
-  if (!is_time_default(qos_policies.lifespan)) {
+  if (!is_duration_default(qos_policies.lifespan)) {
     entity_qos.m_lifespan.duration = rmw_duration_to_fastrtps(qos_policies.lifespan);
   }
 
-  if (!is_time_default(qos_policies.deadline)) {
+  if (!is_duration_default(qos_policies.deadline)) {
     entity_qos.m_deadline.period = rmw_duration_to_fastrtps(qos_policies.deadline);
   }
 
@@ -120,7 +120,7 @@ bool fill_entity_qos_from_profile(
       RMW_SET_ERROR_MSG("Unknown QoS Liveliness policy");
       return false;
   }
-  if (!is_time_default(qos_policies.liveliness_lease_duration)) {
+  if (!is_duration_default(qos_policies.liveliness_lease_duration)) {
     entity_qos.m_liveliness.lease_duration =
       rmw_duration_to_fastrtps(qos_policies.liveliness_lease_duration);
 

--- a/rmw_fastrtps_shared_cpp/src/qos.cpp
+++ b/rmw_fastrtps_shared_cpp/src/qos.cpp
@@ -23,18 +23,18 @@
 
 static
 eprosima::fastrtps::Duration_t
-rmw_duration_to_fastrtps(const rmw_duration_t time)
+rmw_duration_to_fastrtps(const rmw_duration_t duration)
 {
   return eprosima::fastrtps::Duration_t(
-    static_cast<int32_t>(RCUTILS_NS_TO_S(time)),
-    static_cast<uint32_t>(time % RCUTILS_S_TO_NS(1)));
+    static_cast<int32_t>(RCUTILS_NS_TO_S(duration)),
+    static_cast<uint32_t>(duration % RCUTILS_S_TO_NS(1)));
 }
 
 static
 bool
 is_time_default(const rmw_duration_t & time)
 {
-  return time == 0;
+  return time == RMW_DURATION_INFINITE;
 }
 
 template<typename DDSEntityQos>
@@ -154,6 +154,16 @@ bool
 is_valid_qos(const rmw_qos_profile_t & /* qos_policies */)
 {
   return true;
+}
+
+rmw_duration_t
+fastrtps_duration_to_rmw(const eprosima::fastrtps::Duration_t & duration)
+{
+  if (duration == eprosima::fastrtps::rtps::c_RTPSTimeInfinite) {
+    return RMW_DURATION_INFINITE;
+  } else {
+    return RCUTILS_S_TO_NS(duration.seconds) + duration.nanosec;
+  }
 }
 
 template<typename AttributeT>

--- a/rmw_fastrtps_shared_cpp/test/test_dds_attributes_to_rmw_qos.cpp
+++ b/rmw_fastrtps_shared_cpp/test/test_dds_attributes_to_rmw_qos.cpp
@@ -65,23 +65,23 @@ TEST_F(DDSAttributesToRMWQosTest, test_publisher_liveliness_conversion) {
 
 TEST_F(DDSAttributesToRMWQosTest, test_publisher_liveliness_lease_duration_conversion) {
   publisher_attributes_.qos.m_liveliness.lease_duration = {8, 78901234};
+  rmw_duration_t expected = RCUTILS_S_TO_NS(8) + 78901234;
   dds_attributes_to_rmw_qos(publisher_attributes_, &qos_profile_);
-  EXPECT_EQ(qos_profile_.liveliness_lease_duration.sec, 8u);
-  EXPECT_EQ(qos_profile_.liveliness_lease_duration.nsec, 78901234u);
+  EXPECT_EQ(qos_profile_.liveliness_lease_duration, expected);
 }
 
 TEST_F(DDSAttributesToRMWQosTest, test_publisher_deadline_conversion) {
   publisher_attributes_.qos.m_deadline.period = {12, 1234};
+  rmw_duration_t expected = RCUTILS_S_TO_NS(12) + 1234;
   dds_attributes_to_rmw_qos(publisher_attributes_, &qos_profile_);
-  EXPECT_EQ(qos_profile_.deadline.sec, 12u);
-  EXPECT_EQ(qos_profile_.deadline.nsec, 1234u);
+  EXPECT_EQ(qos_profile_.deadline, expected);
 }
 
 TEST_F(DDSAttributesToRMWQosTest, test_publisher_lifespan_conversion) {
   publisher_attributes_.qos.m_lifespan.duration = {19, 5432};
+  rmw_duration_t expected = RCUTILS_S_TO_NS(19) + 5432;
   dds_attributes_to_rmw_qos(publisher_attributes_, &qos_profile_);
-  EXPECT_EQ(qos_profile_.lifespan.sec, 19u);
-  EXPECT_EQ(qos_profile_.lifespan.nsec, 5432u);
+  EXPECT_EQ(qos_profile_.lifespan, expected);
 }
 
 
@@ -118,21 +118,21 @@ TEST_F(DDSAttributesToRMWQosTest, test_subscriber_liveliness_conversion) {
 
 TEST_F(DDSAttributesToRMWQosTest, test_subscriber_liveliness_lease_duration_conversion) {
   subscriber_attributes_.qos.m_liveliness.lease_duration = {80, 34567};
+  rmw_duration_t expected = RCUTILS_S_TO_NS(80) + 34567;
   dds_attributes_to_rmw_qos(subscriber_attributes_, &qos_profile_);
-  EXPECT_EQ(qos_profile_.liveliness_lease_duration.sec, 80u);
-  EXPECT_EQ(qos_profile_.liveliness_lease_duration.nsec, 34567u);
+  EXPECT_EQ(qos_profile_.liveliness_lease_duration, expected);
 }
 
 TEST_F(DDSAttributesToRMWQosTest, test_subscriber_deadline_conversion) {
   subscriber_attributes_.qos.m_deadline.period = {1, 3324};
+  rmw_duration_t expected = RCUTILS_S_TO_NS(1) + 3324;
   dds_attributes_to_rmw_qos(subscriber_attributes_, &qos_profile_);
-  EXPECT_EQ(qos_profile_.deadline.sec, 1u);
-  EXPECT_EQ(qos_profile_.deadline.nsec, 3324u);
+  EXPECT_EQ(qos_profile_.deadline, expected);
 }
 
 TEST_F(DDSAttributesToRMWQosTest, test_subscriber_lifespan_conversion) {
   subscriber_attributes_.qos.m_lifespan.duration = {9, 432};
+  rmw_duration_t expected = RCUTILS_S_TO_NS(9) + 432;
   dds_attributes_to_rmw_qos(subscriber_attributes_, &qos_profile_);
-  EXPECT_EQ(qos_profile_.lifespan.sec, 9u);
-  EXPECT_EQ(qos_profile_.lifespan.nsec, 432u);
+  EXPECT_EQ(qos_profile_.lifespan, expected);
 }

--- a/rmw_fastrtps_shared_cpp/test/test_rmw_qos_to_dds_attributes.cpp
+++ b/rmw_fastrtps_shared_cpp/test/test_rmw_qos_to_dds_attributes.cpp
@@ -67,13 +67,10 @@ TEST_F(GetDataReaderQoSTest, nominal_conversion) {
   qos_profile_.history = RMW_QOS_POLICY_HISTORY_KEEP_LAST;
   qos_profile_.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
   qos_profile_.durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
-  qos_profile_.lifespan.sec = 0u;
-  qos_profile_.lifespan.nsec = 500000000u;
-  qos_profile_.deadline.sec = 0u;
-  qos_profile_.deadline.nsec = 100000000u;
+  qos_profile_.lifespan = 500000000u;
+  qos_profile_.deadline = 100000000u;
   qos_profile_.liveliness = RMW_QOS_POLICY_LIVELINESS_AUTOMATIC;
-  qos_profile_.liveliness_lease_duration.sec = 10u;
-  qos_profile_.liveliness_lease_duration.nsec = 0u;
+  qos_profile_.liveliness_lease_duration = RCUTILS_S_TO_NS(10u);
 
   EXPECT_TRUE(get_datareader_qos(qos_profile_, subscriber_attributes_));
 
@@ -165,13 +162,10 @@ TEST_F(GetDataWriterQoSTest, nominal_conversion) {
   qos_profile_.history = RMW_QOS_POLICY_HISTORY_KEEP_LAST;
   qos_profile_.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
   qos_profile_.durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
-  qos_profile_.lifespan.sec = 0u;
-  qos_profile_.lifespan.nsec = 500000000u;
-  qos_profile_.deadline.sec = 0u;
-  qos_profile_.deadline.nsec = 100000000u;
+  qos_profile_.lifespan = 500000000u;
+  qos_profile_.deadline = 100000000u;
   qos_profile_.liveliness = RMW_QOS_POLICY_LIVELINESS_AUTOMATIC;
-  qos_profile_.liveliness_lease_duration.sec = 10u;
-  qos_profile_.liveliness_lease_duration.nsec = 0u;
+  qos_profile_.liveliness_lease_duration = RCUTILS_S_TO_NS(10u);
 
   EXPECT_TRUE(get_datawriter_qos(qos_profile_, publisher_attributes_));
 


### PR DESCRIPTION
Linked to ros2/rmw#255
Depends on #508

Use the newly defined constant RMW_DURATION_INFINITE as both input from ROS2, and as output when reporting QoS values back to ROS 2.