### PR TITLE
Removed some heap interactions in rmw_serialize.cpp

### DIFF
--- a/rmw_fastrtps_cpp/src/rmw_serialize.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_serialize.cpp
@@ -40,8 +40,8 @@ rmw_serialize(
   }
 
   auto callbacks = static_cast<const message_type_support_callbacks_t *>(ts->data);
-  auto tss = new MessageTypeSupport_cpp(callbacks);
-  auto data_length = tss->getEstimatedSerializedSize(ros_message, callbacks);
+  auto tss = MessageTypeSupport_cpp(callbacks);
+  auto data_length = tss.getEstimatedSerializedSize(ros_message, callbacks);
   if (serialized_message->buffer_capacity < data_length) {
     if (rmw_serialized_message_resize(serialized_message, data_length) != RMW_RET_OK) {
       RMW_SET_ERROR_MSG("unable to dynamically resize serialized message");
@@ -54,10 +54,9 @@ rmw_serialize(
   eprosima::fastcdr::Cdr ser(
     buffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN, eprosima::fastcdr::Cdr::DDS_CDR);
 
-  auto ret = tss->serializeROSmessage(ros_message, ser, callbacks);
+  auto ret = tss.serializeROSmessage(ros_message, ser, callbacks);
   serialized_message->buffer_length = data_length;
   serialized_message->buffer_capacity = data_length;
-  delete tss;
   return ret == true ? RMW_RET_OK : RMW_RET_ERROR;
 }
 
@@ -79,14 +78,13 @@ rmw_deserialize(
   }
 
   auto callbacks = static_cast<const message_type_support_callbacks_t *>(ts->data);
-  auto tss = new MessageTypeSupport_cpp(callbacks);
+  auto tss = MessageTypeSupport_cpp(callbacks);
   eprosima::fastcdr::FastBuffer buffer(
     reinterpret_cast<char *>(serialized_message->buffer), serialized_message->buffer_length);
   eprosima::fastcdr::Cdr deser(buffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
     eprosima::fastcdr::Cdr::DDS_CDR);
 
-  auto ret = tss->deserializeROSmessage(deser, ros_message, callbacks);
-  delete tss;
+  auto ret = tss.deserializeROSmessage(deser, ros_message, callbacks);
   return ret == true ? RMW_RET_OK : RMW_RET_ERROR;
 }
 


### PR DESCRIPTION
The functions rmw_deserialize and rmw_serialize in the file rmw_seralize.cpp created an instance of the class MessageTypeSupport_cpp on the heap but this instances can also be allocated on the stack.
This change removes 2 new and 2 delete calls which makes serialization and deserialization faster and enables this code to be hard realtime capable.

PS: I hope I got the sign-off correct now,...

Signed-off-by: Martin Mayer <martin.mayer@gmx.de>