### PR TITLE
Delay lock on message callback setters

### DIFF
--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_client_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_client_info.hpp
@@ -127,10 +127,10 @@ public:
     const void * user_data,
     rmw_event_callback_t callback)
   {
-    std::unique_lock<std::mutex> lock_mutex(on_new_response_m_);
-
     if (callback) {
       auto unread_responses = get_unread_responses();
+
+      std::lock_guard<std::mutex> lock_mutex(on_new_response_m_);
 
       if (0 < unread_responses) {
         callback(user_data, unread_responses);
@@ -143,6 +143,8 @@ public:
       status_mask |= eprosima::fastdds::dds::StatusMask::data_available();
       info_->response_reader_->set_listener(this, status_mask);
     } else {
+      std::lock_guard<std::mutex> lock_mutex(on_new_response_m_);
+
       eprosima::fastdds::dds::StatusMask status_mask = info_->response_reader_->get_status_mask();
       status_mask &= ~eprosima::fastdds::dds::StatusMask::data_available();
       info_->response_reader_->set_listener(this, status_mask);

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
@@ -226,10 +226,10 @@ public:
     const void * user_data,
     rmw_event_callback_t callback)
   {
-    std::unique_lock<std::mutex> lock_mutex(on_new_request_m_);
-
     if (callback) {
       auto unread_requests = get_unread_resquests();
+
+      std::lock_guard<std::mutex> lock_mutex(on_new_request_m_);
 
       if (0 < unread_requests) {
         callback(user_data, unread_requests);
@@ -242,6 +242,8 @@ public:
       status_mask |= eprosima::fastdds::dds::StatusMask::data_available();
       info_->request_reader_->set_listener(this, status_mask);
     } else {
+      std::lock_guard<std::mutex> lock_mutex(on_new_request_m_);
+
       eprosima::fastdds::dds::StatusMask status_mask = info_->request_reader_->get_status_mask();
       status_mask &= ~eprosima::fastdds::dds::StatusMask::data_available();
       info_->request_reader_->set_listener(this, status_mask);

--- a/rmw_fastrtps_shared_cpp/src/custom_subscriber_info.cpp
+++ b/rmw_fastrtps_shared_cpp/src/custom_subscriber_info.cpp
@@ -210,10 +210,10 @@ SubListener::set_on_new_message_callback(
   const void * user_data,
   rmw_event_callback_t callback)
 {
-  std::unique_lock<std::mutex> lock_mutex(on_new_message_m_);
-
   if (callback) {
     auto unread_messages = get_unread_messages();
+
+    std::lock_guard<std::mutex> lock_mutex(on_new_message_m_);
 
     if (0 < unread_messages) {
       callback(user_data, unread_messages);
@@ -227,6 +227,8 @@ SubListener::set_on_new_message_callback(
     status_mask |= eprosima::fastdds::dds::StatusMask::data_available();
     subscriber_info_->data_reader_->set_listener(this, status_mask);
   } else {
+    std::lock_guard<std::mutex> lock_mutex(on_new_message_m_);
+
     eprosima::fastdds::dds::StatusMask status_mask =
       subscriber_info_->data_reader_->get_status_mask();
     status_mask &= ~eprosima::fastdds::dds::StatusMask::data_available();


### PR DESCRIPTION
This should fix #646 by calling `get_unread_count` before taking the lock on the mutex `on_new_message_m_`.

It provides similar fixes for the callback setter on subscriptions, services, and clients.