### PR TITLE
Improve node graph delivery by using a unique listening port

### DIFF
--- a/rmw_fastrtps_cpp/src/init_rmw_context_impl.cpp
+++ b/rmw_fastrtps_cpp/src/init_rmw_context_impl.cpp
@@ -51,7 +51,8 @@ init_context_impl(
   // Avoid receiving graph updates from our own publication
   subscription_options.ignore_local_publications = true;
   // Improve graph discovery by using a unique listening port for its subscription
-  subscription_options.require_unique_network_flow_endpoints = RMW_UNIQUE_NETWORK_FLOW_ENDPOINTS_OPTIONALLY_REQUIRED;
+  subscription_options.require_unique_network_flow_endpoints =
+    RMW_UNIQUE_NETWORK_FLOW_ENDPOINTS_OPTIONALLY_REQUIRED;
 
   std::unique_ptr<rmw_dds_common::Context> common_context(
     new(std::nothrow) rmw_dds_common::Context());

--- a/rmw_fastrtps_cpp/src/init_rmw_context_impl.cpp
+++ b/rmw_fastrtps_cpp/src/init_rmw_context_impl.cpp
@@ -48,8 +48,10 @@ init_context_impl(
   rmw_publisher_options_t publisher_options = rmw_get_default_publisher_options();
   rmw_subscription_options_t subscription_options = rmw_get_default_subscription_options();
 
-  // This is currently not implemented in fastrtps
+  // Avoid receiving graph updates from our own publication
   subscription_options.ignore_local_publications = true;
+  // Improve graph discovery by using a unique listening port for its subscription
+  subscription_options.require_unique_network_flow_endpoints = RMW_UNIQUE_NETWORK_FLOW_ENDPOINTS_OPTIONALLY_REQUIRED;
 
   std::unique_ptr<rmw_dds_common::Context> common_context(
     new(std::nothrow) rmw_dds_common::Context());

--- a/rmw_fastrtps_dynamic_cpp/src/init_rmw_context_impl.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/init_rmw_context_impl.cpp
@@ -51,7 +51,8 @@ init_context_impl(
   // Avoid receiving graph updates from our own publication
   subscription_options.ignore_local_publications = true;
   // Improve graph discovery by using a unique listening port for its subscription
-  subscription_options.require_unique_network_flow_endpoints = RMW_UNIQUE_NETWORK_FLOW_ENDPOINTS_OPTIONALLY_REQUIRED;
+  subscription_options.require_unique_network_flow_endpoints =
+    RMW_UNIQUE_NETWORK_FLOW_ENDPOINTS_OPTIONALLY_REQUIRED;
 
   std::unique_ptr<rmw_dds_common::Context> common_context(
     new(std::nothrow) rmw_dds_common::Context());

--- a/rmw_fastrtps_dynamic_cpp/src/init_rmw_context_impl.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/init_rmw_context_impl.cpp
@@ -48,8 +48,10 @@ init_context_impl(
   rmw_publisher_options_t publisher_options = rmw_get_default_publisher_options();
   rmw_subscription_options_t subscription_options = rmw_get_default_subscription_options();
 
-  // This is currently not implemented in fastrtps
+  // Avoid receiving graph updates from our own publication
   subscription_options.ignore_local_publications = true;
+  // Improve graph discovery by using a unique listening port for its subscription
+  subscription_options.require_unique_network_flow_endpoints = RMW_UNIQUE_NETWORK_FLOW_ENDPOINTS_OPTIONALLY_REQUIRED;
 
   std::unique_ptr<rmw_dds_common::Context> common_context(
     new(std::nothrow) rmw_dds_common::Context());


### PR DESCRIPTION
Using a unique listening port for `ros_discovery_info` will make that topic have its own socket buffer, thus avoiding interference from other topics.

This could help mitigate service discovery issues when incoming network traffic on user topics is high.