### PR TITLE
Be more proactive about skipping work if possible

### DIFF
--- a/rmw_fastrtps_shared_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_shared_cpp/CMakeLists.txt
@@ -49,9 +49,6 @@ find_package(fastcdr REQUIRED CONFIG)
 find_package(fastrtps 2.3 REQUIRED CONFIG)
 find_package(FastRTPS 2.3 REQUIRED MODULE)
 
-find_package(Threads REQUIRED)
-find_package(tracy_vendor REQUIRED)
-
 find_package(rmw REQUIRED)
 
 add_library(rmw_fastrtps_shared_cpp
@@ -118,8 +115,6 @@ ament_target_dependencies(rmw_fastrtps_shared_cpp
   "rosidl_typesupport_introspection_c"
   "rosidl_typesupport_introspection_cpp"
   "tracetools"
-  "tracy_vendor"
-  "Threads"
 )
 
 # Causes the visibility macros to use dllexport rather than dllimport,
@@ -142,8 +137,6 @@ ament_export_dependencies(rmw_dds_common)
 ament_export_dependencies(rosidl_typesupport_introspection_c)
 ament_export_dependencies(rosidl_typesupport_introspection_cpp)
 ament_export_dependencies(tracetools)
-ament_export_dependencies(tracy_vendor)
-ament_export_dependencies(Threads)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/rmw_fastrtps_shared_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_shared_cpp/CMakeLists.txt
@@ -49,6 +49,9 @@ find_package(fastcdr REQUIRED CONFIG)
 find_package(fastrtps 2.3 REQUIRED CONFIG)
 find_package(FastRTPS 2.3 REQUIRED MODULE)
 
+find_package(Threads REQUIRED)
+find_package(tracy_vendor REQUIRED)
+
 find_package(rmw REQUIRED)
 
 add_library(rmw_fastrtps_shared_cpp
@@ -115,6 +118,8 @@ ament_target_dependencies(rmw_fastrtps_shared_cpp
   "rosidl_typesupport_introspection_c"
   "rosidl_typesupport_introspection_cpp"
   "tracetools"
+  "tracy_vendor"
+  "Threads"
 )
 
 # Causes the visibility macros to use dllexport rather than dllimport,
@@ -137,6 +142,8 @@ ament_export_dependencies(rmw_dds_common)
 ament_export_dependencies(rosidl_typesupport_introspection_c)
 ament_export_dependencies(rosidl_typesupport_introspection_cpp)
 ament_export_dependencies(tracetools)
+ament_export_dependencies(tracy_vendor)
+ament_export_dependencies(Threads)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/rmw_fastrtps_shared_cpp/src/rmw_wait.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_wait.cpp
@@ -56,7 +56,8 @@ bool should_skip_wait(
     for (size_t i = 0; i < events->event_count; ++i) {
       auto event = static_cast<rmw_event_t *>(events->events[i]);
       auto custom_event_info = static_cast<CustomEventInfo *>(event->data);
-      if (custom_event_info->get_listener()->get_statuscondition().get_trigger_value())
+      if (custom_event_info->get_listener()->get_statuscondition().get_trigger_value() ||
+          custom_event_info->get_listener()->get_event_guard(event->event_type).get_trigger_value())
         return true;
     }
   }


### PR DESCRIPTION
This makes `rmw_wait` more aggressive about how it skips work.

In the case that a condition is already met, this will skip attaching/detaching conditions from the underlying waitset and skip waiting.

In the case that a wait is required, it generally looks like this: 
![image](https://user-images.githubusercontent.com/279701/230673405-79e16c40-d8c7-445c-a688-46a7a5ef5d70.png)

and when a wait isn't needed: 

![image](https://user-images.githubusercontent.com/279701/230673574-8c8e0867-ef5c-4a6b-850a-af72a8be8cb8.png)
