### PR TITLE
Account for alignment on is_plain calculations.

### DIFF
--- a/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport_impl.hpp
+++ b/rmw_fastrtps_dynamic_cpp/include/rmw_fastrtps_dynamic_cpp/TypeSupport_impl.hpp
@@ -852,26 +852,26 @@ size_t TypeSupport<MembersType>::calculateMaxSerializedSize(
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT8:
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_CHAR:
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT8:
-        last_member_size = sizeof(int8_t);
+        last_member_size = array_size * sizeof(int8_t);
         current_alignment += array_size * sizeof(int8_t);
         break;
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT16:
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT16:
-        last_member_size = sizeof(uint16_t);
+        last_member_size = array_size * sizeof(uint16_t);
         current_alignment += array_size * sizeof(uint16_t) +
           eprosima::fastcdr::Cdr::alignment(current_alignment, sizeof(uint16_t));
         break;
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_FLOAT32:
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT32:
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT32:
-        last_member_size = sizeof(uint32_t);
+        last_member_size = array_size * sizeof(uint32_t);
         current_alignment += array_size * sizeof(uint32_t) +
           eprosima::fastcdr::Cdr::alignment(current_alignment, sizeof(uint32_t));
         break;
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_FLOAT64:
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT64:
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT64:
-        last_member_size = sizeof(uint64_t);
+        last_member_size = array_size * sizeof(uint64_t);
         current_alignment += array_size * sizeof(uint64_t) +
           eprosima::fastcdr::Cdr::alignment(current_alignment, sizeof(uint64_t));
         break;


### PR DESCRIPTION
This takes into consideration whether the alignment generated by the compiler is compatible with the one required by CDR serialization.

This goes along with https://github.com/ros2/rosidl_typesupport_fastrtps/pull/108 , and fixes the problem in my testing.  @MiguelCompany let me know if this is what you expect here.