### PR TITLE
Update includes after rcutils/get_env.h deprecation

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/participant.cpp
+++ b/rmw_fastrtps_shared_cpp/src/participant.cpp
@@ -32,8 +32,8 @@
 #include "fastdds/rtps/transport/shared_mem/SharedMemTransportDescriptor.h"
 
 #include "rcpputils/scope_exit.hpp"
+#include "rcutils/env.h"
 #include "rcutils/filesystem.h"
-#include "rcutils/get_env.h"
 
 #include "rmw/allocators.h"
 

--- a/rmw_fastrtps_shared_cpp/src/rmw_security_logging.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_security_logging.cpp
@@ -24,8 +24,8 @@
 
 #include "fastrtps/config.h"
 
+#include "rcutils/env.h"
 #include "rcutils/filesystem.h"
-#include "rcutils/get_env.h"
 
 #include "rmw/error_handling.h"
 #include "rmw/qos_profiles.h"


### PR DESCRIPTION
https://github.com/ros2/rcutils/pull/340 deprecates `rcutils/get_env.h`. This PR doesn't need to wait until the `rcutils` PR is merged, though.