### PR TITLE
[Foxy] Handle exception on deserializing ROS message

### DIFF
--- a/rmw_fastrtps_cpp/src/type_support_common.cpp
+++ b/rmw_fastrtps_cpp/src/type_support_common.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <fastcdr/exceptions/Exception.h>
+
 #include <string>
 
 #include "rmw/error_handling.h"

--- a/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport_impl.hpp
+++ b/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport_impl.hpp
@@ -831,10 +831,10 @@ bool TypeSupport<MembersType>::deserializeROSmessage(
             }
             for (size_t index = 0; index < array_size; ++index) {
               if (!deserializeROSmessage(
-                deser, sub_members,
-                get_subros_message(
-                  member, field, index, member->array_size_,
-                  member->is_upper_bound_)))
+                  deser, sub_members,
+                  get_subros_message(
+                    member, field, index, member->array_size_,
+                    member->is_upper_bound_)))
               {
                 return false;
               }

--- a/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport_impl.hpp
+++ b/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport_impl.hpp
@@ -834,8 +834,8 @@ bool TypeSupport<MembersType>::deserializeROSmessage(
                 deser, sub_members,
                 get_subros_message(
                   member, field, index, member->array_size_,
-                  member->is_upper_bound_))
-              ) {
+                  member->is_upper_bound_)))
+              {
                 return false;
               }
             }

--- a/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport_impl.hpp
+++ b/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport_impl.hpp
@@ -17,6 +17,8 @@
 
 #include <fastcdr/FastBuffer.h>
 #include <fastcdr/Cdr.h>
+#include <fastcdr/exceptions/Exception.h>
+
 #include <cassert>
 #include <string>
 #include <vector>
@@ -803,7 +805,9 @@ bool TypeSupport<MembersType>::deserializeROSmessage(
         {
           auto sub_members = static_cast<const MembersType *>(member->members_->data);
           if (!member->is_array_) {
-            deserializeROSmessage(deser, sub_members, field);
+            if (!deserializeROSmessage(deser, sub_members, field)) {
+              return false;
+            }
           } else {
             size_t array_size = 0;
 
@@ -826,11 +830,14 @@ bool TypeSupport<MembersType>::deserializeROSmessage(
               return false;
             }
             for (size_t index = 0; index < array_size; ++index) {
-              deserializeROSmessage(
+              if (!deserializeROSmessage(
                 deser, sub_members,
                 get_subros_message(
                   member, field, index, member->array_size_,
-                  member->is_upper_bound_));
+                  member->is_upper_bound_))
+              ) {
+                return false;
+              }
             }
           }
         }
