### PR TITLE
Pass the CRL down to Fast-DDS if available.

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/participant.cpp
+++ b/rmw_fastrtps_shared_cpp/src/participant.cpp
@@ -258,6 +258,11 @@ rmw_fastrtps_shared_cpp::create_participant(
         "dds.sec.access.builtin.Access-Permissions.permissions",
         security_files_paths["PERMISSIONS"]);
 
+      if (security_files_paths.count("CRL") > 0) {
+        property_policy.properties().emplace_back(
+          "dds.sec.auth.builtin.PKI-DH.identity_crl", security_files_paths["CRL"]);
+      }
+
       // Configure security logging
       if (!apply_security_logging_configuration(property_policy)) {
         return nullptr;


### PR DESCRIPTION
If the rmw_dds_common layer tells us that a CRL file is
available, set the appropriate property so Fast-DDS will
honor it.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Note that this can be merged at any time, but will have no effect until https://github.com/ros2/rmw_dds_common/pull/52 is merged.