### PR TITLE
[Foxy] Remove unnecessary includes

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/participant.cpp
+++ b/rmw_fastrtps_shared_cpp/src/participant.cpp
@@ -25,12 +25,7 @@
 #include "fastrtps/participant/Participant.h"
 #include "fastrtps/publisher/Publisher.h"
 #include "fastrtps/publisher/PublisherListener.h"
-#include "fastrtps/rtps/RTPSDomain.h"
 #include "fastrtps/rtps/common/Locator.h"
-#include "fastrtps/rtps/builtin/discovery/endpoint/EDPSimple.h"
-#include "fastrtps/rtps/reader/ReaderListener.h"
-#include "fastrtps/rtps/reader/RTPSReader.h"
-#include "fastrtps/rtps/reader/StatefulReader.h"
 #include "fastrtps/subscriber/Subscriber.h"
 #include "fastrtps/subscriber/SubscriberListener.h"
 #include "fastrtps/subscriber/SampleInfo.h"
@@ -51,7 +46,6 @@ using IPLocator = eprosima::fastrtps::rtps::IPLocator;
 using Locator_t = eprosima::fastrtps::rtps::Locator_t;
 using Participant = eprosima::fastrtps::Participant;
 using ParticipantAttributes = eprosima::fastrtps::ParticipantAttributes;
-using StatefulReader = eprosima::fastrtps::rtps::StatefulReader;
 using UDPv4TransportDescriptor = eprosima::fastrtps::rtps::UDPv4TransportDescriptor;
 
 #if FASTRTPS_VERSION_MAJOR >= 2
@@ -100,7 +94,7 @@ static
 CustomParticipantInfo *
 __create_participant(
   const char * identifier,
-  ParticipantAttributes participantAttrs,
+  const ParticipantAttributes & participantAttrs,
   bool leave_middleware_default_qos,
   rmw_dds_common::Context * common_context)
 {


### PR DESCRIPTION
Backport #487 into foxy.

Should fix the build issues on windows for ros2/ros2#1114 and ros2/ros2#1113