### PR TITLE
[WIP] Improve handling of dynamic discovery - rmw_fastrtps changes

### DIFF
--- a/rmw_fastrtps_cpp/src/init_rmw_context_impl.cpp
+++ b/rmw_fastrtps_cpp/src/init_rmw_context_impl.cpp
@@ -63,7 +63,7 @@ init_context_impl(
       eprosima_fastrtps_identifier,
       context->actual_domain_id,
       &context->options.security_options,
-      &context->options.discovery_params,
+      &context->options.discovery_options,
       context->options.enclave,
       common_context.get()),
     [&](CustomParticipantInfo * participant_info)

--- a/rmw_fastrtps_dynamic_cpp/src/init_rmw_context_impl.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/init_rmw_context_impl.cpp
@@ -63,7 +63,7 @@ init_context_impl(
       eprosima_fastrtps_identifier,
       context->actual_domain_id,
       &context->options.security_options,
-      &context->options.discovery_params,
+      &context->options.discovery_options,
       context->options.enclave,
       common_context.get()),
     [&](CustomParticipantInfo * participant_info)

--- a/rmw_fastrtps_shared_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_shared_cpp/CMakeLists.txt
@@ -96,6 +96,7 @@ add_library(rmw_fastrtps_shared_cpp
   src/time_utils.cpp
   src/TypeSupport_impl.cpp
   src/utils.cpp
+  src/utils/net_utils.cpp
 )
 target_include_directories(rmw_fastrtps_shared_cpp
   PUBLIC

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
@@ -143,9 +143,9 @@ public:
   explicit ParticipantListener(const char *identifier,
                                rmw_dds_common::Context *context,
                                const std::string &hostname,
-                               const rmw_discovery_params_t *discovery_params)
+                               const rmw_discovery_options_t *discovery_options)
       : context(context), identifier_(identifier), my_hostname_(hostname),
