### PR TITLE
Use TRACETOOLS_ prefix for tracepoint-related macros

### DIFF
--- a/rmw_fastrtps_cpp/src/publisher.cpp
+++ b/rmw_fastrtps_cpp/src/publisher.cpp
@@ -321,7 +321,7 @@ rmw_fastrtps_cpp::create_publisher(
   cleanup_datawriter.cancel();
   cleanup_info.cancel();
 
-  TRACEPOINT(
+  TRACETOOLS_TRACEPOINT(
     rmw_publisher_init,
     static_cast<const void *>(rmw_publisher),
     info->publisher_gid.data);

--- a/rmw_fastrtps_cpp/src/subscription.cpp
+++ b/rmw_fastrtps_cpp/src/subscription.cpp
@@ -454,7 +454,7 @@ __create_dynamic_subscription(
   cleanup_datareader.cancel();
   cleanup_info.cancel();
 
-  TRACEPOINT(
+  TRACETOOLS_TRACEPOINT(
     rmw_subscription_init,
     static_cast<const void *>(rmw_subscription),
     info->subscription_gid_.data);
@@ -721,7 +721,7 @@ __create_subscription(
   cleanup_datareader.cancel();
   cleanup_info.cancel();
 
-  TRACEPOINT(
+  TRACETOOLS_TRACEPOINT(
     rmw_subscription_init,
     static_cast<const void *>(rmw_subscription),
     info->subscription_gid_.data);

--- a/rmw_fastrtps_shared_cpp/src/rmw_publish.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_publish.cpp
@@ -57,7 +57,7 @@ __rmw_publish(
   data.type = FASTRTPS_SERIALIZED_DATA_TYPE_ROS_MESSAGE;
   data.data = const_cast<void *>(ros_message);
   data.impl = info->type_support_impl_;
-  TRACEPOINT(rmw_publish, ros_message);
+  TRACETOOLS_TRACEPOINT(rmw_publish, ros_message);
   if (!info->data_writer_->write(&data)) {
     RMW_SET_ERROR_MSG("cannot publish data");
     return RMW_RET_ERROR;

--- a/rmw_fastrtps_shared_cpp/src/rmw_take.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_take.cpp
@@ -125,7 +125,7 @@ _take(
     }
   }
 
-  TRACEPOINT(
+  TRACETOOLS_TRACEPOINT(
     rmw_take,
     static_cast<const void *>(subscription),
     static_cast<const void *>(ros_message),


### PR DESCRIPTION
Part of https://github.com/ros2/ros2_tracing/issues/18

Requires https://github.com/ros2/ros2_tracing/pull/56

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>