### PR TITLE
Add support for PKCS#11 in security files

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/participant.cpp
+++ b/rmw_fastrtps_shared_cpp/src/participant.cpp
@@ -319,7 +319,7 @@ rmw_fastrtps_shared_cpp::create_participant(
 #if HAVE_SECURITY
     std::unordered_map<std::string, std::string> security_files_paths;
     if (rmw_dds_common::get_security_files(
-        "file://", security_options->security_root_path, security_files_paths))
+        true, "file://", security_options->security_root_path, security_files_paths))
     {
       eprosima::fastrtps::rtps::PropertyPolicy property_policy;
       property_policy.properties().emplace_back(


### PR DESCRIPTION
Implementation of the support for PKCS#11 URIs described in https://github.com/ros2/design/pull/319.

Since #544 the generation of the security property values from the files in the enclave relied on `rmw_dds_common::get_security_files`. To avoid affecting any other RMW implementation, we had to move the generation of the values back to the RMW itself, adapting it to support several file names for the same security property. 

For each property, we define an ordered sequence of possible file names that can be used to get that property, and the method to use to get the property value from that file.
  - The sequence is ordered by file name priority. The first file that provides a positive match is used. In this case, legacy `*.pem` files have priority over the new `*.p11` files.
  - Legacy `*.pem` and `*.p7s` files are processed as always. The attribute value is composed by the prefix prepended to the file path.
  - New `*.p11` files are opened and their content is used as the value of the attribute. It is assumed this content is a single line representing the PKCS#11 URI.

Signed-off-by: Iker Luengo <ikerluengo@eprosima.com>