### PR TITLE
Add EventsExecutor API for dynamic_fastrtps (Humble)

### DIFF
--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -533,7 +533,6 @@ rmw_client_set_on_new_response_callback(
   const void * user_data)
 {
   RMW_CHECK_ARGUMENT_FOR_NULL(rmw_client, RMW_RET_INVALID_ARGUMENT);
-  RMW_CHECK_ARGUMENT_FOR_NULL(callback, RMW_RET_INVALID_ARGUMENT);
 
   return rmw_fastrtps_shared_cpp::__rmw_client_set_on_new_response_callback(
     rmw_client,

--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -532,6 +532,9 @@ rmw_client_set_on_new_response_callback(
   rmw_event_callback_t callback,
   const void * user_data)
 {
+  RMW_CHECK_ARGUMENT_FOR_NULL(rmw_client, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(callback, RMW_RET_INVALID_ARGUMENT);
+
   return rmw_fastrtps_shared_cpp::__rmw_client_set_on_new_response_callback(
     rmw_client,
     callback,

--- a/rmw_fastrtps_cpp/src/rmw_event.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_event.cpp
@@ -55,7 +55,6 @@ rmw_event_set_callback(
   const void * user_data)
 {
   RMW_CHECK_ARGUMENT_FOR_NULL(rmw_event, RMW_RET_INVALID_ARGUMENT);
-  RMW_CHECK_ARGUMENT_FOR_NULL(callback, RMW_RET_INVALID_ARGUMENT);
 
   return rmw_fastrtps_shared_cpp::__rmw_event_set_callback(
     rmw_event,

--- a/rmw_fastrtps_cpp/src/rmw_event.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_event.cpp
@@ -54,6 +54,9 @@ rmw_event_set_callback(
   rmw_event_callback_t callback,
   const void * user_data)
 {
+  RMW_CHECK_ARGUMENT_FOR_NULL(rmw_event, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(callback, RMW_RET_INVALID_ARGUMENT);
+
   return rmw_fastrtps_shared_cpp::__rmw_event_set_callback(
     rmw_event,
     callback,

--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -532,7 +532,6 @@ rmw_service_set_on_new_request_callback(
   const void * user_data)
 {
   RMW_CHECK_ARGUMENT_FOR_NULL(rmw_service, RMW_RET_INVALID_ARGUMENT);
-  RMW_CHECK_ARGUMENT_FOR_NULL(callback, RMW_RET_INVALID_ARGUMENT);
 
   return rmw_fastrtps_shared_cpp::__rmw_service_set_on_new_request_callback(
     rmw_service,

--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -531,6 +531,9 @@ rmw_service_set_on_new_request_callback(
   rmw_event_callback_t callback,
   const void * user_data)
 {
+  RMW_CHECK_ARGUMENT_FOR_NULL(rmw_service, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(callback, RMW_RET_INVALID_ARGUMENT);
+
   return rmw_fastrtps_shared_cpp::__rmw_service_set_on_new_request_callback(
     rmw_service,
     callback,

--- a/rmw_fastrtps_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_subscription.cpp
@@ -215,6 +215,9 @@ rmw_subscription_set_on_new_message_callback(
   rmw_event_callback_t callback,
   const void * user_data)
 {
+  RMW_CHECK_ARGUMENT_FOR_NULL(rmw_subscription, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(callback, RMW_RET_INVALID_ARGUMENT);
+
   return rmw_fastrtps_shared_cpp::__rmw_subscription_set_on_new_message_callback(
     rmw_subscription,
     callback,

--- a/rmw_fastrtps_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_subscription.cpp
@@ -216,7 +216,6 @@ rmw_subscription_set_on_new_message_callback(
   const void * user_data)
 {
   RMW_CHECK_ARGUMENT_FOR_NULL(rmw_subscription, RMW_RET_INVALID_ARGUMENT);
-  RMW_CHECK_ARGUMENT_FOR_NULL(callback, RMW_RET_INVALID_ARGUMENT);
 
   return rmw_fastrtps_shared_cpp::__rmw_subscription_set_on_new_message_callback(
     rmw_subscription,

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
@@ -580,7 +580,6 @@ rmw_client_set_on_new_response_callback(
   const void * user_data)
 {
   RMW_CHECK_ARGUMENT_FOR_NULL(rmw_client, RMW_RET_INVALID_ARGUMENT);
-  RMW_CHECK_ARGUMENT_FOR_NULL(callback, RMW_RET_INVALID_ARGUMENT);
 
   return rmw_fastrtps_shared_cpp::__rmw_client_set_on_new_response_callback(
     rmw_client,

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
@@ -572,4 +572,19 @@ rmw_client_response_subscription_get_actual_qos(
 
   return rmw_fastrtps_shared_cpp::__rmw_client_response_subscription_get_actual_qos(client, qos);
 }
+
+rmw_ret_t
+rmw_client_set_on_new_response_callback(
+  rmw_client_t * rmw_client,
+  rmw_event_callback_t callback,
+  const void * user_data)
+{
+  RMW_CHECK_ARGUMENT_FOR_NULL(rmw_client, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(callback, RMW_RET_INVALID_ARGUMENT);
+
+  return rmw_fastrtps_shared_cpp::__rmw_client_set_on_new_response_callback(
+    rmw_client,
+    callback,
+    user_data);
+}
 }  // extern "C"

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_event.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_event.cpp
@@ -47,4 +47,19 @@ rmw_subscription_event_init(
     subscription->data,
     event_type);
 }
+
+rmw_ret_t
+rmw_event_set_callback(
+  rmw_event_t * rmw_event,
+  rmw_event_callback_t callback,
+  const void * user_data)
+{
+  RMW_CHECK_ARGUMENT_FOR_NULL(rmw_event, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(callback, RMW_RET_INVALID_ARGUMENT);
+
+  return rmw_fastrtps_shared_cpp::__rmw_event_set_callback(
+    rmw_event,
+    callback,
+    user_data);
+}
 }  // extern "C"

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_event.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_event.cpp
@@ -55,7 +55,6 @@ rmw_event_set_callback(
   const void * user_data)
 {
   RMW_CHECK_ARGUMENT_FOR_NULL(rmw_event, RMW_RET_INVALID_ARGUMENT);
-  RMW_CHECK_ARGUMENT_FOR_NULL(callback, RMW_RET_INVALID_ARGUMENT);
 
   return rmw_fastrtps_shared_cpp::__rmw_event_set_callback(
     rmw_event,

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
@@ -571,4 +571,19 @@ rmw_service_request_subscription_get_actual_qos(
 
   return rmw_fastrtps_shared_cpp::__rmw_service_request_subscription_get_actual_qos(service, qos);
 }
+
+rmw_ret_t
+rmw_service_set_on_new_request_callback(
+  rmw_service_t * rmw_service,
+  rmw_event_callback_t callback,
+  const void * user_data)
+{
+  RMW_CHECK_ARGUMENT_FOR_NULL(rmw_service, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(callback, RMW_RET_INVALID_ARGUMENT);
+
+  return rmw_fastrtps_shared_cpp::__rmw_service_set_on_new_request_callback(
+    rmw_service,
+    callback,
+    user_data);
+}
 }  // extern "C"

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
@@ -579,7 +579,6 @@ rmw_service_set_on_new_request_callback(
   const void * user_data)
 {
   RMW_CHECK_ARGUMENT_FOR_NULL(rmw_service, RMW_RET_INVALID_ARGUMENT);
-  RMW_CHECK_ARGUMENT_FOR_NULL(callback, RMW_RET_INVALID_ARGUMENT);
 
   return rmw_fastrtps_shared_cpp::__rmw_service_set_on_new_request_callback(
     rmw_service,

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_subscription.cpp
@@ -217,7 +217,6 @@ rmw_subscription_set_on_new_message_callback(
   const void * user_data)
 {
   RMW_CHECK_ARGUMENT_FOR_NULL(rmw_subscription, RMW_RET_INVALID_ARGUMENT);
-  RMW_CHECK_ARGUMENT_FOR_NULL(callback, RMW_RET_INVALID_ARGUMENT);
 
   return rmw_fastrtps_shared_cpp::__rmw_subscription_set_on_new_message_callback(
     rmw_subscription,

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_subscription.cpp
@@ -209,4 +209,19 @@ rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription)
   return rmw_fastrtps_shared_cpp::__rmw_destroy_subscription(
     eprosima_fastrtps_identifier, node, subscription);
 }
+
+rmw_ret_t
+rmw_subscription_set_on_new_message_callback(
+  rmw_subscription_t * rmw_subscription,
+  rmw_event_callback_t callback,
+  const void * user_data)
+{
+  RMW_CHECK_ARGUMENT_FOR_NULL(rmw_subscription, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(callback, RMW_RET_INVALID_ARGUMENT);
+
+  return rmw_fastrtps_shared_cpp::__rmw_subscription_set_on_new_message_callback(
+    rmw_subscription,
+    callback,
+    user_data);
+}
 }  // extern "C"


### PR DESCRIPTION
Backport of the last three commits in master adding EventsExecutor api to the rmw dynamic_fastrtps.

I'm not sure if this as a backport should be squash merged or just leave the three commits that are in master as well.

I left https://github.com/ros2/rmw_fastrtps/pull/601 outside of the backport, should this one be backported?