### PR TITLE
Clear out errors once we have handled them.

### DIFF
--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
@@ -228,6 +228,8 @@ private:
             reinterpret_cast<const char *>(userDataValue.data()));
           */
           type_hash = rosidl_get_zero_initialized_type_hash();
+          // We've handled the error, so clear it out.
+          rmw_reset_error();
         }
 
         context->graph_cache.add_entity(

--- a/rmw_fastrtps_shared_cpp/src/qos.cpp
+++ b/rmw_fastrtps_shared_cpp/src/qos.cpp
@@ -165,6 +165,9 @@ fill_data_entity_qos_from_profile(
       "rmw_fastrtps_shared_cpp",
       "Failed to encode type hash for topic, will not distribute it in USER_DATA.");
     user_data_str.clear();
+    // Since we are going to go on without a hash, we clear the error so other
+    // code won't overwrite it.
+    rmw_reset_error();
   }
   std::vector<uint8_t> user_data(user_data_str.begin(), user_data_str.end());
   entity_qos.user_data().resize(user_data.size());


### PR DESCRIPTION
In particular, in the type-hash code we can handle a failure to encode or parse the type hash from the user data.  Once we've handled it, and printed out an error about it, we should clear it because we are going to continue on and something else down the line might have an error.

This will avoid errors like:

This error state is being overwritten:

 <old message>

with this new error message:

 <new message>