### PR TITLE
Take and return new RMW_DURATION_INFINITE correctly

### DIFF
--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/qos.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/qos.hpp
@@ -51,6 +51,10 @@ get_datawriter_qos(
   const rmw_qos_profile_t & qos_policies,
   eprosima::fastrtps::PublisherAttributes & pattr);
 
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
+rmw_time_t
+dds_duration_to_rmw(const eprosima::fastrtps::Duration_t & duration);
+
 /*
  * Converts the low-level QOS Policy; of type WriterQos or ReaderQos into rmw_qos_profile_t.
  * Since WriterQos or ReaderQos does not have information about history and depth, these values are not set
@@ -89,11 +93,8 @@ dds_qos_to_rmw_qos(
       break;
   }
 
-  qos->deadline.sec = dds_qos.m_deadline.period.seconds;
-  qos->deadline.nsec = dds_qos.m_deadline.period.nanosec;
-
-  qos->lifespan.sec = dds_qos.m_lifespan.duration.seconds;
-  qos->lifespan.nsec = dds_qos.m_lifespan.duration.nanosec;
+  qos->deadline = dds_duration_to_rmw(dds_qos.m_deadline.period);
+  qos->lifespan = dds_duration_to_rmw(dds_qos.m_lifespan.duration);
 
   switch (dds_qos.m_liveliness.kind) {
     case eprosima::fastrtps::AUTOMATIC_LIVELINESS_QOS:
@@ -106,8 +107,7 @@ dds_qos_to_rmw_qos(
       qos->liveliness = RMW_QOS_POLICY_LIVELINESS_UNKNOWN;
       break;
   }
-  qos->liveliness_lease_duration.sec = dds_qos.m_liveliness.lease_duration.seconds;
-  qos->liveliness_lease_duration.nsec = dds_qos.m_liveliness.lease_duration.nanosec;
+  qos->liveliness_lease_duration = dds_duration_to_rmw(dds_qos.m_liveliness.lease_duration);
 }
 
 template<typename AttributeT>

--- a/rmw_fastrtps_shared_cpp/test/test_dds_attributes_to_rmw_qos.cpp
+++ b/rmw_fastrtps_shared_cpp/test/test_dds_attributes_to_rmw_qos.cpp
@@ -23,6 +23,8 @@
 
 using eprosima::fastrtps::PublisherAttributes;
 using eprosima::fastrtps::SubscriberAttributes;
+static const eprosima::fastrtps::Duration_t InfiniteDuration =
+  eprosima::fastrtps::rtps::c_RTPSTimeInfinite.to_duration_t();
 
 class DDSAttributesToRMWQosTest : public ::testing::Test
 {
@@ -135,4 +137,24 @@ TEST_F(DDSAttributesToRMWQosTest, test_subscriber_lifespan_conversion) {
   dds_attributes_to_rmw_qos(subscriber_attributes_, &qos_profile_);
   EXPECT_EQ(qos_profile_.lifespan.sec, 9u);
   EXPECT_EQ(qos_profile_.lifespan.nsec, 432u);
+}
+
+TEST_F(DDSAttributesToRMWQosTest, test_subscriber_infinite_duration_conversions) {
+  subscriber_attributes_.qos.m_lifespan.duration = InfiniteDuration;
+  subscriber_attributes_.qos.m_deadline.period = InfiniteDuration;
+  subscriber_attributes_.qos.m_liveliness.lease_duration = InfiniteDuration;
+  dds_attributes_to_rmw_qos(subscriber_attributes_, &qos_profile_);
+  EXPECT_TRUE(rmw_time_equal(qos_profile_.deadline, RMW_DURATION_INFINITE));
+  EXPECT_TRUE(rmw_time_equal(qos_profile_.lifespan, RMW_DURATION_INFINITE));
+  EXPECT_TRUE(rmw_time_equal(qos_profile_.liveliness_lease_duration, RMW_DURATION_INFINITE));
+}
+
+TEST_F(DDSAttributesToRMWQosTest, test_publisher_infinite_duration_conversions) {
+  publisher_attributes_.qos.m_lifespan.duration = InfiniteDuration;
+  publisher_attributes_.qos.m_deadline.period = InfiniteDuration;
+  publisher_attributes_.qos.m_liveliness.lease_duration = InfiniteDuration;
+  dds_attributes_to_rmw_qos(publisher_attributes_, &qos_profile_);
+  EXPECT_TRUE(rmw_time_equal(qos_profile_.deadline, RMW_DURATION_INFINITE));
+  EXPECT_TRUE(rmw_time_equal(qos_profile_.lifespan, RMW_DURATION_INFINITE));
+  EXPECT_TRUE(rmw_time_equal(qos_profile_.liveliness_lease_duration, RMW_DURATION_INFINITE));
 }

--- a/rmw_fastrtps_shared_cpp/test/test_rmw_qos_to_dds_attributes.cpp
+++ b/rmw_fastrtps_shared_cpp/test/test_rmw_qos_to_dds_attributes.cpp
@@ -26,6 +26,8 @@
 
 
 using eprosima::fastrtps::SubscriberAttributes;
+static const eprosima::fastrtps::Duration_t InfiniteDuration =
+  eprosima::fastrtps::rtps::c_RTPSTimeInfinite.to_duration_t();
 
 class GetDataReaderQoSTest : public ::testing::Test
 {
@@ -219,4 +221,26 @@ TEST_F(GetDataWriterQoSTest, large_depth_conversion) {
     qos_profile_.depth = max_depth + 1;
     EXPECT_FALSE(get_datawriter_qos(qos_profile_, publisher_attributes_));
   }
+}
+
+TEST_F(GetDataReaderQoSTest, infinite_duration_conversions)
+{
+  qos_profile_.lifespan = RMW_DURATION_INFINITE;
+  qos_profile_.deadline = RMW_DURATION_INFINITE;
+  qos_profile_.liveliness_lease_duration = RMW_DURATION_INFINITE;
+  EXPECT_TRUE(get_datareader_qos(qos_profile_, subscriber_attributes_));
+  EXPECT_EQ(subscriber_attributes_.qos.m_lifespan.duration, InfiniteDuration);
+  EXPECT_EQ(subscriber_attributes_.qos.m_deadline.period, InfiniteDuration);
+  EXPECT_EQ(subscriber_attributes_.qos.m_liveliness.lease_duration, InfiniteDuration);
+}
+
+TEST_F(GetDataWriterQoSTest, infinite_duration_conversions)
+{
+  qos_profile_.lifespan = RMW_DURATION_INFINITE;
+  qos_profile_.deadline = RMW_DURATION_INFINITE;
+  qos_profile_.liveliness_lease_duration = RMW_DURATION_INFINITE;
+  EXPECT_TRUE(get_datawriter_qos(qos_profile_, publisher_attributes_));
+  EXPECT_EQ(publisher_attributes_.qos.m_lifespan.duration, InfiniteDuration);
+  EXPECT_EQ(publisher_attributes_.qos.m_deadline.period, InfiniteDuration);
+  EXPECT_EQ(publisher_attributes_.qos.m_liveliness.lease_duration, InfiniteDuration);
 }


### PR DESCRIPTION
Depends on https://github.com/ros2/rmw/pull/301

Meets the new API expectations introduced in https://github.com/ros2/rmw/pull/301 - to accept and return `RMW_DURATION_INFINITE` for cross-implementation consistency.