### PR TITLE
Capture `std::bad_alloc` on deserializeROSmessage.

### DIFF
--- a/rmw_fastrtps_cpp/src/type_support_common.cpp
+++ b/rmw_fastrtps_cpp/src/type_support_common.cpp
@@ -119,6 +119,11 @@ bool TypeSupport::deserializeROSmessage(
       "Fast CDR exception deserializing message of type %s.",
       getName());
     return false;
+  } catch (...) {
+    RMW_SET_ERROR_MSG_WITH_FORMAT_STRING(
+      "Unhandled exception deserializing message of type %s.",
+      getName());
+    return false;
   }
 
   return true;

--- a/rmw_fastrtps_cpp/src/type_support_common.cpp
+++ b/rmw_fastrtps_cpp/src/type_support_common.cpp
@@ -119,9 +119,9 @@ bool TypeSupport::deserializeROSmessage(
       "Fast CDR exception deserializing message of type %s.",
       getName());
     return false;
-  } catch (...) {
+  } catch (std::bad_alloc &) {
     RMW_SET_ERROR_MSG_WITH_FORMAT_STRING(
-      "Unhandled exception deserializing message of type %s.",
+      "'Bad alloc' exception deserializing message of type %s.",
       getName());
     return false;
   }

--- a/rmw_fastrtps_cpp/src/type_support_common.cpp
+++ b/rmw_fastrtps_cpp/src/type_support_common.cpp
@@ -119,7 +119,7 @@ bool TypeSupport::deserializeROSmessage(
       "Fast CDR exception deserializing message of type %s.",
       getName());
     return false;
-  } catch (std::bad_alloc &) {
+  } catch (const std::bad_alloc &) {
     RMW_SET_ERROR_MSG_WITH_FORMAT_STRING(
       "'Bad alloc' exception deserializing message of type %s.",
       getName());

--- a/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport_impl.hpp
+++ b/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport_impl.hpp
@@ -983,9 +983,9 @@ bool TypeSupport<MembersType>::deserializeROSmessage(
       "Fast CDR exception deserializing message of type %s.",
       getName());
     return false;
-  } catch (...) {
+  } catch (std::bad_alloc &) {
     RMW_SET_ERROR_MSG_WITH_FORMAT_STRING(
-      "Unhandled exception deserializing message of type %s.",
+      "'Bad alloc' exception deserializing message of type %s.",
       getName());
     return false;
   }

--- a/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport_impl.hpp
+++ b/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport_impl.hpp
@@ -983,7 +983,7 @@ bool TypeSupport<MembersType>::deserializeROSmessage(
       "Fast CDR exception deserializing message of type %s.",
       getName());
     return false;
-  } catch (std::bad_alloc &) {
+  } catch (const std::bad_alloc &) {
     RMW_SET_ERROR_MSG_WITH_FORMAT_STRING(
       "'Bad alloc' exception deserializing message of type %s.",
       getName());

--- a/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport_impl.hpp
+++ b/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport_impl.hpp
@@ -983,6 +983,11 @@ bool TypeSupport<MembersType>::deserializeROSmessage(
       "Fast CDR exception deserializing message of type %s.",
       getName());
     return false;
+  } catch (...) {
+    RMW_SET_ERROR_MSG_WITH_FORMAT_STRING(
+      "Unhandled exception deserializing message of type %s.",
+      getName());
+    return false;
   }
 
   return true;


### PR DESCRIPTION
This should fix crashes coming from serialization mismatches that cannot be detected by Fast CDR

Related to https://github.com/ros2/ros2_documentation/issues/3288#issuecomment-1404876431