### PR TITLE
Add support for the MESSAGE_LOST event

### DIFF
--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
@@ -112,6 +112,12 @@ public:
     eprosima::fastdds::dds::DataReader *,
     const eprosima::fastrtps::LivelinessChangedStatus &) final;
 
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
+  void
+  on_sample_lost(
+    eprosima::fastdds::dds::DataReader *,
+    const eprosima::fastdds::dds::SampleLostStatus &) final;
+
   // EventListenerInterface implementation
   RMW_FASTRTPS_SHARED_CPP_PUBLIC
   bool

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
@@ -182,6 +182,10 @@ private:
   eprosima::fastdds::dds::LivelinessChangedStatus liveliness_changed_status_
   RCPPUTILS_TSA_GUARDED_BY(internalMutex_);
 
+  std::atomic_bool sample_lost_changes_;
+  eprosima::fastdds::dds::SampleLostStatus sample_lost_status_
+  RCPPUTILS_TSA_GUARDED_BY(internalMutex_);
+
   std::mutex * conditionMutex_ RCPPUTILS_TSA_GUARDED_BY(internalMutex_);
   std::condition_variable * conditionVariable_ RCPPUTILS_TSA_GUARDED_BY(internalMutex_);
 

--- a/rmw_fastrtps_shared_cpp/src/custom_subscriber_info.cpp
+++ b/rmw_fastrtps_shared_cpp/src/custom_subscriber_info.cpp
@@ -64,6 +64,12 @@ void SubListener::on_liveliness_changed(
   liveliness_changes_.store(true, std::memory_order_relaxed);
 }
 
+void SubListener::on_sample_lost(
+  eprosima::fastdds::dds::DataReader * /* reader */,
+  const eprosima::fastdds::dds::SampleLostStatus & status)
+{
+}
+
 bool SubListener::hasEvent(rmw_event_type_t event_type) const
 {
   assert(rmw_fastrtps_shared_cpp::internal::is_event_supported(event_type));

--- a/rmw_fastrtps_shared_cpp/src/custom_subscriber_info.cpp
+++ b/rmw_fastrtps_shared_cpp/src/custom_subscriber_info.cpp
@@ -90,6 +90,8 @@ bool SubListener::hasEvent(rmw_event_type_t event_type) const
       return liveliness_changes_.load(std::memory_order_relaxed);
     case RMW_EVENT_REQUESTED_DEADLINE_MISSED:
       return deadline_changes_.load(std::memory_order_relaxed);
+    case RMW_EVENT_MESSAGE_LOST:
+      return sample_lost_changes_.load(std::memory_order_relaxed);
     default:
       break;
   }
@@ -120,6 +122,15 @@ bool SubListener::takeNextEvent(rmw_event_type_t event_type, void * event_info)
         rmw_data->total_count_change = requested_deadline_missed_status_.total_count_change;
         requested_deadline_missed_status_.total_count_change = 0;
         deadline_changes_.store(false, std::memory_order_relaxed);
+      }
+      break;
+    case RMW_EVENT_MESSAGE_LOST:
+      {
+        auto rmw_data = static_cast<rmw_message_lost_status_t *>(event_info);
+        rmw_data->total_count = sample_lost_status_.total_count;
+        rmw_data->total_count_change = sample_lost_status_.total_count_change;
+        sample_lost_status_.total_count_change = 0;
+        sample_lost_changes_.store(false, std::memory_order_relaxed);
       }
       break;
     default:

--- a/rmw_fastrtps_shared_cpp/src/rmw_event.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_event.cpp
@@ -24,8 +24,6 @@ static const std::unordered_set<rmw_event_type_t> g_rmw_event_type_set{
   RMW_EVENT_REQUESTED_DEADLINE_MISSED,
   RMW_EVENT_LIVELINESS_LOST,
   RMW_EVENT_OFFERED_DEADLINE_MISSED,
-  // TODO(clalancette): This isn't really supported at the moment, but enabling
-  // it here allows rviz2 to start-up when using rmw_fastrtps_cpp
   RMW_EVENT_MESSAGE_LOST
 };
 

--- a/rmw_fastrtps_shared_cpp/src/rmw_event.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_event.cpp
@@ -23,7 +23,10 @@ static const std::unordered_set<rmw_event_type_t> g_rmw_event_type_set{
   RMW_EVENT_LIVELINESS_CHANGED,
   RMW_EVENT_REQUESTED_DEADLINE_MISSED,
   RMW_EVENT_LIVELINESS_LOST,
-  RMW_EVENT_OFFERED_DEADLINE_MISSED
+  RMW_EVENT_OFFERED_DEADLINE_MISSED,
+  // TODO(clalancette): This isn't really supported at the moment, but enabling
+  // it here allows rviz2 to start-up when using rmw_fastrtps_cpp
+  RMW_EVENT_MESSAGE_LOST
 };
 
 namespace rmw_fastrtps_shared_cpp


### PR DESCRIPTION
This replaces #580 and adds proper support for MESSAGE_LOST event.

The interfaces are already present in Fast-DDS, but the listener callback is currently never called.
This means the RMW will behave as if messages are never lost, until we implement on_sample_lost on Fast DDS v2.6.0.