### PR TITLE
Add listener callbacks to newly added events

### DIFF
--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_event_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_event_info.hpp
@@ -15,8 +15,10 @@
 #ifndef RMW_FASTRTPS_SHARED_CPP__CUSTOM_EVENT_INFO_HPP_
 #define RMW_FASTRTPS_SHARED_CPP__CUSTOM_EVENT_INFO_HPP_
 
+#include <algorithm>
 #include <atomic>
 #include <condition_variable>
+#include <limits>
 #include <list>
 #include <memory>
 #include <mutex>
@@ -106,7 +108,7 @@ class EventTypeCallback
 public:
   EventTypeCallback() = default;
 
-  EventTypeCallback(size_t depth)
+  explicit EventTypeCallback(size_t depth)
   {
     history_depth_ = (depth > 0) ? depth : std::numeric_limits<size_t>::max();
   }

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_publisher_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_publisher_info.hpp
@@ -107,7 +107,9 @@ public:
   hasEvent(rmw_event_type_t event_type) const final;
 
   RMW_FASTRTPS_SHARED_CPP_PUBLIC
-  void set_on_new_event_callback(
+  rmw_ret_t
+  set_on_new_event_callback(
+    rmw_event_type_t event_type,
     const void * user_data,
     rmw_event_callback_t callback) final;
 
@@ -158,6 +160,11 @@ private:
 
   std::mutex * conditionMutex_ RCPPUTILS_TSA_GUARDED_BY(internalMutex_);
   std::condition_variable * conditionVariable_ RCPPUTILS_TSA_GUARDED_BY(internalMutex_);
+
+  // The callbacks to call when the listener detects events
+  EventTypeCallback on_liveliness_lost_;
+  EventTypeCallback on_offered_deadline_missed_;
+  EventTypeCallback on_offered_incompatible_qos_;
 };
 
 #endif  // RMW_FASTRTPS_SHARED_CPP__CUSTOM_PUBLISHER_INFO_HPP_

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
@@ -42,6 +42,7 @@
 
 #include "rmw/event_callback_type.h"
 
+#include "rmw_fastrtps_shared_cpp/custom_event_info.hpp"
 #include "rmw_fastrtps_shared_cpp/guid_utils.hpp"
 #include "rmw_fastrtps_shared_cpp/TypeSupport.hpp"
 
@@ -249,13 +250,7 @@ public:
           list_has_data_.store(true);
         }
 
-        std::unique_lock<std::mutex> lock_mutex(on_new_request_m_);
-
-        if (on_new_request_cb_) {
-          on_new_request_cb_(user_data_, 1);
-        } else {
-          unread_count_++;
-        }
+        on_data_available_.call();
       }
     }
   }
@@ -313,20 +308,7 @@ public:
     const void * user_data,
     rmw_event_callback_t callback)
   {
-    std::unique_lock<std::mutex> lock_mutex(on_new_request_m_);
-
-    if (callback) {
-      // Push events arrived before setting the the executor callback
-      if (unread_count_) {
-        callback(user_data, unread_count_);
-        unread_count_ = 0;
-      }
-      user_data_ = user_data;
-      on_new_request_cb_ = callback;
-    } else {
-      user_data_ = nullptr;
-      on_new_request_cb_ = nullptr;
-    }
+    on_data_available_.set_callback(user_data, callback);
   }
 
 private:
@@ -337,10 +319,8 @@ private:
   std::mutex * conditionMutex_ RCPPUTILS_TSA_GUARDED_BY(internalMutex_);
   std::condition_variable * conditionVariable_ RCPPUTILS_TSA_GUARDED_BY(internalMutex_);
 
-  rmw_event_callback_t on_new_request_cb_{nullptr};
-  const void * user_data_{nullptr};
-  std::mutex on_new_request_m_;
-  uint64_t unread_count_ = 0;
+  // Callback to call when the listener detects events
+  EventTypeCallback on_data_available_;
 };
 
 #endif  // RMW_FASTRTPS_SHARED_CPP__CUSTOM_SERVICE_INFO_HPP_

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
@@ -16,7 +16,6 @@
 #define RMW_FASTRTPS_SHARED_CPP__CUSTOM_SUBSCRIBER_INFO_HPP_
 
 #include <atomic>
-#include <algorithm>
 #include <condition_variable>
 #include <limits>
 #include <memory>

--- a/rmw_fastrtps_shared_cpp/src/custom_publisher_info.cpp
+++ b/rmw_fastrtps_shared_cpp/src/custom_publisher_info.cpp
@@ -111,8 +111,7 @@ rmw_ret_t PubListener::set_on_new_event_callback(
   const void * user_data,
   rmw_event_callback_t callback)
 {
-  switch (event_type)
-  {
+  switch (event_type) {
     case RMW_EVENT_LIVELINESS_LOST:
       on_liveliness_lost_.set_callback(user_data, callback);
       break;

--- a/rmw_fastrtps_shared_cpp/src/custom_subscriber_info.cpp
+++ b/rmw_fastrtps_shared_cpp/src/custom_subscriber_info.cpp
@@ -140,8 +140,7 @@ rmw_ret_t SubListener::set_on_new_event_callback(
   const void * user_data,
   rmw_event_callback_t callback)
 {
-  switch (event_type)
-  {
+  switch (event_type) {
     case RMW_EVENT_MESSAGE_LOST:
       on_sample_lost_.set_callback(user_data, callback);
       break;

--- a/rmw_fastrtps_shared_cpp/src/rmw_event.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_event.cpp
@@ -102,10 +102,11 @@ __rmw_event_set_callback(
   const void * user_data)
 {
   auto custom_event_info = static_cast<CustomEventInfo *>(rmw_event->data);
-  custom_event_info->getListener()->set_on_new_event_callback(
-    user_data,
-    callback);
-  return RMW_RET_OK;
+
+  auto listener = custom_event_info->getListener();
+
+  return listener->set_on_new_event_callback(
+    rmw_event->event_type, user_data, callback);
 }
 
 }  // namespace rmw_fastrtps_shared_cpp

--- a/rmw_fastrtps_shared_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_subscription.cpp
@@ -267,7 +267,7 @@ __rmw_subscription_set_on_new_message_callback(
   const void * user_data)
 {
   auto custom_subscriber_info = static_cast<CustomSubscriberInfo *>(rmw_subscription->data);
-  custom_subscriber_info->listener_->set_on_new_message_callback(
+  custom_subscriber_info->listener_->set_on_data_available_callback(
     user_data,
     callback);
   return RMW_RET_OK;


### PR DESCRIPTION
The recently merged PR https://github.com/ros2/rmw_fastrtps/pull/583 added support for missing events:

- RMW_EVENT_OFFERED_QOS_INCOMPATIBLE
- RMW_EVENT_REQUESTED_QOS_INCOMPATIBLE
- RMW_EVENT_MESSAGE_LOST

This PR adds listener callbacks associated with those new events.

Also a bug is fixed in which setting a callback for some event type, would override the any previous other callback set (there was a single callback for listener). Now we have multiple callbacks for the different listener event types.

@alsora FYI