### PR TITLE
Add in support for the MESSAGE_LOST event.

### DIFF
--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
@@ -112,6 +112,12 @@ public:
     eprosima::fastdds::dds::DataReader *,
     const eprosima::fastrtps::LivelinessChangedStatus &) final;
 
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
+  void
+  on_sample_lost(
+    eprosima::fastdds::dds::DataReader *,
+    const eprosima::fastdds::dds::SampleLostStatus &) final;
+
   // EventListenerInterface implementation
   RMW_FASTRTPS_SHARED_CPP_PUBLIC
   bool
@@ -174,6 +180,10 @@ private:
 
   std::atomic_bool liveliness_changes_;
   eprosima::fastdds::dds::LivelinessChangedStatus liveliness_changed_status_
+  RCPPUTILS_TSA_GUARDED_BY(internalMutex_);
+
+  std::atomic_bool sample_lost_changes_;
+  eprosima::fastdds::dds::SampleLostStatus sample_lost_status_
   RCPPUTILS_TSA_GUARDED_BY(internalMutex_);
 
   std::mutex * conditionMutex_ RCPPUTILS_TSA_GUARDED_BY(internalMutex_);

--- a/rmw_fastrtps_shared_cpp/src/rmw_event.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_event.cpp
@@ -23,7 +23,8 @@ static const std::unordered_set<rmw_event_type_t> g_rmw_event_type_set{
   RMW_EVENT_LIVELINESS_CHANGED,
   RMW_EVENT_REQUESTED_DEADLINE_MISSED,
   RMW_EVENT_LIVELINESS_LOST,
-  RMW_EVENT_OFFERED_DEADLINE_MISSED
+  RMW_EVENT_OFFERED_DEADLINE_MISSED,
+  RMW_EVENT_MESSAGE_LOST
 };
 
 namespace rmw_fastrtps_shared_cpp


### PR DESCRIPTION
Fast-DDS (and rmw_fastrtps_cpp) don't fully support this right
now, but having it in the list here allows RViz2 to start up.

Implementation extracted from
https://github.com/ros2/rmw_fastrtps/pull/583, which is the more
complete solution.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This also requires a small fix in rcl, which is upcoming.

@MiguelCompany FYI.  We really need to fix RViz2, and the only part we need in order to do that is the MESSAGE_LOST fix.  So this just extracts the necessary bits from https://github.com/ros2/rmw_fastrtps/pull/583 so we can get it in faster.  We can rebase 583 on top of this later on.