### PR TITLE
Clarify rule for selecting a XML profile using topic name

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ The following table presents different combinations of node namespaces and user 
 | `/chatter` | `/test_namespace` | `/chatter` | `/chatter` |
 
 
+**IMPORTANT**: As shown in the table, node namespaces are NOT prepended to user specified topic names starting with `/`, a.k.a Fully Qualified Names (FQN).
+For a complete description of topic name remapping please refer to [Remapping Names](http://design.ros2.org/articles/static_remapping.html).
+
 ##### Creating services with different profiles
 
 ROS 2 services contain a subscription for receiving requests, and a publisher to reply to them.

--- a/README.md
+++ b/README.md
@@ -110,8 +110,19 @@ For doing so, `rmw_fastrtps` locates profiles in the XML based on topic names ab
 
 ##### Creating publishers/subscriptions with different profiles
 
-To configure a publisher/subscription, define a `<publisher>`/`<subscriber>` profile with attribute `profile_name=topic_name`, where topic name is the name of the topic before mangling, i.e. the topic name used to create the publisher/subscription.
+To configure a publisher/subscription, define a `<publisher>`/`<subscriber>` profile with attribute `profile_name=topic_name`, where topic name is the name of the topic prepended by the node namespace (which defaults to `""` if not specified), i.e. the node's namespace followed by topic name used to create the publisher/subscription.
+Mind that topic names always start with `/` (it is added when creating the topic if not present), and that namespace and topic name are always separated by one `/`.
 If such profile is not defined, `rmw_fastrtps` attempts to load the `<publisher>`/`<subscriber>` profile with attribute `is_default_profile="true"`.
+The following table presents different combinations of node namespaces and user specified topic names, as well as the resulting topic names and the suitable profile names:
+
+| User specified topic name | Node namespace | Final topic name | Profile name |
+|-|-|-|-|
+| `chatter` | DEFAULT (`""`) | `/chatter` | `/chatter` |
+| `chatter` | `test_namespace` | `/test_namespace/chatter` | `/test_namespace/chatter` |
+| `chatter` | `/test_namespace` | `/test_namespace/chatter` | `/test_namespace/chatter` |
+| `/chatter` | `test_namespace` | `/chatter` | `/chatter` |
+| `/chatter` | `/test_namespace` | `/chatter` | `/chatter` |
+
 
 ##### Creating services with different profiles
 


### PR DESCRIPTION
This PR addresses ros2/rmw_fastrtps#554. It explains how to name an `publisher` or `subscriber` XML profile so it is selected for publishers or subscribers on given topics.

Signed-off-by: Eduardo Ponz Segrelles <eduardoponz@eprosima.com>