### PR TITLE
Rewrite how Topics are tracked in rmw_fastrtps_cpp.

### DIFF
--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/publisher.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/publisher.hpp
@@ -23,7 +23,7 @@ namespace rmw_fastrtps_cpp
 
 rmw_publisher_t *
 create_publisher(
-  const CustomParticipantInfo * participant_info,
+  CustomParticipantInfo * participant_info,
   const rosidl_message_type_support_t * type_supports,
   const char * topic_name,
   const rmw_qos_profile_t * qos_policies,

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/subscription.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/subscription.hpp
@@ -25,7 +25,7 @@ namespace rmw_fastrtps_cpp
 
 rmw_subscription_t *
 create_subscription(
-  const CustomParticipantInfo * participant_info,
+  CustomParticipantInfo * participant_info,
   const rosidl_message_type_support_t * type_supports,
   const char * topic_name,
   const rmw_qos_profile_t * qos_policies,

--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -193,15 +193,13 @@ rmw_create_client(
   }
 
   auto cleanup_info = rcpputils::make_scope_exit(
-    [info, dds_participant]() {
+    [info, participant_info]() {
       delete info->pub_listener_;
       delete info->listener_;
-      if (info->response_type_support_) {
-        dds_participant->unregister_type(info->response_type_support_.get_type_name());
-      }
-      if (info->request_type_support_) {
-        dds_participant->unregister_type(info->request_type_support_.get_type_name());
-      }
+      rmw_fastrtps_shared_cpp::remove_topic_and_type(
+        participant_info, info->response_topic_, info->response_type_support_);
+      rmw_fastrtps_shared_cpp::remove_topic_and_type(
+        participant_info, info->request_topic_, info->request_type_support_);
       delete info;
     });
 
@@ -269,29 +267,25 @@ rmw_create_client(
   }
 
   // Create response topic
-  rmw_fastrtps_shared_cpp::TopicHolder response_topic;
-  if (!rmw_fastrtps_shared_cpp::cast_or_create_topic(
-      dds_participant, response_topic_desc,
-      response_topic_name, response_type_name, topic_qos, false, &response_topic))
-  {
+  info->response_topic_ = participant_info->find_or_create_topic(
+    response_topic_name, response_type_name, topic_qos);
+  if (!info->response_topic_) {
     RMW_SET_ERROR_MSG("create_client() failed to create response topic");
     return nullptr;
   }
 
-  response_topic_desc = response_topic.desc;
+  response_topic_desc = info->response_topic_;
 
   // Create request topic
-  rmw_fastrtps_shared_cpp::TopicHolder request_topic;
-  if (!rmw_fastrtps_shared_cpp::cast_or_create_topic(
-      dds_participant, request_topic_desc,
-      request_topic_name, request_type_name, topic_qos, true, &request_topic))
-  {
+  info->request_topic_ = participant_info->find_or_create_topic(
+    request_topic_name, request_type_name, topic_qos);
+  if (!info->request_topic_) {
     RMW_SET_ERROR_MSG("create_client() failed to create request topic");
     return nullptr;
   }
 
-  info->request_topic_ = request_topic_name;
-  info->response_topic_ = response_topic_name;
+  info->request_topic_name_ = request_topic_name;
+  info->response_topic_name_ = response_topic_name;
 
   // Keyword to find DataWriter and DataReader QoS
   const std::string topic_name_fallback = "client";
@@ -381,7 +375,7 @@ rmw_create_client(
 
   // Creates DataWriter with a mask enabling publication_matched calls for the listener
   info->request_writer_ = publisher->create_datawriter(
-    request_topic.topic,
+    info->request_topic_,
     writer_qos,
     info->pub_listener_,
     eprosima::fastdds::dds::StatusMask::publication_matched());
@@ -479,8 +473,6 @@ rmw_create_client(
     }
   }
 
-  request_topic.should_be_deleted = false;
-  response_topic.should_be_deleted = false;
   cleanup_rmw_client.cancel();
   cleanup_datawriter.cancel();
   cleanup_datareader.cancel();

--- a/rmw_fastrtps_cpp/src/subscription.cpp
+++ b/rmw_fastrtps_cpp/src/subscription.cpp
@@ -227,6 +227,10 @@ create_subscription(
     return nullptr;
   }
 
+  info->dds_participant_ = dds_participant;
+  info->subscriber_ = subscriber;
+  info->topic_name_mangled_ = topic_name_mangled;
+
   des_topic = info->topic_;
 
   // Create ContentFilteredTopic

--- a/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/publisher.hpp
+++ b/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/publisher.hpp
@@ -23,7 +23,7 @@ namespace rmw_fastrtps_dynamic_cpp
 
 rmw_publisher_t *
 create_publisher(
-  const CustomParticipantInfo * participant_info,
+  CustomParticipantInfo * participant_info,
   const rosidl_message_type_support_t * type_supports,
   const char * topic_name,
   const rmw_qos_profile_t * qos_policies,

--- a/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/subscription.hpp
+++ b/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/subscription.hpp
@@ -25,7 +25,7 @@ namespace rmw_fastrtps_dynamic_cpp
 
 rmw_subscription_t *
 create_subscription(
-  const CustomParticipantInfo * participant_info,
+  CustomParticipantInfo * participant_info,
   const rosidl_message_type_support_t * type_supports,
   const char * topic_name,
   const rmw_qos_profile_t * qos_policies,

--- a/rmw_fastrtps_dynamic_cpp/src/publisher.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/publisher.cpp
@@ -53,7 +53,7 @@ using TypeSupportProxy = rmw_fastrtps_dynamic_cpp::TypeSupportProxy;
 
 rmw_publisher_t *
 rmw_fastrtps_dynamic_cpp::create_publisher(
-  const CustomParticipantInfo * participant_info,
+  CustomParticipantInfo * participant_info,
   const rosidl_message_type_support_t * type_supports,
   const char * topic_name,
   const rmw_qos_profile_t * qos_policies,
@@ -164,11 +164,10 @@ rmw_fastrtps_dynamic_cpp::create_publisher(
   }
 
   auto cleanup_info = rcpputils::make_scope_exit(
-    [info, dds_participant]() {
+    [info, participant_info]() {
       delete info->listener_;
-      if (info->type_support_) {
-        dds_participant->unregister_type(info->type_support_.get_type_name());
-      }
+      rmw_fastrtps_shared_cpp::remove_topic_and_type(
+        participant_info, info->topic_, info->type_support_);
       delete info;
     });
 
@@ -231,11 +230,8 @@ rmw_fastrtps_dynamic_cpp::create_publisher(
     return nullptr;
   }
 
-  rmw_fastrtps_shared_cpp::TopicHolder topic;
-  if (!rmw_fastrtps_shared_cpp::cast_or_create_topic(
-      dds_participant, des_topic,
-      topic_name_mangled, type_name, topic_qos, true, &topic))
-  {
+  info->topic_ = participant_info->find_or_create_topic(topic_name_mangled, type_name, topic_qos);
+  if (!info->topic_) {
     RMW_SET_ERROR_MSG("create_publisher() failed to create topic");
     return nullptr;
   }
@@ -275,7 +271,7 @@ rmw_fastrtps_dynamic_cpp::create_publisher(
 
   // Creates DataWriter (with publisher name to not change name policy)
   info->data_writer_ = publisher->create_datawriter(
-    topic.topic,
+    info->topic_,
     writer_qos,
     info->listener_,
     eprosima::fastdds::dds::StatusMask::publication_matched());
@@ -325,7 +321,6 @@ rmw_fastrtps_dynamic_cpp::create_publisher(
 
   rmw_publisher->options = *publisher_options;
 
-  topic.should_be_deleted = false;
   cleanup_rmw_publisher.cancel();
   cleanup_datawriter.cancel();
   return_type_support.cancel();

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
@@ -204,15 +204,13 @@ rmw_create_service(
     return nullptr;
   }
   auto cleanup_info = rcpputils::make_scope_exit(
-    [info, dds_participant]() {
+    [info, participant_info]() {
       delete info->pub_listener_;
       delete info->listener_;
-      if (info->response_type_support_) {
-        dds_participant->unregister_type(info->response_type_support_.get_type_name());
-      }
-      if (info->request_type_support_) {
-        dds_participant->unregister_type(info->request_type_support_.get_type_name());
-      }
+      rmw_fastrtps_shared_cpp::remove_topic_and_type(
+        participant_info, info->response_topic_, info->response_type_support_);
+      rmw_fastrtps_shared_cpp::remove_topic_and_type(
+        participant_info, info->request_topic_, info->request_type_support_);
       delete info;
     });
 
@@ -302,23 +300,19 @@ rmw_create_service(
   }
 
   // Create request topic
-  rmw_fastrtps_shared_cpp::TopicHolder request_topic;
-  if (!rmw_fastrtps_shared_cpp::cast_or_create_topic(
-      dds_participant, request_topic_desc,
-      request_topic_name, request_type_name, topic_qos, false, &request_topic))
-  {
+  info->request_topic_ = participant_info->find_or_create_topic(
+    request_topic_name, request_type_name, topic_qos);
+  if (!info->request_topic_) {
     RMW_SET_ERROR_MSG("create_service() failed to create request topic");
     return nullptr;
   }
 
-  request_topic_desc = request_topic.desc;
+  request_topic_desc = info->request_topic_;
 
   // Create response topic
-  rmw_fastrtps_shared_cpp::TopicHolder response_topic;
-  if (!rmw_fastrtps_shared_cpp::cast_or_create_topic(
-      dds_participant, response_topic_desc,
-      response_topic_name, response_type_name, topic_qos, true, &response_topic))
-  {
+  info->response_topic_ = participant_info->find_or_create_topic(
+    response_topic_name, response_type_name, topic_qos);
+  if (!info->response_topic_) {
     RMW_SET_ERROR_MSG("create_service() failed to create response topic");
     return nullptr;
   }
@@ -415,7 +409,7 @@ rmw_create_service(
 
   // Creates DataWriter
   info->response_writer_ = publisher->create_datawriter(
-    response_topic.topic,
+    info->response_topic_,
     writer_qos,
     info->pub_listener_,
     eprosima::fastdds::dds::StatusMask::publication_matched());
@@ -505,8 +499,6 @@ rmw_create_service(
     }
   }
 
-  request_topic.should_be_deleted = false;
-  response_topic.should_be_deleted = false;
   cleanup_rmw_service.cancel();
   cleanup_datawriter.cancel();
   cleanup_datareader.cancel();

--- a/rmw_fastrtps_dynamic_cpp/src/subscription.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/subscription.cpp
@@ -60,7 +60,7 @@ namespace rmw_fastrtps_dynamic_cpp
 
 rmw_subscription_t *
 create_subscription(
-  const CustomParticipantInfo * participant_info,
+  CustomParticipantInfo * participant_info,
   const rosidl_message_type_support_t * type_supports,
   const char * topic_name,
   const rmw_qos_profile_t * qos_policies,
@@ -163,12 +163,11 @@ create_subscription(
   }
 
   auto cleanup_info = rcpputils::make_scope_exit(
-    [info, dds_participant]()
+    [info, participant_info]()
     {
       delete info->listener_;
-      if (info->type_support_) {
-        dds_participant->unregister_type(info->type_support_.get_type_name());
-      }
+      rmw_fastrtps_shared_cpp::remove_topic_and_type(
+        participant_info, info->topic_, info->type_support_);
       delete info;
     });
 
@@ -229,16 +228,13 @@ create_subscription(
     return nullptr;
   }
 
-  rmw_fastrtps_shared_cpp::TopicHolder topic;
-  if (!rmw_fastrtps_shared_cpp::cast_or_create_topic(
-      dds_participant, des_topic,
-      topic_name_mangled, type_name, topic_qos, false, &topic))
-  {
+  info->topic_ = participant_info->find_or_create_topic(topic_name_mangled, type_name, topic_qos);
+  if (!info->topic_) {
     RMW_SET_ERROR_MSG("create_subscription() failed to create topic");
     return nullptr;
   }
 
-  des_topic = topic.desc;
+  des_topic = info->topic_;
 
   /////
   // Create DataReader
@@ -358,7 +354,6 @@ create_subscription(
   // TODO(iuhilnehc-ynos): update after rmw_fastrtps_cpp is confirmed
   rmw_subscription->is_cft_enabled = false;
 
-  topic.should_be_deleted = false;
   cleanup_rmw_subscription.cancel();
   cleanup_datareader.cancel();
   return_type_support.cancel();

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_client_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_client_info.hpp
@@ -55,8 +55,11 @@ typedef struct CustomClientInfo
   eprosima::fastdds::dds::DataReader * response_reader_{nullptr};
   eprosima::fastdds::dds::DataWriter * request_writer_{nullptr};
 
-  std::string request_topic_;
-  std::string response_topic_;
+  std::string request_topic_name_;
+  std::string response_topic_name_;
+
+  eprosima::fastdds::dds::Topic * request_topic_{nullptr};
+  eprosima::fastdds::dds::Topic * response_topic_{nullptr};
 
   ClientListener * listener_{nullptr};
   eprosima::fastrtps::rtps::GUID_t writer_guid_;

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
@@ -16,8 +16,10 @@
 #define RMW_FASTRTPS_SHARED_CPP__CUSTOM_PARTICIPANT_INFO_HPP_
 
 #include <map>
+#include <memory>
 #include <mutex>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "fastdds/dds/domain/DomainParticipant.hpp"
@@ -53,10 +55,25 @@ enum class publishing_mode_t
   AUTO           // Use publishing mode set in XML file or Fast DDS default
 };
 
+typedef struct UseCountTopic
+{
+  eprosima::fastdds::dds::Topic * topic{nullptr};
+  size_t use_count{0};
+} UseCountTopic;
+
 typedef struct CustomParticipantInfo
 {
   eprosima::fastdds::dds::DomainParticipant * participant_{nullptr};
   ParticipantListener * listener_{nullptr};
+
+  std::mutex topic_name_to_topic_mutex_;
+  // As of 2023-02-07, Fast-DDS only allows one create_topic() with the same
+  // topic name per DomainParticipant.  Thus, we need to check if the topic
+  // was already created.  If it did, then we just increase the use_count
+  // that we are tracking, and return the existing topic.  If it
+  // didn't, then we create a new one and start tracking it.  Once all
+  // users of the topic are removed, we will delete the topic.
+  std::map<std::string, std::unique_ptr<UseCountTopic>> topic_name_to_topic_;
 
   eprosima::fastdds::dds::Publisher * publisher_{nullptr};
   eprosima::fastdds::dds::Subscriber * subscriber_{nullptr};
@@ -71,6 +88,54 @@ typedef struct CustomParticipantInfo
   // with the default configuration.
   bool leave_middleware_default_qos;
   publishing_mode_t publishing_mode;
+
+  eprosima::fastdds::dds::Topic * find_or_create_topic(
+    const std::string & topic_name,
+    const std::string & type_name,
+    const eprosima::fastdds::dds::TopicQos & topic_qos)
+  {
+    eprosima::fastdds::dds::Topic * topic = nullptr;
+
+    std::lock_guard<std::mutex> lck(topic_name_to_topic_mutex_);
+    std::map<std::string,
+      std::unique_ptr<UseCountTopic>>::const_iterator it = topic_name_to_topic_.find(topic_name);
+    if (it == topic_name_to_topic_.end()) {
+      // Not already in the map, we need to add it
+      topic = participant_->create_topic(topic_name, type_name, topic_qos);
+
+      auto uct = std::make_unique<UseCountTopic>();
+      uct->topic = topic;
+      uct->use_count = 1;
+
+      topic_name_to_topic_[topic_name] = std::move(uct);
+    } else {
+      // Already in the map, just increase the use count
+      it->second->use_count++;
+      topic = it->second->topic;
+    }
+
+    return topic;
+  }
+
+  void delete_topic(const eprosima::fastdds::dds::Topic * topic)
+  {
+    if (topic == nullptr) {
+      return;
+    }
+
+    std::lock_guard<std::mutex> lck(topic_name_to_topic_mutex_);
+    std::map<std::string, std::unique_ptr<UseCountTopic>>::const_iterator it =
+      topic_name_to_topic_.find(topic->get_name());
+
+    if (it != topic_name_to_topic_.end()) {
+      it->second->use_count--;
+      if (it->second->use_count <= 0) {
+        participant_->delete_topic(it->second->topic);
+
+        topic_name_to_topic_.erase(it);
+      }
+    }
+  }
 } CustomParticipantInfo;
 
 class ParticipantListener : public eprosima::fastdds::dds::DomainParticipantListener

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
@@ -134,6 +134,11 @@ typedef struct CustomParticipantInfo
 
         topic_name_to_topic_.erase(it);
       }
+    } else {
+      RCUTILS_LOG_WARN_NAMED(
+        "rmw_fastrtps_shared_cpp",
+        "Attempted to delete topic '%s', but it was never created.  Ignoring",
+        topic->get_name().c_str());
     }
   }
 } CustomParticipantInfo;

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_publisher_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_publisher_info.hpp
@@ -48,6 +48,8 @@ typedef struct CustomPublisherInfo : public CustomEventInfo
   rmw_gid_t publisher_gid{};
   const char * typesupport_identifier_{nullptr};
 
+  eprosima::fastdds::dds::Topic * topic_{nullptr};
+
   RMW_FASTRTPS_SHARED_CPP_PUBLIC
   EventListenerInterface *
   get_listener() const final;

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
@@ -63,6 +63,9 @@ typedef struct CustomServiceInfo
   eprosima::fastdds::dds::DataReader * request_reader_{nullptr};
   eprosima::fastdds::dds::DataWriter * response_writer_{nullptr};
 
+  eprosima::fastdds::dds::Topic * request_topic_{nullptr};
+  eprosima::fastdds::dds::Topic * response_topic_{nullptr};
+
   ServiceListener * listener_{nullptr};
   ServicePubListener * pub_listener_{nullptr};
 

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
@@ -70,7 +70,7 @@ struct CustomSubscriberInfo : public CustomEventInfo
   eprosima::fastdds::dds::DomainParticipant * dds_participant_ {nullptr};
   eprosima::fastdds::dds::Subscriber * subscriber_ {nullptr};
   std::string topic_name_mangled_;
-  eprosima::fastdds::dds::TopicDescription * topic_ {nullptr};
+  eprosima::fastdds::dds::Topic * topic_ {nullptr};
   eprosima::fastdds::dds::ContentFilteredTopic * filtered_topic_ {nullptr};
   eprosima::fastdds::dds::DataReaderQos datareader_qos_;
 

--- a/rmw_fastrtps_shared_cpp/src/publisher.cpp
+++ b/rmw_fastrtps_shared_cpp/src/publisher.cpp
@@ -39,9 +39,6 @@ destroy_publisher(
     // Get RMW Publisher
     auto info = static_cast<CustomPublisherInfo *>(publisher->data);
 
-    // Keep pointer to topic, so we can remove it later
-    auto topic = info->data_writer_->get_topic();
-
     // Delete DataWriter
     ReturnCode_t ret = participant_info->publisher_->delete_datawriter(info->data_writer_);
     if (ReturnCode_t::RETCODE_OK != ret) {
@@ -55,7 +52,7 @@ destroy_publisher(
     delete info->listener_;
 
     // Delete topic and unregister type
-    remove_topic_and_type(participant_info, topic, info->type_support_);
+    remove_topic_and_type(participant_info, info->topic_, info->type_support_);
 
     // Delete CustomPublisherInfo structure
     delete info;

--- a/rmw_fastrtps_shared_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_client.cpp
@@ -81,10 +81,6 @@ __rmw_destroy_client(
   {
     std::lock_guard<std::mutex> lck(participant_info->entity_creation_mutex_);
 
-    // Keep pointers to topics, so we can remove them later
-    auto response_topic = info->response_reader_->get_topicdescription();
-    auto request_topic = info->request_writer_->get_topic();
-
     // Delete DataReader
     ReturnCode_t ret = participant_info->subscriber_->delete_datareader(info->response_reader_);
     if (ret != ReturnCode_t::RETCODE_OK) {
@@ -114,8 +110,8 @@ __rmw_destroy_client(
     }
 
     // Delete topics and unregister types
-    remove_topic_and_type(participant_info, request_topic, info->request_type_support_);
-    remove_topic_and_type(participant_info, response_topic, info->response_type_support_);
+    remove_topic_and_type(participant_info, info->request_topic_, info->request_type_support_);
+    remove_topic_and_type(participant_info, info->response_topic_, info->response_type_support_);
 
     // Delete CustomClientInfo structure
     delete info;

--- a/rmw_fastrtps_shared_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_service.cpp
@@ -93,10 +93,6 @@ __rmw_destroy_service(
   {
     std::lock_guard<std::mutex> lck(participant_info->entity_creation_mutex_);
 
-    // Keep pointers to topics, so we can remove them later
-    auto response_topic = info->response_writer_->get_topic();
-    auto request_topic = info->request_reader_->get_topicdescription();
-
     // Delete DataReader
     ReturnCode_t ret = participant_info->subscriber_->delete_datareader(info->request_reader_);
     if (ret != ReturnCode_t::RETCODE_OK) {
@@ -128,8 +124,8 @@ __rmw_destroy_service(
     }
 
     // Delete topics and unregister types
-    remove_topic_and_type(participant_info, request_topic, info->request_type_support_);
-    remove_topic_and_type(participant_info, response_topic, info->response_type_support_);
+    remove_topic_and_type(participant_info, info->request_topic_, info->request_type_support_);
+    remove_topic_and_type(participant_info, info->response_topic_, info->response_type_support_);
 
     // Delete CustomServiceInfo structure
     delete info;

--- a/rmw_fastrtps_shared_cpp/src/rmw_service_server_is_available.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_service_server_is_available.cpp
@@ -72,9 +72,9 @@ __rmw_service_server_is_available(
     return RMW_RET_ERROR;
   }
 
-  auto pub_topic_name = client_info->request_topic_;
+  auto pub_topic_name = client_info->request_topic_name_;
 
-  auto sub_topic_name = client_info->response_topic_;
+  auto sub_topic_name = client_info->response_topic_name_;
 
   *is_available = false;
   auto common_context = static_cast<rmw_dds_common::Context *>(node->context->impl->common);

--- a/rmw_fastrtps_shared_cpp/src/utils.cpp
+++ b/rmw_fastrtps_shared_cpp/src/utils.cpp
@@ -54,43 +54,6 @@ rmw_ret_t cast_error_dds_to_rmw(ReturnCode_t code)
 }
 
 bool
-cast_or_create_topic(
-  eprosima::fastdds::dds::DomainParticipant * participant,
-  eprosima::fastdds::dds::TopicDescription * desc,
-  const std::string & topic_name,
-  const std::string & type_name,
-  const eprosima::fastdds::dds::TopicQos & topic_qos,
-  bool is_writer_topic,
-  TopicHolder * topic_holder)
-{
-  topic_holder->should_be_deleted = false;
-  topic_holder->participant = participant;
-  topic_holder->desc = desc;
-  topic_holder->topic = nullptr;
-
-  if (nullptr == desc) {
-    topic_holder->topic = participant->create_topic(
-      topic_name,
-      type_name,
-      topic_qos);
-
-    if (!topic_holder->topic) {
-      return false;
-    }
-
-    topic_holder->desc = topic_holder->topic;
-    topic_holder->should_be_deleted = true;
-  } else {
-    if (is_writer_topic) {
-      topic_holder->topic = dynamic_cast<eprosima::fastdds::dds::Topic *>(desc);
-      assert(nullptr != topic_holder->topic);
-    }
-  }
-
-  return true;
-}
-
-bool
 find_and_check_topic_and_type(
   const CustomParticipantInfo * participant_info,
   const std::string & topic_name,
@@ -112,7 +75,7 @@ find_and_check_topic_and_type(
 
 void
 remove_topic_and_type(
-  const CustomParticipantInfo * participant_info,
+  CustomParticipantInfo * participant_info,
   const eprosima::fastdds::dds::TopicDescription * topic_desc,
   const eprosima::fastdds::dds::TypeSupport & type)
 {
@@ -122,7 +85,7 @@ remove_topic_and_type(
   auto topic = dynamic_cast<const eprosima::fastdds::dds::Topic *>(topic_desc);
 
   if (nullptr != topic) {
-    participant_info->participant_->delete_topic(topic);
+    participant_info->delete_topic(topic);
   }
 
   if (type) {


### PR DESCRIPTION
Every DataReader and DataWriter in the system needs to have an associated Topic.  Ideally we would create these as one per publisher/subscriber, but Fast-DDS does not allow you to create multiple topics within the same DomainParticipant with the same topic name.  Instead, what we need to do is track ourselves whether a topic should be reused.

This was previously done with a combination of TopicHolder and cast_or_create_topic, but that had a couple of problems. First of all, a TopicHolder is really a SCOPE_EXIT by a different name.  Second, cast_or_create_topic worked, but really left the semantics of who owned a Topic up in the air.  If you created multiple topics with the same name, the first one would own it, and thus own the lifetime. The subsequent ones would reuse that.  But if you happened to remove the first one, then everything would probably crash.

Rewrite this whole thing to instead store the list of Topic pointers in the CustomParticipantInfo, which seems like a much more appropriate place for it.  When we go to add them, we first look if it already exists and if so, just increase the use_count.  If it doesn't exist, we create it with a use_count of 1.  On deletion, we do the opposite; decrease the use_count, and call delete_topic iff the use_count <= 0.  This data is wrapped in another class called UseCountTopic; we'll also be using this in the future to associate TopicListener with the Topic.

With this implementation, the semantics are much more clearly defined, and this should be able to handle deletion as well. It also happens to remove a bunch of code from the implementation, which is an added bonus.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Once we get this in (or something like it), I'll be able to redo the code in #654 to take advantage of this refactor.

Still a draft while I run CI on it.

@MiguelCompany I could especially use review from you.