### PR TITLE
Export rmw_dds_common as an rmw_fastrtps_shared_cpp dependency

### DIFF
--- a/rmw_fastrtps_shared_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_shared_cpp/CMakeLists.txt
@@ -118,6 +118,7 @@ ament_export_targets(rmw_fastrtps_shared_cpp)
 ament_export_dependencies(rcpputils)
 ament_export_dependencies(rcutils)
 ament_export_dependencies(rmw)
+ament_export_dependencies(rmw_dds_common)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)


### PR DESCRIPTION
Precisely what the title says.

CI up to `rmw_fastrtps_cpp`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=14586)](http://ci.ros2.org/job/ci_linux/14586/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=9341)](http://ci.ros2.org/job/ci_linux-aarch64/9341/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=12250)](http://ci.ros2.org/job/ci_osx/12250/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=14715)](http://ci.ros2.org/job/ci_windows/14715/)
