### PR TITLE
Make sure to add semicolons to the CHECK_TYPE_IDENTIFIER_MATCH.

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/rmw_take.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_take.cpp
@@ -81,7 +81,7 @@ _take(
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
     subscription handle,
     subscription->implementation_identifier, identifier,
-    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION)
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
 
   auto info = static_cast<CustomSubscriberInfo *>(subscription->data);
   RCUTILS_CHECK_FOR_NULL_WITH_MSG(info, "custom subscriber info is null", return RMW_RET_ERROR);
@@ -303,7 +303,7 @@ _take_serialized_message(
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
     subscription handle,
     subscription->implementation_identifier, identifier,
-    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION)
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
 
   auto info = static_cast<CustomSubscriberInfo *>(subscription->data);
   RCUTILS_CHECK_FOR_NULL_WITH_MSG(info, "custom subscriber info is null", return RMW_RET_ERROR);

--- a/rmw_fastrtps_shared_cpp/src/rmw_wait.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_wait.cpp
@@ -47,7 +47,7 @@ __rmw_wait(
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
     wait set handle,
     wait_set->implementation_identifier, identifier,
-    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION)
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
 
   // If wait_set_info is ever nullptr, it can only mean one of three things:
   // - Wait set is invalid. Caller did not respect preconditions.

--- a/rmw_fastrtps_shared_cpp/src/rmw_wait_set.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_wait_set.cpp
@@ -80,7 +80,7 @@ __rmw_destroy_wait_set(const char * identifier, rmw_wait_set_t * wait_set)
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
     wait set handle,
     wait_set->implementation_identifier, identifier,
-    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION)
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
 
   auto result = RMW_RET_OK;
   // If wait_set_info is ever nullptr, it can only mean one of three things:


### PR DESCRIPTION
That way it is an actual C/C++ statement, and we can make minor changes to that macro as needed.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

On its own, this isn't interesting, but I'm going to be doing some minor modifications to the `RMW_CHECK_TYPE_IDENTIFIERS_MATCH` macro that requires this.