### PR TITLE
[galactic] Export rmw_dds_common as an rmw_fastrtps_shared_cpp dependency (#530)

### DIFF
--- a/rmw_fastrtps_shared_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_shared_cpp/CMakeLists.txt
@@ -118,6 +118,7 @@ ament_export_targets(rmw_fastrtps_shared_cpp)
 ament_export_dependencies(rcpputils)
 ament_export_dependencies(rcutils)
 ament_export_dependencies(rmw)
+ament_export_dependencies(rmw_dds_common)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)


### PR DESCRIPTION
This pull requests backport #530 to Galactic.

Galactic CI above `rmw_fastrtps_shared_cpp`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=15530)](http://ci.ros2.org/job/ci_linux/15530/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=10216)](http://ci.ros2.org/job/ci_linux-aarch64/10216/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=13200)](http://ci.ros2.org/job/ci_osx/13200/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=15741)](http://ci.ros2.org/job/ci_windows/15741/)