-        discovery_params_(*discovery_params) {}
+        discovery_options_(*discovery_options) {}
 
   void on_participant_discovery(
       eprosima::fastdds::dds::DomainParticipant *participant,
@@ -302,14 +302,14 @@ private:
     bool should_ignore = false;
 
     if (RMW_AUTOMATIC_DISCOVERY_RANGE_OFF ==
-          discovery_params_.automatic_discovery_range) {
+          discovery_options_.automatic_discovery_range) {
       return true;
     }
     if (hostname != my_hostname_) {
       if (RMW_AUTOMATIC_DISCOVERY_RANGE_LOCALHOST ==
-              discovery_params_.automatic_discovery_range ||
+              discovery_options_.automatic_discovery_range ||
           RMW_AUTOMATIC_DISCOVERY_RANGE_DEFAULT ==
-              discovery_params_.automatic_discovery_range) {
+              discovery_options_.automatic_discovery_range) {
 
         if (!is_static_peer(hostname, other_static_peers)) {
           should_ignore = true;
@@ -327,14 +327,14 @@ private:
     using namespace rmw_fastrtps_shared_cpp;
     // Check if the host is a static peer on our list
     auto aliases = utils::get_peer_aliases(hostname);
-    for (size_t ii = 0; ii < discovery_params_.static_peers_count; ++ii) {
-      if (hostname == discovery_params_.static_peers[ii].peer_address) {
+    for (size_t ii = 0; ii < discovery_options_.static_peers_count; ++ii) {
+      if (hostname == discovery_options_.static_peers[ii].peer_address) {
         RCUTILS_LOG_DEBUG_NAMED("rmw_fastrtps_shared_cpp",
                                 "Matching host in our static peer list");
         return true;
       }
-    
-      if (aliases.count(discovery_params_.static_peers[ii].peer_address) > 0)
+
+      if (aliases.count(discovery_options_.static_peers[ii].peer_address) > 0)
       {
         RCUTILS_LOG_DEBUG_NAMED("rmw_fastrtps_shared_cpp",
                               "Matching host in our static peer list");
@@ -358,7 +358,7 @@ private:
   rmw_dds_common::Context *context;
   const char *const identifier_;
   std::string my_hostname_;
-  rmw_discovery_params_t discovery_params_;
+  rmw_discovery_options_t discovery_options_;
 };
 
 #endif // RMW_FASTRTPS_SHARED_CPP__CUSTOM_PARTICIPANT_INFO_HPP_

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
@@ -283,14 +283,14 @@ private:
           for (const auto &a : peer_aliases) {
             result.insert(a);
           }
-          RCUTILS_LOG_DEBUG_NAMED("rmw_fastrtps_shared_cpp", "Got static peer: %s", hostname);
+          RCUTILS_LOG_DEBUG_NAMED("rmw_fastrtps_shared_cpp", "Got static peer: %s", hostname.c_str());
         }
         start = end + delimiter.length();
       }
       if (start < static_peers_string.length() - 1) {
         auto peer = static_peers_string.substr(start);
         result.insert(peer);
-        RCUTILS_LOG_DEBUG_NAMED("rmw_fastrtps_shared_cpp", "Got last static peer: %s", peer);
+        RCUTILS_LOG_DEBUG_NAMED("rmw_fastrtps_shared_cpp", "Got last static peer: %s", peer.c_str());
       }
     }
 
@@ -341,13 +341,13 @@ private:
     // Check if the host is a static peer on our list
     auto aliases = utils::get_peer_aliases(hostname);
     for (size_t ii = 0; ii < discovery_params_.static_peers_count; ++ii) {
-      if (hostname == discovery_params_.static_peers[ii]) {
+      if (hostname == discovery_params_.static_peers[ii].peer_address) {
         RCUTILS_LOG_DEBUG_NAMED("rmw_fastrtps_shared_cpp",
                                 "Matching host in our static peer list");
         return true;
       }
     
-      if (aliases.count(discovery_params_.static_peers[ii]) > 0)
+      if (aliases.count(discovery_params_.static_peers[ii].peer_address) > 0)
       {
         RCUTILS_LOG_DEBUG_NAMED("rmw_fastrtps_shared_cpp",
                               "Matching host in our static peer list");

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
@@ -326,7 +326,6 @@ private:
         }
       }
     }
-    std::cout << "Got " << hostname << "Should ignore: " << should_ignore << "\n";
 
     return should_ignore;
   }

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
@@ -300,26 +300,13 @@ private:
   bool should_ignore_host(const std::string &hostname,
                           const std::unordered_set<std::string> &other_static_peers) {
     bool should_ignore = false;
-    if (hostname == my_hostname_) {
-      if (RMW_AUTOMATIC_DISCOVERY_RANGE_OFF ==
+
+    if (RMW_AUTOMATIC_DISCOVERY_RANGE_OFF ==
           discovery_params_.automatic_discovery_range) {
-        RCUTILS_LOG_DEBUG_NAMED(
-            "rmw_fastrtps_shared_cpp",
-            "Found new participant on same host and discovery range is off");
-        if (!is_static_peer(hostname, other_static_peers)) {
-          should_ignore = true;
-        }
-      } else {
-        RCUTILS_LOG_DEBUG_NAMED("rmw_fastrtps_shared_cpp",
-                                "Found new participant on same host and "
-                                "discovery range is not off");
-      }
-    } else {
-      RCUTILS_LOG_DEBUG_NAMED("rmw_fastrtps_shared_cpp",
-                              "Found new participant on different host");
-      if (RMW_AUTOMATIC_DISCOVERY_RANGE_OFF ==
-              discovery_params_.automatic_discovery_range ||
-          RMW_AUTOMATIC_DISCOVERY_RANGE_LOCALHOST ==
+      return true;
+    }
+    if (hostname != my_hostname_) {
+      if (RMW_AUTOMATIC_DISCOVERY_RANGE_LOCALHOST ==
               discovery_params_.automatic_discovery_range ||
           RMW_AUTOMATIC_DISCOVERY_RANGE_DEFAULT ==
               discovery_params_.automatic_discovery_range) {

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
@@ -259,7 +259,7 @@ private:
 
   std::unordered_set<std::string>
   get_other_static_peers(
-    const std::unordered_map<std::string, std::vector<uint8_t>> &map) {
+    const std::map<std::string, std::vector<uint8_t>> &map) {
     std::unordered_set<std::string> result;
 
     auto static_peers_entry = map.find("staticpeers");

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/participant.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/participant.hpp
@@ -37,7 +37,7 @@ create_participant(
   const char * identifier,
   size_t domain_id,
   const rmw_security_options_t * security_options,
-  const rmw_discovery_params_t * discovery_params,
+  const rmw_discovery_options_t * discovery_options,
   const char * enclave,
   rmw_dds_common::Context * common_context);
 

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/utils/net_utils.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/utils/net_utils.hpp
@@ -1,0 +1,31 @@
+// Copyright 2023 Intrinsic Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RMW_FASTRTPS_SHARED_CPP__DETAIL_NET_UTILS_HPP_
+#define RMW_FASTRTPS_SHARED_CPP__DETAIL_NET_UTILS_HPP_
+
+#include <string>
+#include <unordered_set>
+
+namespace rmw_fastrtps_shared_cpp
+{
+namespace utils
+{
+    std::string get_fqdn_for_host(const std::string& hostname);
+
+    std::unordered_set<std::string> get_peer_aliases(const std::string& peer);
+}
+}
+
+#endif

--- a/rmw_fastrtps_shared_cpp/src/participant.cpp
+++ b/rmw_fastrtps_shared_cpp/src/participant.cpp
@@ -209,29 +209,16 @@ CustomParticipantInfo *rmw_fastrtps_shared_cpp::create_participant(
   // Configure discovery
   switch (discovery_params->automatic_discovery_range) {
   case RMW_AUTOMATIC_DISCOVERY_RANGE_OFF: {
-    if (discovery_params->static_peers_count == 0) {
-      // Clear the list of multicast listening locators
-      domainParticipantQos.wire_protocol()
-          .builtin.metatrafficMulticastLocatorList.clear();
-      // Clear unicast listening locators and add UDPv4 any
-      domainParticipantQos.wire_protocol()
-          .builtin.metatrafficUnicastLocatorList.clear();
-      eprosima::fastrtps::rtps::Locator_t unicast_locator;
-      std::istringstream("UDPv4:[0.0.0.0]:0") >> unicast_locator;
-      domainParticipantQos.wire_protocol()
-          .builtin.metatrafficUnicastLocatorList.push_back(unicast_locator);
-    }
-    else
-    {
-      // If static peers are set we have to send discovery packets over
-      // the network. Disabling all locators is not feasible.
-      auto udp_transport =
-        std::make_shared<eprosima::fastdds::rtps::UDPv4TransportDescriptor>();
-      udp_transport->TTL = 0;
-      domainParticipantQos.transport().clear();
-      domainParticipantQos.transport().user_transports.push_back(udp_transport);
-      domainParticipantQos.transport().use_builtin_transports = false;
-    }
+    // Clear the list of multicast listening locators
+    domainParticipantQos.wire_protocol()
+        .builtin.metatrafficMulticastLocatorList.clear();
+    // Clear unicast listening locators and add UDPv4 any
+    domainParticipantQos.wire_protocol()
+        .builtin.metatrafficUnicastLocatorList.clear();
+    eprosima::fastrtps::rtps::Locator_t unicast_locator;
+    std::istringstream("UDPv4:[0.0.0.0]:0") >> unicast_locator;
+    domainParticipantQos.wire_protocol()
+        .builtin.metatrafficUnicastLocatorList.push_back(unicast_locator);
     break;
   }
   case RMW_AUTOMATIC_DISCOVERY_RANGE_DEFAULT:
@@ -254,7 +241,8 @@ CustomParticipantInfo *rmw_fastrtps_shared_cpp::create_participant(
   std::stringstream user_data;
 
   // Add any initial peers
-  if (discovery_params->static_peers_count > 0) {
+  if (discovery_params->static_peers_count > 0 &&
+    discovery_params->automatic_discovery_range != RMW_AUTOMATIC_DISCOVERY_RANGE_OFF) {
     user_data << "staticpeers=";
     for (size_t ii = 0; ii < discovery_params->static_peers_count; ++ii) {
       eprosima::fastrtps::rtps::Locator_t peer;

--- a/rmw_fastrtps_shared_cpp/src/participant.cpp
+++ b/rmw_fastrtps_shared_cpp/src/participant.cpp
@@ -219,7 +219,6 @@ CustomParticipantInfo *rmw_fastrtps_shared_cpp::create_participant(
     std::istringstream("UDPv4:[0.0.0.0]:0") >> unicast_locator;
     domainParticipantQos.wire_protocol()
         .builtin.metatrafficUnicastLocatorList.push_back(unicast_locator);
-    std::cout << "Automatic discovery disabled\n";
     break;
   }
   case RMW_AUTOMATIC_DISCOVERY_RANGE_DEFAULT:
@@ -232,7 +231,6 @@ CustomParticipantInfo *rmw_fastrtps_shared_cpp::create_participant(
     domainParticipantQos.transport().clear();
     domainParticipantQos.transport().user_transports.push_back(udp_transport);
     domainParticipantQos.transport().use_builtin_transports = false;
-    std::cout << "Automatic discovery localhost\n";
     break;
   }
   case RMW_AUTOMATIC_DISCOVERY_RANGE_SUBNET:

--- a/rmw_fastrtps_shared_cpp/src/participant.cpp
+++ b/rmw_fastrtps_shared_cpp/src/participant.cpp
@@ -258,13 +258,13 @@ CustomParticipantInfo *rmw_fastrtps_shared_cpp::create_participant(
     user_data << "staticpeers=";
     for (size_t ii = 0; ii < discovery_params->static_peers_count; ++ii) {
       eprosima::fastrtps::rtps::Locator_t peer;
-      if (ip_version(discovery_params->static_peers[ii]) == 4) {
+      if (ip_version(discovery_params->static_peers[ii].peer_address) == 4) {
         eprosima::fastrtps::rtps::IPLocator::setIPv4(
-            peer, discovery_params->static_peers[ii]);
+            peer, discovery_params->static_peers[ii].peer_address);
       }
-      else if (ip_version(discovery_params->static_peers[ii]) == 6) {
+      else if (ip_version(discovery_params->static_peers[ii].peer_address) == 6) {
         eprosima::fastrtps::rtps::IPLocator::setIPv6(
-            peer, discovery_params->static_peers[ii]);
+            peer, discovery_params->static_peers[ii].peer_address);
       }
       // Not specifying the port of the peer means FastDDS will try all
       // possible participant ports according to the port calculation equation
@@ -273,10 +273,11 @@ CustomParticipantInfo *rmw_fastrtps_shared_cpp::create_participant(
       domainParticipantQos.wire_protocol().builtin.initialPeersList.push_back(
           peer);
 
-      user_data << discovery_params->static_peers[ii] << ',';
+      user_data << discovery_params->static_peers[ii].peer_address << ',';
 
       // Add any aliases (IPs for hostnames, hostnames for IPs)
-      auto aliases = utils::get_peer_aliases(discovery_params->static_peers[ii]);
+      auto aliases = utils::get_peer_aliases(
+        discovery_params->static_peers[ii].peer_address);
       for (const auto &alias : aliases) {
         user_data << alias << ',';
       }

--- a/rmw_fastrtps_shared_cpp/src/rmw_init.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_init.cpp
@@ -81,11 +81,11 @@ rmw_init_options_copy(
     allocator->deallocate(tmp.enclave, allocator->state);
     return ret;
   }
-  tmp.discovery_params = rmw_get_zero_initialized_discovery_params();
-  ret = rmw_discovery_params_copy(
-    &src->discovery_params,
-    allocator,
-    &tmp.discovery_params);
+  tmp.discovery_options = rmw_get_zero_initialized_discovery_options();
+  ret = rmw_discovery_options_copy(
+    &src->discovery_options,
+    *allocator,
+    &tmp.discovery_options);
   *dst = tmp;
   return RMW_RET_OK;
 }
@@ -111,8 +111,8 @@ rmw_init_options_fini(const char * identifier, rmw_init_options_t * init_options
   rmw_ret_t ret = rmw_security_options_fini(&init_options->security_options, allocator);
   if (ret != RMW_RET_OK)
     return ret;
-  
-  ret = rmw_discovery_params_fini(&init_options->discovery_params, allocator);
+
+  ret = rmw_discovery_options_fini(&init_options->discovery_options, *allocator);
   *init_options = rmw_get_zero_initialized_init_options();
   return ret;
 }

--- a/rmw_fastrtps_shared_cpp/src/utils/net_utils.cpp
+++ b/rmw_fastrtps_shared_cpp/src/utils/net_utils.cpp
@@ -1,0 +1,111 @@
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include "rcutils/logging_macros.h"
+#include "rmw_fastrtps_shared_cpp/utils/net_utils.hpp"
+
+namespace rmw_fastrtps_shared_cpp
+{
+namespace utils
+{
+std::string get_fqdn_for_host(const std::string& hostname) {
+  struct addrinfo hints, *addresses = nullptr;
+
+  memset(&hints, 0, sizeof(hints));
+  hints.ai_family = AF_UNSPEC;
+  hints.ai_flags = AI_CANONNAME;
+
+  if (getaddrinfo(hostname.c_str(), nullptr, &hints, &addresses) != 0) {
+    RCUTILS_LOG_WARN_NAMED("rmw_fastrtps_shared_cpp", "Failed to look up fully-qualified domain name for host %s", hostname.c_str());
+    return hostname;
+  }
+
+  return std::string(addresses->ai_canonname);
+}
+
+std::unordered_set<std::string> get_peer_aliases(const std::string& peer) {
+  std::unordered_set<std::string> aliases;
+
+  struct sockaddr_in addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  auto result = inet_pton(addr.sin_family, peer.c_str(), &addr.sin_addr);
+  if (result != 1) {
+    // Could not interpret the string as an IPv4 address, so try IPv6
+
+    struct sockaddr_in6 addr6;
+    memset(&addr6, 0, sizeof(addr6));
+    addr6.sin6_family = AF_INET6;
+    result = inet_pton(addr6.sin6_family, peer.c_str(), &addr6.sin6_addr);
+    if (result != 1) {
+      // Failure to convert the string to a binary IP address means we treat it
+      // as a hostname, and find all its IP addresses
+      std::string ip_addr;
+
+      struct addrinfo *addresses = nullptr;
+      if (getaddrinfo(peer.c_str(), nullptr, nullptr, &addresses) != 0) {
+        // Failed to look up the hostname
+        RCUTILS_LOG_WARN_NAMED("rmw_fastrtps_shared_cpp",
+                               "Could not look up hostname %s", peer.c_str());
+      } else {
+        for (struct addrinfo *address_entry = addresses;
+             address_entry != nullptr; address_entry = address_entry->ai_next) {
+          void * address_data = nullptr;
+          char address_string[INET6_ADDRSTRLEN];
+          if (address_entry->ai_family == AF_INET) { // IPv4
+            address_data = &reinterpret_cast<struct sockaddr_in *>(address_entry->ai_addr)->sin_addr;
+          } else { // IPv6
+            address_data = &reinterpret_cast<struct sockaddr_in6 *>(address_entry->ai_addr)->sin6_addr;
+          }
+          inet_ntop(address_entry->ai_family, address_data, address_string, sizeof(address_string));
+          // Avoid duplicate aliases (e.g. when two identical IPs are returned for SOCK_STREAM and SOCK_DGRAM)
+          aliases.insert(address_string);
+          RCUTILS_LOG_DEBUG_NAMED(
+              "rmw_fastrtps_shared_cpp",
+              "Added IP address %s for host %s to static peers", address_string,
+              peer.c_str());
+          
+        }
+
+        freeaddrinfo(addresses);
+      }
+
+      // Also add the fully-qualified domain name for the host as an alias
+      std::string fqdn = get_fqdn_for_host(peer);
+     
+      RCUTILS_LOG_DEBUG_NAMED(
+          "rmw_fastrtps_shared_cpp",
+          "Added fully-qualified domain name %s as alias for host %s to static peers", fqdn.c_str(),
+          peer.c_str());
+      aliases.insert(fqdn);
+      
+    } else {
+      // Success converting the string to a binary IPv6 address, so find the hostname for that address
+      char hostname[NI_MAXHOST];
+
+      aliases.insert(hostname);
+      RCUTILS_LOG_DEBUG_NAMED("rmw_fastrtps_shared_cpp", "Added host %s as alias for IPv6 address %s", hostname, peer.c_str());
+
+    }
+  } else {
+    // Success converting the string to a binary IPv4 address, so find the hostname for that address
+    char hostname[NI_MAXHOST];
+
+    if (getnameinfo(reinterpret_cast<struct sockaddr *>(&addr), sizeof(addr), hostname, sizeof(hostname), nullptr, 0, NI_NAMEREQD) == 0) {
+      aliases.insert(hostname);
+      RCUTILS_LOG_DEBUG_NAMED("rmw_fastrtps_shared_cpp", "Added host %s as alias for IPv4 address %s", hostname, peer.c_str());
+    }
+  }
+
+  return aliases;
+}
+}
+} // namespace rmw_fastrtps_shared_cpp

--- a/rmw_fastrtps_shared_cpp/src/utils/net_utils.cpp
+++ b/rmw_fastrtps_shared_cpp/src/utils/net_utils.cpp
@@ -33,7 +33,7 @@ std::string get_fqdn_for_host(const std::string& hostname) {
 
 std::unordered_set<std::string> get_peer_aliases(const std::string& peer) {
   std::unordered_set<std::string> aliases;
-
+  aliases.insert(peer);
   struct sockaddr_in addr;
   memset(&addr, 0, sizeof(addr));
   addr.sin_family = AF_INET;
@@ -60,6 +60,7 @@ std::unordered_set<std::string> get_peer_aliases(const std::string& peer) {
              address_entry != nullptr; address_entry = address_entry->ai_next) {
           void * address_data = nullptr;
           char address_string[INET6_ADDRSTRLEN];
+          memset(address_string, 0, NI_MAXHOST);
           if (address_entry->ai_family == AF_INET) { // IPv4
             address_data = &reinterpret_cast<struct sockaddr_in *>(address_entry->ai_addr)->sin_addr;
           } else { // IPv6
@@ -90,6 +91,7 @@ std::unordered_set<std::string> get_peer_aliases(const std::string& peer) {
     } else {
       // Success converting the string to a binary IPv6 address, so find the hostname for that address
       char hostname[NI_MAXHOST];
+      memset(hostname, 0, NI_MAXHOST);
 
       aliases.insert(hostname);
       RCUTILS_LOG_DEBUG_NAMED("rmw_fastrtps_shared_cpp", "Added host %s as alias for IPv6 address %s", hostname, peer.c_str());
@@ -98,7 +100,7 @@ std::unordered_set<std::string> get_peer_aliases(const std::string& peer) {
   } else {
     // Success converting the string to a binary IPv4 address, so find the hostname for that address
     char hostname[NI_MAXHOST];
-
+    memset(hostname, 0, NI_MAXHOST);
     if (getnameinfo(reinterpret_cast<struct sockaddr *>(&addr), sizeof(addr), hostname, sizeof(hostname), nullptr, 0, NI_NAMEREQD) == 0) {
       aliases.insert(hostname);
       RCUTILS_LOG_DEBUG_NAMED("rmw_fastrtps_shared_cpp", "Added host %s as alias for IPv4 address %s", hostname, peer.c_str());


### PR DESCRIPTION
Takes off from where #653 leaves off. Currently added support for IPv4 addresses as well as hostname based addressing.

Current status according to goal matrix (Ideal goal matrix can be found [here](https://discourse.ros.org/t/proposed-changes-to-how-ros-performs-discovery-of-nodes/27640), tools to compute the matrix can be found [here]()):

```
Other Host
                           static defined       static not defined
                           1      2      3      1      2      3      default      
static defined     1       ✓      ✓      ✓      ✗      ✗      ✓      ✗      
                   2       ✓      ✓      ✓      ✗      ✗      ✓      ✓      
                   3       ✓      ✓      ✓      ✗      ✗      ✓      ✓      
static not defined 1       ✗      ✗      ✗      ✗      ✗      ✗      ✗      
                   2       ✗      ✗      ✗      ✗      ✗      ✗      ✗      
                   3       ✓      ✗      ✓      ✗      ✗      ✗      ✓      
                   default ✓      ✓      ✗      ✗      ✗      ✓      ✓      
```