### PR TITLE
Add "default subscriber profile" to the XML example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,11 @@ The following example configures Fast DDS to publish synchronously, and to have 
                 <historyMemoryPolicy>PREALLOCATED_WITH_REALLOC</historyMemoryPolicy>
             </publisher>
 
+            <!-- Default subscriber profile -->
+            <subscriber profile_name="default subscriber profile" is_default_profile="true">
+                <historyMemoryPolicy>PREALLOCATED_WITH_REALLOC</historyMemoryPolicy>
+            </subscriber>
+
             <!-- Publisher profile for topic helloworld -->
             <publisher profile_name="helloworld">
                 <qos>


### PR DESCRIPTION
When I try the talker/listener example in the README, I get the following error message.

```
$ FASTRTPS_DEFAULT_PROFILES_FILE=test.xml RMW_FASTRTPS_USE_QOS_FROM_XML=1 RMW_IMPLEMENTATION=rmw_fastrtps_cpp ros2 run demo_nodes_cpp talker
2023-01-24 11:18:49.428 [RTPS_READER_HISTORY Error] Change payload size of '60' bytes is larger than the history payload size of '35' bytes and cannot be resized. -> Function can_change_be_added_nts
2023-01-24 11:18:49.429 [RTPS_READER_HISTORY Error] Change payload size of '84' bytes is larger than the history payload size of '35' bytes and cannot be resized. -> Function can_change_be_added_nts
...
```

```
$ FASTRTPS_DEFAULT_PROFILES_FILE=test.xml RMW_FASTRTPS_USE_QOS_FROM_XML=1 RMW_IMPLEMENTATION=rmw_fastrtps_cpp ros2 run demo_nodes_cpp listener
2023-01-24 11:22:27.736 [RTPS_READER_HISTORY Error] Change payload size of '64' bytes is larger than the history payload size of '35' bytes and cannot be resized. -> Function can_change_be_added_nts
2023-01-24 11:22:27.737 [RTPS_READER_HISTORY Error] Change payload size of '88' bytes is larger than the history payload size of '35' bytes and cannot be resized. -> Function can_change_be_added_nts
...
```

Adding "default subscriber profile" to XML works, so I created such a pull request.

The default subscriber profile seems to have been lost in the 1853a8397560f867187741ae5a1306c9918cabbd.