### PR TITLE
Instrument loaned message publication code path

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/rmw_publish.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_publish.cpp
@@ -135,6 +135,7 @@ __rmw_publish_loaned_message(
   RMW_CHECK_ARGUMENT_FOR_NULL(ros_message, RMW_RET_INVALID_ARGUMENT);
 
   auto info = static_cast<CustomPublisherInfo *>(publisher->data);
+  TRACETOOLS_TRACEPOINT(rmw_publish, ros_message);
   if (!info->data_writer_->write(const_cast<void *>(ros_message))) {
     RMW_SET_ERROR_MSG("cannot publish data");
     return RMW_RET_ERROR;


### PR DESCRIPTION
Just trigger the `rmw_publish` tracepoint for loaned message publications too.