@@ -972,16 +979,23 @@ bool TypeSupport<MembersType>::deserializeROSmessage(
   assert(ros_message);
   assert(members_);
 
-  // Deserialize encapsulation.
-  deser.read_encapsulation();
+  try {
+    // Deserialize encapsulation.
+    deser.read_encapsulation();
 
-  (void)impl;
-  if (members_->member_count_ != 0) {
-    TypeSupport::deserializeROSmessage(deser, members_, ros_message);
-  } else {
+    (void)impl;
+    if (members_->member_count_ != 0) {
+      return TypeSupport::deserializeROSmessage(deser, members_, ros_message);
+    }
+
     uint8_t dump = 0;
     deser >> dump;
     (void)dump;
+  } catch (const eprosima::fastcdr::exception::Exception &) {
+    RMW_SET_ERROR_MSG_WITH_FORMAT_STRING(
+      "Fast CDR exception deserializing message of type %s.",
+      getName());
+    return false;
   }
 
   return true;

--- a/rmw_fastrtps_shared_cpp/src/rmw_request.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_request.cpp
@@ -96,22 +96,22 @@ __rmw_take_request(
   if (request.buffer_ != nullptr) {
     eprosima::fastcdr::Cdr deser(*request.buffer_, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
       eprosima::fastcdr::Cdr::DDS_CDR);
-    info->request_type_support_->deserializeROSmessage(
-      deser, ros_request, info->request_type_support_impl_);
-
-    // Get header
-    rmw_fastrtps_shared_cpp::copy_from_fastrtps_guid_to_byte_array(
-      request.sample_identity_.writer_guid(),
-      request_header->request_id.writer_guid);
-    request_header->request_id.sequence_number =
-      ((int64_t)request.sample_identity_.sequence_number().high) <<
-      32 | request.sample_identity_.sequence_number().low;
-    request_header->source_timestamp = request.sample_info_.sourceTimestamp.to_ns();
-    request_header->received_timestamp = request.sample_info_.receptionTimestamp.to_ns();
+    if (info->request_type_support_->deserializeROSmessage(
+        deser, ros_request, info->request_type_support_impl_))
+    {
+      // Get header
+      rmw_fastrtps_shared_cpp::copy_from_fastrtps_guid_to_byte_array(
+        request.sample_identity_.writer_guid(),
+        request_header->request_id.writer_guid);
+      request_header->request_id.sequence_number =
+        ((int64_t)request.sample_identity_.sequence_number().high) <<
+        32 | request.sample_identity_.sequence_number().low;
+      request_header->source_timestamp = request.sample_info_.sourceTimestamp.to_ns();
+      request_header->received_timestamp = request.sample_info_.receptionTimestamp.to_ns();
+      *taken = true;
+    }
 
     delete request.buffer_;
-
-    *taken = true;
   }
 
   return RMW_RET_OK;

--- a/rmw_fastrtps_shared_cpp/src/rmw_response.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_response.cpp
@@ -59,16 +59,17 @@ __rmw_take_response(
       *response.buffer_,
       eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
       eprosima::fastcdr::Cdr::DDS_CDR);
-    info->response_type_support_->deserializeROSmessage(
-      deser, ros_response, info->response_type_support_impl_);
+    if (info->response_type_support_->deserializeROSmessage(
+        deser, ros_response, info->response_type_support_impl_))
+    {
+      request_header->source_timestamp = response.sample_info_.sourceTimestamp.to_ns();
+      request_header->received_timestamp = response.sample_info_.receptionTimestamp.to_ns();
+      request_header->request_id.sequence_number =
+        ((int64_t)response.sample_identity_.sequence_number().high) <<
+        32 | response.sample_identity_.sequence_number().low;
 
-    request_header->source_timestamp = response.sample_info_.sourceTimestamp.to_ns();
-    request_header->received_timestamp = response.sample_info_.receptionTimestamp.to_ns();
-    request_header->request_id.sequence_number =
-      ((int64_t)response.sample_identity_.sequence_number().high) <<
-      32 | response.sample_identity_.sequence_number().low;
-
-    *taken = true;
+      *taken = true;
+    }
   }
 
   return RMW_RET_OK;


### PR DESCRIPTION
Fixes https://github.com/ros2/rclpy/issues/923.

Minimal code for reproducing error:
```python
import rclpy.serialization, std_msgs.msg
rclpy.serialization.deserialize_message(b"", std_msgs.msg.String)
```

Result without the fix:
```python
user@host:~$ python3
Python 3.8.10 (default, Sep 28 2021, 16:10:42) 
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import rclpy.serialization, std_msgs.msg
>>> rclpy.serialization.deserialize_message(b"", std_msgs.msg.String)
terminate called after throwing an instance of 'eprosima::fastcdr::exception::NotEnoughMemoryException'
  what():  Not enough memory in the buffer stream
Aborted (core dumped)
user@host:~$
```

Result with the fix:
```python
user@host:~$ python3
Python 3.8.10 (default, Sep 28 2021, 16:10:42) 
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import rclpy.serialization, std_msgs.msg
>>> rclpy.serialization.deserialize_message(b"", std_msgs.msg.String)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/ros/foxy/lib/python3.8/site-packages/rclpy/serialization.py", line 42, in deserialize_message
    return _rclpy.rclpy_deserialize(serialized_message, message_type)
_rclpy.RCLError: Failed to deserialize ROS message
>>>
```

