### PR TITLE
Add in a missing data_reader check when creating subscription.

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/utils.cpp
+++ b/rmw_fastrtps_shared_cpp/src/utils.cpp
@@ -162,7 +162,7 @@ create_datareader(
     updated_qos,
     listener,
     eprosima::fastdds::dds::StatusMask::subscription_matched());
-  if (!data_reader &&
+  if (!(*data_reader) &&
     (RMW_UNIQUE_NETWORK_FLOW_ENDPOINTS_OPTIONALLY_REQUIRED ==
     subscription_options->require_unique_network_flow_endpoints))
   {
@@ -172,6 +172,11 @@ create_datareader(
       listener,
       eprosima::fastdds::dds::StatusMask::subscription_matched());
   }
+
+  if (!(*data_reader)) {
+    return false;
+  }
+
   return true;
 }
 


### PR DESCRIPTION
The end stanza of create_datareader() is supposed to be attempting to create a datareader with the underlying Fast-DDS library.  If creation of the datareader returns a valid pointer, we've succeeded, and if it returns a nullptr, it has failed.

However, there were two separate problems of the logic checking for these conditions:

1. It was checking the datareader pointer-to-a-pointer, which should always be non-null.  What it really meant to check was the datareader pointer (dereferenced).
2. There is a fallback mechanism for when unique network flow endpoints were optionally required.  The problem with that is that when using the fallback, we never check again to make sure the fallback was successful.  Therefore, if we failed for another reason (like security), we would not discover it until a crash later on.

This commit fixes both of these issues.

This commit will improve the error reporting as in https://github.com/ros2/sros2/issues/287 , though it does not completely solve it (I think we need more work at the rclcpp layer).