### PR TITLE
Allow loaned messages without data-sharing

### DIFF
--- a/rmw_fastrtps_cpp/src/publisher.cpp
+++ b/rmw_fastrtps_cpp/src/publisher.cpp
@@ -51,8 +51,6 @@
 
 #include "type_support_common.hpp"
 
-using DataSharingKind = eprosima::fastdds::dds::DataSharingKind;
-
 rmw_publisher_t *
 rmw_fastrtps_cpp::create_publisher(
   const CustomParticipantInfo * participant_info,

--- a/rmw_fastrtps_cpp/src/publisher.cpp
+++ b/rmw_fastrtps_cpp/src/publisher.cpp
@@ -304,8 +304,7 @@ rmw_fastrtps_cpp::create_publisher(
       rmw_publisher_free(rmw_publisher);
     });
 
-  bool has_data_sharing = DataSharingKind::OFF != writer_qos.data_sharing().kind();
-  rmw_publisher->can_loan_messages = has_data_sharing && info->type_support_->is_plain();
+  rmw_publisher->can_loan_messages = info->type_support_->is_plain();
   rmw_publisher->implementation_identifier = eprosima_fastrtps_identifier;
   rmw_publisher->data = info;
 

--- a/rmw_fastrtps_dynamic_cpp/src/publisher.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/publisher.cpp
@@ -309,8 +309,7 @@ rmw_fastrtps_dynamic_cpp::create_publisher(
       rmw_publisher_free(rmw_publisher);
     });
 
-  bool has_data_sharing = DataSharingKind::OFF != writer_qos.data_sharing().kind();
-  rmw_publisher->can_loan_messages = has_data_sharing && info->type_support_->is_plain();
+  rmw_publisher->can_loan_messages = info->type_support_->is_plain();
   rmw_publisher->implementation_identifier = eprosima_fastrtps_identifier;
   rmw_publisher->data = info;
 

--- a/rmw_fastrtps_dynamic_cpp/src/publisher.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/publisher.cpp
@@ -49,7 +49,6 @@
 #include "type_support_common.hpp"
 #include "type_support_registry.hpp"
 
-using DataSharingKind = eprosima::fastdds::dds::DataSharingKind;
 using TypeSupportProxy = rmw_fastrtps_dynamic_cpp::TypeSupportProxy;
 
 rmw_publisher_t *

--- a/rmw_fastrtps_shared_cpp/src/rmw_take.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_take.cpp
@@ -39,8 +39,6 @@
 namespace rmw_fastrtps_shared_cpp
 {
 
-using DataSharingKind = eprosima::fastdds::dds::DataSharingKind;
-
 void
 _assign_message_info(
   const char * identifier,

--- a/rmw_fastrtps_shared_cpp/src/rmw_take.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_take.cpp
@@ -449,8 +449,7 @@ __init_subscription_for_loans(
 {
   auto info = static_cast<CustomSubscriberInfo *>(subscription->data);
   const auto & qos = info->data_reader_->get_qos();
-  bool has_data_sharing = DataSharingKind::OFF != qos.data_sharing().kind();
-  subscription->can_loan_messages = has_data_sharing && info->type_support_->is_plain();
+  subscription->can_loan_messages = info->type_support_->is_plain();
   if (subscription->can_loan_messages) {
     const auto & allocation_qos = qos.reader_resource_limits().outstanding_reads_allocation;
     info->loan_manager_ = std::make_shared<LoanManager>(allocation_qos);


### PR DESCRIPTION
The only requirement on the Fast DDS API in order for loans to be used is that the type is plain.

This PR allows calling the loan APIs when data-sharing is OFF.
This enables performance improvements on intra-process and UDP.