### PR TITLE
avoid using dds common public mutex directly

### DIFF
--- a/rmw_fastrtps_cpp/src/init_rmw_context_impl.cpp
+++ b/rmw_fastrtps_cpp/src/init_rmw_context_impl.cpp
@@ -159,7 +159,7 @@ init_context_impl(
   common_context->gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
     eprosima_fastrtps_identifier, participant_info->participant_->guid());
   common_context->pub = publisher.get();
-  common_context->publish_callback = [](rmw_publisher_t * pub, void * msg) {
+  common_context->publish_callback = [](const rmw_publisher_t * pub, const void * msg) {
       return rmw_fastrtps_shared_cpp::__rmw_publish(
         eprosima_fastrtps_identifier,
         pub,

--- a/rmw_fastrtps_cpp/src/init_rmw_context_impl.cpp
+++ b/rmw_fastrtps_cpp/src/init_rmw_context_impl.cpp
@@ -159,6 +159,13 @@ init_context_impl(
   common_context->gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
     eprosima_fastrtps_identifier, participant_info->participant_->guid());
   common_context->pub = publisher.get();
+  common_context->publish_callback = [](rmw_publisher_t * pub, void * msg) {
+      return rmw_fastrtps_shared_cpp::__rmw_publish(
+        eprosima_fastrtps_identifier,
+        pub,
+        msg,
+        nullptr);
+    };
   common_context->sub = subscription.get();
   common_context->graph_guard_condition = graph_guard_condition.get();
 

--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -450,7 +450,7 @@ rmw_create_client(
   rmw_ret_t rmw_ret = common_context->update_client_graph(
     request_publisher_gid, response_subscriber_gid,
     node->name, node->namespace_,
-    [] (rmw_publisher_t * pub, void * msg) {
+    [](rmw_publisher_t * pub, void * msg) {
       return rmw_fastrtps_shared_cpp::__rmw_publish(
         eprosima_fastrtps_identifier,
         pub,

--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -447,12 +447,10 @@ rmw_create_client(
     eprosima_fastrtps_identifier, info->request_writer_->guid());
   rmw_gid_t response_subscriber_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
     eprosima_fastrtps_identifier, info->response_reader_->guid());
-  rmw_ret_t rmw_ret = common_context->update_client_graph(
-    request_publisher_gid, response_subscriber_gid,
-    node->name, node->namespace_
-  );
-
-  if (RMW_RET_OK != rmw_ret) {
+  if (RMW_RET_OK != common_context->update_client_graph(
+      request_publisher_gid, response_subscriber_gid,
+      node->name, node->namespace_))
+  {
     return nullptr;
   }
 

--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -132,7 +132,7 @@ rmw_create_client(
     }
   }
 
-  std::lock_guard<std::mutex> lck(participant_info->entity_creation_mutex_);
+  std::unique_lock<std::mutex> lck(participant_info->entity_creation_mutex_);
 
   /////
   // Find and check existing topics and types
@@ -443,6 +443,16 @@ rmw_create_client(
   memcpy(const_cast<char *>(rmw_client->service_name), service_name, strlen(service_name) + 1);
 
   {
+    // It's unnecessary to lock `lck` in current scope.
+    // Unlock `lck` first and re-lock it after exiting the scope can avoid `lock-order-inversion`.
+    // https://github.com/ros2/ros2/issues/1488
+    lck.unlock();
+    auto lock_scope_exit = rcpputils::make_scope_exit(
+      [&lck]() {
+        // lock again for cleanup actions
+        lck.lock();
+      });
+
     // Update graph
     std::lock_guard<std::mutex> guard(common_context->node_update_mutex);
     rmw_gid_t request_publisher_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(

--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -447,7 +447,7 @@ rmw_create_client(
     eprosima_fastrtps_identifier, info->request_writer_->guid());
   rmw_gid_t response_subscriber_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
     eprosima_fastrtps_identifier, info->response_reader_->guid());
-  if (RMW_RET_OK != common_context->update_client_graph(
+  if (RMW_RET_OK != common_context->add_client_graph(
       request_publisher_gid, response_subscriber_gid,
       node->name, node->namespace_))
   {

--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -442,43 +442,25 @@ rmw_create_client(
   }
   memcpy(const_cast<char *>(rmw_client->service_name), service_name, strlen(service_name) + 1);
 
-  {
-    // Update graph
-    std::lock_guard<std::mutex> guard(common_context->node_update_mutex);
-    rmw_gid_t request_publisher_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
-      eprosima_fastrtps_identifier, info->request_writer_->guid());
-    common_context->graph_cache.associate_writer(
-      request_publisher_gid,
-      common_context->gid,
-      node->name,
-      node->namespace_);
-
-    rmw_gid_t response_subscriber_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
-      eprosima_fastrtps_identifier, info->response_reader_->guid());
-    rmw_dds_common::msg::ParticipantEntitiesInfo msg =
-      common_context->graph_cache.associate_reader(
-      response_subscriber_gid,
-      common_context->gid,
-      node->name,
-      node->namespace_);
-    rmw_ret_t ret = rmw_fastrtps_shared_cpp::__rmw_publish(
-      eprosima_fastrtps_identifier,
-      common_context->pub,
-      static_cast<void *>(&msg),
-      nullptr);
-    if (RMW_RET_OK != ret) {
-      common_context->graph_cache.dissociate_reader(
-        response_subscriber_gid,
-        common_context->gid,
-        node->name,
-        node->namespace_);
-      common_context->graph_cache.dissociate_writer(
-        request_publisher_gid,
-        common_context->gid,
-        node->name,
-        node->namespace_);
-      return nullptr;
+  // Update graph
+  rmw_gid_t request_publisher_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
+    eprosima_fastrtps_identifier, info->request_writer_->guid());
+  rmw_gid_t response_subscriber_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
+    eprosima_fastrtps_identifier, info->response_reader_->guid());
+  rmw_ret_t rmw_ret = common_context->update_client_graph(
+    request_publisher_gid, response_subscriber_gid,
+    node->name, node->namespace_,
+    [] (rmw_publisher_t * pub, void * msg) {
+      return rmw_fastrtps_shared_cpp::__rmw_publish(
+        eprosima_fastrtps_identifier,
+        pub,
+        msg,
+        nullptr);
     }
+  );
+
+  if (RMW_RET_OK != rmw_ret) {
+    return nullptr;
   }
 
   cleanup_rmw_client.cancel();

--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -449,14 +449,7 @@ rmw_create_client(
     eprosima_fastrtps_identifier, info->response_reader_->guid());
   rmw_ret_t rmw_ret = common_context->update_client_graph(
     request_publisher_gid, response_subscriber_gid,
-    node->name, node->namespace_,
-    [](rmw_publisher_t * pub, void * msg) {
-      return rmw_fastrtps_shared_cpp::__rmw_publish(
-        eprosima_fastrtps_identifier,
-        pub,
-        msg,
-        nullptr);
-    }
+    node->name, node->namespace_
   );
 
   if (RMW_RET_OK != rmw_ret) {

--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -132,7 +132,7 @@ rmw_create_client(
     }
   }
 
-  std::unique_lock<std::mutex> lck(participant_info->entity_creation_mutex_);
+  std::lock_guard<std::mutex> lck(participant_info->entity_creation_mutex_);
 
   /////
   // Find and check existing topics and types
@@ -443,16 +443,6 @@ rmw_create_client(
   memcpy(const_cast<char *>(rmw_client->service_name), service_name, strlen(service_name) + 1);
 
   {
-    // It's unnecessary to lock `lck` in current scope.
-    // Unlock `lck` first and re-lock it after exiting the scope can avoid `lock-order-inversion`.
-    // https://github.com/ros2/ros2/issues/1488
-    lck.unlock();
-    auto lock_scope_exit = rcpputils::make_scope_exit(
-      [&lck]() {
-        // lock again for cleanup actions
-        lck.lock();
-      });
-
     // Update graph
     std::lock_guard<std::mutex> guard(common_context->node_update_mutex);
     rmw_gid_t request_publisher_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(

--- a/rmw_fastrtps_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publisher.cpp
@@ -108,7 +108,7 @@ rmw_create_publisher(
   rmw_ret_t rmw_ret = common_context->update_publisher_graph(
     info->publisher_gid,
     node->name, node->namespace_,
-    [] (rmw_publisher_t * pub, void * msg) {
+    [](rmw_publisher_t * pub, void * msg) {
       return rmw_fastrtps_shared_cpp::__rmw_publish(
         eprosima_fastrtps_identifier,
         pub,

--- a/rmw_fastrtps_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publisher.cpp
@@ -116,7 +116,6 @@ rmw_create_publisher(
     });
 
   auto common_context = static_cast<rmw_dds_common::Context *>(node->context->impl->common);
-
   auto info = static_cast<const CustomPublisherInfo *>(publisher->data);
 
   // Update graph

--- a/rmw_fastrtps_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publisher.cpp
@@ -20,6 +20,8 @@
 #include "rmw/get_topic_endpoint_info.h"
 #include "rmw/rmw.h"
 
+#include "rcpputils/scope_exit.hpp"
+
 #include "rmw/impl/cpp/macros.hpp"
 
 #include "rmw_dds_common/qos.hpp"
@@ -99,31 +101,33 @@ rmw_create_publisher(
   if (!publisher) {
     return nullptr;
   }
+  auto cleanup_publisher = rcpputils::make_scope_exit(
+    [participant_info, publisher]() {
+      rmw_error_state_t error_state = *rmw_get_error_state();
+      rmw_reset_error();
+      if (RMW_RET_OK != rmw_fastrtps_shared_cpp::destroy_publisher(
+        eprosima_fastrtps_identifier, participant_info, publisher))
+      {
+        RMW_SAFE_FWRITE_TO_STDERR(rmw_get_error_string().str);
+        RMW_SAFE_FWRITE_TO_STDERR(" during '" RCUTILS_STRINGIFY(__function__) "' cleanup\n");
+        rmw_reset_error();
+      }
+      rmw_set_error_state(error_state.message, error_state.file, error_state.line_number);
+    });
 
   auto common_context = static_cast<rmw_dds_common::Context *>(node->context->impl->common);
 
   auto info = static_cast<const CustomPublisherInfo *>(publisher->data);
 
   // Update graph
-  rmw_ret_t rmw_ret = common_context->update_publisher_graph(
-    info->publisher_gid,
-    node->name, node->namespace_
-  );
-
-  if (RMW_RET_OK != rmw_ret) {
-    rmw_error_state_t error_state = *rmw_get_error_state();
-    rmw_reset_error();
-    rmw_ret = rmw_fastrtps_shared_cpp::destroy_publisher(
-      eprosima_fastrtps_identifier, participant_info, publisher);
-    if (RMW_RET_OK != rmw_ret) {
-      RMW_SAFE_FWRITE_TO_STDERR(rmw_get_error_string().str);
-      RMW_SAFE_FWRITE_TO_STDERR(" during '" RCUTILS_STRINGIFY(__function__) "' cleanup\n");
-      rmw_reset_error();
-    }
-    rmw_set_error_state(error_state.message, error_state.file, error_state.line_number);
+  if (RMW_RET_OK != common_context->update_publisher_graph(
+      info->publisher_gid,
+      node->name, node->namespace_))
+  {
     return nullptr;
   }
 
+  cleanup_publisher.cancel();
   return publisher;
 }
 

--- a/rmw_fastrtps_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publisher.cpp
@@ -103,33 +103,34 @@ rmw_create_publisher(
   auto common_context = static_cast<rmw_dds_common::Context *>(node->context->impl->common);
 
   auto info = static_cast<const CustomPublisherInfo *>(publisher->data);
-  {
-    // Update graph
-    std::lock_guard<std::mutex> guard(common_context->node_update_mutex);
-    rmw_dds_common::msg::ParticipantEntitiesInfo msg =
-      common_context->graph_cache.associate_writer(
-      info->publisher_gid, common_context->gid, node->name, node->namespace_);
-    rmw_ret_t rmw_ret = rmw_fastrtps_shared_cpp::__rmw_publish(
-      eprosima_fastrtps_identifier,
-      common_context->pub,
-      static_cast<void *>(&msg),
-      nullptr);
-    if (RMW_RET_OK != rmw_ret) {
-      rmw_error_state_t error_state = *rmw_get_error_state();
-      rmw_reset_error();
-      static_cast<void>(common_context->graph_cache.dissociate_writer(
-        info->publisher_gid, common_context->gid, node->name, node->namespace_));
-      rmw_ret = rmw_fastrtps_shared_cpp::destroy_publisher(
-        eprosima_fastrtps_identifier, participant_info, publisher);
-      if (RMW_RET_OK != rmw_ret) {
-        RMW_SAFE_FWRITE_TO_STDERR(rmw_get_error_string().str);
-        RMW_SAFE_FWRITE_TO_STDERR(" during '" RCUTILS_STRINGIFY(__function__) "' cleanup\n");
-        rmw_reset_error();
-      }
-      rmw_set_error_state(error_state.message, error_state.file, error_state.line_number);
-      return nullptr;
+
+  // Update graph
+  rmw_ret_t rmw_ret = common_context->update_publisher_graph(
+    info->publisher_gid,
+    node->name, node->namespace_,
+    [] (rmw_publisher_t * pub, void * msg) {
+      return rmw_fastrtps_shared_cpp::__rmw_publish(
+        eprosima_fastrtps_identifier,
+        pub,
+        msg,
+        nullptr);
     }
+  );
+
+  if (RMW_RET_OK != rmw_ret) {
+    rmw_error_state_t error_state = *rmw_get_error_state();
+    rmw_reset_error();
+    rmw_ret = rmw_fastrtps_shared_cpp::destroy_publisher(
+      eprosima_fastrtps_identifier, participant_info, publisher);
+    if (RMW_RET_OK != rmw_ret) {
+      RMW_SAFE_FWRITE_TO_STDERR(rmw_get_error_string().str);
+      RMW_SAFE_FWRITE_TO_STDERR(" during '" RCUTILS_STRINGIFY(__function__) "' cleanup\n");
+      rmw_reset_error();
+    }
+    rmw_set_error_state(error_state.message, error_state.file, error_state.line_number);
+    return nullptr;
   }
+
   return publisher;
 }
 

--- a/rmw_fastrtps_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publisher.cpp
@@ -120,7 +120,7 @@ rmw_create_publisher(
   auto info = static_cast<const CustomPublisherInfo *>(publisher->data);
 
   // Update graph
-  if (RMW_RET_OK != common_context->update_publisher_graph(
+  if (RMW_RET_OK != common_context->add_publisher_graph(
       info->publisher_gid,
       node->name, node->namespace_))
   {

--- a/rmw_fastrtps_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publisher.cpp
@@ -107,14 +107,7 @@ rmw_create_publisher(
   // Update graph
   rmw_ret_t rmw_ret = common_context->update_publisher_graph(
     info->publisher_gid,
-    node->name, node->namespace_,
-    [](rmw_publisher_t * pub, void * msg) {
-      return rmw_fastrtps_shared_cpp::__rmw_publish(
-        eprosima_fastrtps_identifier,
-        pub,
-        msg,
-        nullptr);
-    }
+    node->name, node->namespace_
   );
 
   if (RMW_RET_OK != rmw_ret) {

--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -137,7 +137,7 @@ rmw_create_service(
     }
   }
 
-  std::lock_guard<std::mutex> lck(participant_info->entity_creation_mutex_);
+  std::unique_lock<std::mutex> lck(participant_info->entity_creation_mutex_);
 
   /////
   // Find and check existing topics and types
@@ -443,6 +443,16 @@ rmw_create_service(
   memcpy(const_cast<char *>(rmw_service->service_name), service_name, strlen(service_name) + 1);
 
   {
+    // It's unnecessary to lock `lck` in current scope.
+    // Unlock `lck` first and re-lock it after exiting the scope can avoid `lock-order-inversion`.
+    // https://github.com/ros2/ros2/issues/1488
+    lck.unlock();
+    auto lock_scope_exit = rcpputils::make_scope_exit(
+      [&lck]() {
+        // lock again for cleanup actions
+        lck.lock();
+      });
+
     // Update graph
     std::lock_guard<std::mutex> guard(common_context->node_update_mutex);
     rmw_gid_t request_subscriber_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(

--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -449,14 +449,7 @@ rmw_create_service(
     eprosima_fastrtps_identifier, info->response_writer_->guid());
   rmw_ret_t rmw_ret = common_context->update_service_graph(
     request_subscriber_gid, response_publisher_gid,
-    node->name, node->namespace_,
-    [](rmw_publisher_t * pub, void * msg) {
-      return rmw_fastrtps_shared_cpp::__rmw_publish(
-        eprosima_fastrtps_identifier,
-        pub,
-        msg,
-        nullptr);
-    }
+    node->name, node->namespace_
   );
 
   if (RMW_RET_OK != rmw_ret) {

--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -450,7 +450,7 @@ rmw_create_service(
   rmw_ret_t rmw_ret = common_context->update_service_graph(
     request_subscriber_gid, response_publisher_gid,
     node->name, node->namespace_,
-    [] (rmw_publisher_t * pub, void * msg) {
+    [](rmw_publisher_t * pub, void * msg) {
       return rmw_fastrtps_shared_cpp::__rmw_publish(
         eprosima_fastrtps_identifier,
         pub,

--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -447,12 +447,10 @@ rmw_create_service(
     eprosima_fastrtps_identifier, info->request_reader_->guid());
   rmw_gid_t response_publisher_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
     eprosima_fastrtps_identifier, info->response_writer_->guid());
-  rmw_ret_t rmw_ret = common_context->update_service_graph(
-    request_subscriber_gid, response_publisher_gid,
-    node->name, node->namespace_
-  );
-
-  if (RMW_RET_OK != rmw_ret) {
+  if (RMW_RET_OK != common_context->update_service_graph(
+      request_subscriber_gid, response_publisher_gid,
+      node->name, node->namespace_))
+  {
     return nullptr;
   }
 

--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -447,7 +447,7 @@ rmw_create_service(
     eprosima_fastrtps_identifier, info->request_reader_->guid());
   rmw_gid_t response_publisher_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
     eprosima_fastrtps_identifier, info->response_writer_->guid());
-  if (RMW_RET_OK != common_context->update_service_graph(
+  if (RMW_RET_OK != common_context->add_service_graph(
       request_subscriber_gid, response_publisher_gid,
       node->name, node->namespace_))
   {

--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -442,42 +442,25 @@ rmw_create_service(
   }
   memcpy(const_cast<char *>(rmw_service->service_name), service_name, strlen(service_name) + 1);
 
-  {
-    // Update graph
-    std::lock_guard<std::mutex> guard(common_context->node_update_mutex);
-    rmw_gid_t request_subscriber_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
-      eprosima_fastrtps_identifier, info->request_reader_->guid());
-    common_context->graph_cache.associate_reader(
-      request_subscriber_gid,
-      common_context->gid,
-      node->name,
-      node->namespace_);
-    rmw_gid_t response_publisher_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
-      eprosima_fastrtps_identifier, info->response_writer_->guid());
-    rmw_dds_common::msg::ParticipantEntitiesInfo msg =
-      common_context->graph_cache.associate_writer(
-      response_publisher_gid,
-      common_context->gid,
-      node->name,
-      node->namespace_);
-    rmw_ret_t ret = rmw_fastrtps_shared_cpp::__rmw_publish(
-      eprosima_fastrtps_identifier,
-      common_context->pub,
-      static_cast<void *>(&msg),
-      nullptr);
-    if (RMW_RET_OK != ret) {
-      common_context->graph_cache.dissociate_writer(
-        response_publisher_gid,
-        common_context->gid,
-        node->name,
-        node->namespace_);
-      common_context->graph_cache.dissociate_reader(
-        request_subscriber_gid,
-        common_context->gid,
-        node->name,
-        node->namespace_);
-      return nullptr;
+  // Update graph
+  rmw_gid_t request_subscriber_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
+    eprosima_fastrtps_identifier, info->request_reader_->guid());
+  rmw_gid_t response_publisher_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
+    eprosima_fastrtps_identifier, info->response_writer_->guid());
+  rmw_ret_t rmw_ret = common_context->update_service_graph(
+    request_subscriber_gid, response_publisher_gid,
+    node->name, node->namespace_,
+    [] (rmw_publisher_t * pub, void * msg) {
+      return rmw_fastrtps_shared_cpp::__rmw_publish(
+        eprosima_fastrtps_identifier,
+        pub,
+        msg,
+        nullptr);
     }
+  );
+
+  if (RMW_RET_OK != rmw_ret) {
+    return nullptr;
   }
 
   cleanup_rmw_service.cancel();

--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -137,7 +137,7 @@ rmw_create_service(
     }
   }
 
-  std::unique_lock<std::mutex> lck(participant_info->entity_creation_mutex_);
+  std::lock_guard<std::mutex> lck(participant_info->entity_creation_mutex_);
 
   /////
   // Find and check existing topics and types
@@ -443,16 +443,6 @@ rmw_create_service(
   memcpy(const_cast<char *>(rmw_service->service_name), service_name, strlen(service_name) + 1);
 
   {
-    // It's unnecessary to lock `lck` in current scope.
-    // Unlock `lck` first and re-lock it after exiting the scope can avoid `lock-order-inversion`.
-    // https://github.com/ros2/ros2/issues/1488
-    lck.unlock();
-    auto lock_scope_exit = rcpputils::make_scope_exit(
-      [&lck]() {
-        // lock again for cleanup actions
-        lck.lock();
-      });
-
     // Update graph
     std::lock_guard<std::mutex> guard(common_context->node_update_mutex);
     rmw_gid_t request_subscriber_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(

--- a/rmw_fastrtps_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_subscription.cpp
@@ -113,7 +113,7 @@ rmw_create_subscription(
   auto info = static_cast<CustomSubscriberInfo *>(subscription->data);
 
   // Update graph
-  if (RMW_RET_OK != common_context->update_subscriber_graph(
+  if (RMW_RET_OK != common_context->add_subscriber_graph(
       info->subscription_gid_,
       node->name, node->namespace_))
   {

--- a/rmw_fastrtps_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_subscription.cpp
@@ -100,14 +100,7 @@ rmw_create_subscription(
   // Update graph
   rmw_ret_t rmw_ret = common_context->update_subscriber_graph(
     info->subscription_gid_,
-    node->name, node->namespace_,
-    [](rmw_publisher_t * pub, void * msg) {
-      return rmw_fastrtps_shared_cpp::__rmw_publish(
-        eprosima_fastrtps_identifier,
-        pub,
-        msg,
-        nullptr);
-    }
+    node->name, node->namespace_
   );
 
   if (RMW_RET_OK != rmw_ret) {

--- a/rmw_fastrtps_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_subscription.cpp
@@ -101,7 +101,7 @@ rmw_create_subscription(
   rmw_ret_t rmw_ret = common_context->update_subscriber_graph(
     info->subscription_gid_,
     node->name, node->namespace_,
-    [] (rmw_publisher_t * pub, void * msg) {
+    [](rmw_publisher_t * pub, void * msg) {
       return rmw_fastrtps_shared_cpp::__rmw_publish(
         eprosima_fastrtps_identifier,
         pub,

--- a/rmw_fastrtps_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_subscription.cpp
@@ -21,6 +21,8 @@
 #include "rmw/get_topic_endpoint_info.h"
 #include "rmw/rmw.h"
 
+#include "rcpputils/scope_exit.hpp"
+
 #include "rmw_dds_common/qos.hpp"
 
 #include "rmw_fastrtps_shared_cpp/custom_participant_info.hpp"
@@ -93,33 +95,35 @@ rmw_create_subscription(
   if (!subscription) {
     return nullptr;
   }
+  auto cleanup_subscription = rcpputils::make_scope_exit(
+    [participant_info, subscription]() {
+      rmw_error_state_t error_state = *rmw_get_error_state();
+      rmw_reset_error();
+      if (RMW_RET_OK != rmw_fastrtps_shared_cpp::destroy_subscription(
+        eprosima_fastrtps_identifier, participant_info, subscription))
+      {
+        RMW_SAFE_FWRITE_TO_STDERR(rmw_get_error_string().str);
+        RMW_SAFE_FWRITE_TO_STDERR(" during '" RCUTILS_STRINGIFY(__function__) "' cleanup\n");
+        rmw_reset_error();
+      }
+      rmw_set_error_state(error_state.message, error_state.file, error_state.line_number);
+    });
 
   auto common_context = static_cast<rmw_dds_common::Context *>(node->context->impl->common);
   auto info = static_cast<CustomSubscriberInfo *>(subscription->data);
 
   // Update graph
-  rmw_ret_t rmw_ret = common_context->update_subscriber_graph(
-    info->subscription_gid_,
-    node->name, node->namespace_
-  );
-
-  if (RMW_RET_OK != rmw_ret) {
-    rmw_error_state_t error_state = *rmw_get_error_state();
-    rmw_reset_error();
-    rmw_ret = rmw_fastrtps_shared_cpp::destroy_subscription(
-      eprosima_fastrtps_identifier, participant_info, subscription);
-    if (RMW_RET_OK != rmw_ret) {
-      RMW_SAFE_FWRITE_TO_STDERR(rmw_get_error_string().str);
-      RMW_SAFE_FWRITE_TO_STDERR(" during '" RCUTILS_STRINGIFY(__function__) "' cleanup\n");
-      rmw_reset_error();
-    }
-    rmw_set_error_state(error_state.message, error_state.file, error_state.line_number);
+  if (RMW_RET_OK != common_context->update_subscriber_graph(
+      info->subscription_gid_,
+      node->name, node->namespace_))
+  {
     return nullptr;
   }
 
   info->node_ = node;
   info->common_context_ = common_context;
 
+  cleanup_subscription.cancel();
   return subscription;
 }
 

--- a/rmw_fastrtps_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_subscription.cpp
@@ -97,33 +97,33 @@ rmw_create_subscription(
   auto common_context = static_cast<rmw_dds_common::Context *>(node->context->impl->common);
   auto info = static_cast<CustomSubscriberInfo *>(subscription->data);
 
-  {
-    // Update graph
-    std::lock_guard<std::mutex> guard(common_context->node_update_mutex);
-    rmw_dds_common::msg::ParticipantEntitiesInfo msg =
-      common_context->graph_cache.associate_reader(
-      info->subscription_gid_, common_context->gid, node->name, node->namespace_);
-    rmw_ret_t rmw_ret = rmw_fastrtps_shared_cpp::__rmw_publish(
-      eprosima_fastrtps_identifier,
-      common_context->pub,
-      static_cast<void *>(&msg),
-      nullptr);
-    if (RMW_RET_OK != rmw_ret) {
-      rmw_error_state_t error_state = *rmw_get_error_state();
-      rmw_reset_error();
-      static_cast<void>(common_context->graph_cache.dissociate_reader(
-        info->subscription_gid_, common_context->gid, node->name, node->namespace_));
-      rmw_ret = rmw_fastrtps_shared_cpp::destroy_subscription(
-        eprosima_fastrtps_identifier, participant_info, subscription);
-      if (RMW_RET_OK != rmw_ret) {
-        RMW_SAFE_FWRITE_TO_STDERR(rmw_get_error_string().str);
-        RMW_SAFE_FWRITE_TO_STDERR(" during '" RCUTILS_STRINGIFY(__function__) "' cleanup\n");
-        rmw_reset_error();
-      }
-      rmw_set_error_state(error_state.message, error_state.file, error_state.line_number);
-      return nullptr;
+  // Update graph
+  rmw_ret_t rmw_ret = common_context->update_subscriber_graph(
+    info->subscription_gid_,
+    node->name, node->namespace_,
+    [] (rmw_publisher_t * pub, void * msg) {
+      return rmw_fastrtps_shared_cpp::__rmw_publish(
+        eprosima_fastrtps_identifier,
+        pub,
+        msg,
+        nullptr);
     }
+  );
+
+  if (RMW_RET_OK != rmw_ret) {
+    rmw_error_state_t error_state = *rmw_get_error_state();
+    rmw_reset_error();
+    rmw_ret = rmw_fastrtps_shared_cpp::destroy_subscription(
+      eprosima_fastrtps_identifier, participant_info, subscription);
+    if (RMW_RET_OK != rmw_ret) {
+      RMW_SAFE_FWRITE_TO_STDERR(rmw_get_error_string().str);
+      RMW_SAFE_FWRITE_TO_STDERR(" during '" RCUTILS_STRINGIFY(__function__) "' cleanup\n");
+      rmw_reset_error();
+    }
+    rmw_set_error_state(error_state.message, error_state.file, error_state.line_number);
+    return nullptr;
   }
+
   info->node_ = node;
   info->common_context_ = common_context;
 

--- a/rmw_fastrtps_dynamic_cpp/src/init_rmw_context_impl.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/init_rmw_context_impl.cpp
@@ -159,7 +159,7 @@ init_context_impl(
   common_context->gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
     eprosima_fastrtps_identifier, participant_info->participant_->guid());
   common_context->pub = publisher.get();
-  common_context->publish_callback = [](rmw_publisher_t * pub, void * msg) {
+  common_context->publish_callback = [](const rmw_publisher_t * pub, const void * msg) {
       return rmw_fastrtps_shared_cpp::__rmw_publish(
         eprosima_fastrtps_identifier,
         pub,

--- a/rmw_fastrtps_dynamic_cpp/src/init_rmw_context_impl.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/init_rmw_context_impl.cpp
@@ -159,6 +159,13 @@ init_context_impl(
   common_context->gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
     eprosima_fastrtps_identifier, participant_info->participant_->guid());
   common_context->pub = publisher.get();
+  common_context->publish_callback = [](rmw_publisher_t * pub, void * msg) {
+      return rmw_fastrtps_shared_cpp::__rmw_publish(
+        eprosima_fastrtps_identifier,
+        pub,
+        msg,
+        nullptr);
+    };
   common_context->sub = subscription.get();
   common_context->graph_guard_condition = graph_guard_condition.get();
 

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
@@ -480,7 +480,7 @@ rmw_create_client(
   rmw_ret_t rmw_ret = common_context->update_client_graph(
     request_publisher_gid, response_subscriber_gid,
     node->name, node->namespace_,
-    [] (rmw_publisher_t * pub, void * msg) {
+    [](rmw_publisher_t * pub, void * msg) {
       return rmw_fastrtps_shared_cpp::__rmw_publish(
         eprosima_fastrtps_identifier,
         pub,

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
@@ -471,40 +471,26 @@ rmw_create_client(
   }
   memcpy(const_cast<char *>(rmw_client->service_name), service_name, strlen(service_name) + 1);
 
-  {
-    // Update graph
-    std::lock_guard<std::mutex> guard(common_context->node_update_mutex);
-    rmw_gid_t request_publisher_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
-      eprosima_fastrtps_identifier, info->request_writer_->guid());
-    common_context->graph_cache.associate_writer(
-      request_publisher_gid,
-      common_context->gid,
-      node->name,
-      node->namespace_);
+  // Update graph
+  rmw_gid_t request_publisher_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
+    eprosima_fastrtps_identifier, info->request_writer_->guid());
+  rmw_gid_t response_subscriber_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
+    eprosima_fastrtps_identifier, info->response_reader_->guid());
 
-    rmw_gid_t response_subscriber_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
-      eprosima_fastrtps_identifier, info->response_reader_->guid());
-    rmw_dds_common::msg::ParticipantEntitiesInfo msg =
-      common_context->graph_cache.associate_reader(
-      response_subscriber_gid, common_context->gid, node->name, node->namespace_);
-    rmw_ret_t rmw_ret = rmw_fastrtps_shared_cpp::__rmw_publish(
-      eprosima_fastrtps_identifier,
-      common_context->pub,
-      static_cast<void *>(&msg),
-      nullptr);
-    if (RMW_RET_OK != rmw_ret) {
-      common_context->graph_cache.dissociate_reader(
-        response_subscriber_gid,
-        common_context->gid,
-        node->name,
-        node->namespace_);
-      common_context->graph_cache.dissociate_writer(
-        request_publisher_gid,
-        common_context->gid,
-        node->name,
-        node->namespace_);
-      return nullptr;
+  rmw_ret_t rmw_ret = common_context->update_client_graph(
+    request_publisher_gid, response_subscriber_gid,
+    node->name, node->namespace_,
+    [] (rmw_publisher_t * pub, void * msg) {
+      return rmw_fastrtps_shared_cpp::__rmw_publish(
+        eprosima_fastrtps_identifier,
+        pub,
+        msg,
+        nullptr);
     }
+  );
+
+  if (RMW_RET_OK != rmw_ret) {
+    return nullptr;
   }
 
   cleanup_rmw_client.cancel();

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
@@ -479,14 +479,7 @@ rmw_create_client(
 
   rmw_ret_t rmw_ret = common_context->update_client_graph(
     request_publisher_gid, response_subscriber_gid,
-    node->name, node->namespace_,
-    [](rmw_publisher_t * pub, void * msg) {
-      return rmw_fastrtps_shared_cpp::__rmw_publish(
-        eprosima_fastrtps_identifier,
-        pub,
-        msg,
-        nullptr);
-    }
+    node->name, node->namespace_
   );
 
   if (RMW_RET_OK != rmw_ret) {

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
@@ -476,7 +476,7 @@ rmw_create_client(
     eprosima_fastrtps_identifier, info->request_writer_->guid());
   rmw_gid_t response_subscriber_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
     eprosima_fastrtps_identifier, info->response_reader_->guid());
-  if (RMW_RET_OK != common_context->update_client_graph(
+  if (RMW_RET_OK != common_context->add_client_graph(
       request_publisher_gid, response_subscriber_gid,
       node->name, node->namespace_))
   {

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
@@ -476,13 +476,10 @@ rmw_create_client(
     eprosima_fastrtps_identifier, info->request_writer_->guid());
   rmw_gid_t response_subscriber_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
     eprosima_fastrtps_identifier, info->response_reader_->guid());
-
-  rmw_ret_t rmw_ret = common_context->update_client_graph(
-    request_publisher_gid, response_subscriber_gid,
-    node->name, node->namespace_
-  );
-
-  if (RMW_RET_OK != rmw_ret) {
+  if (RMW_RET_OK != common_context->update_client_graph(
+      request_publisher_gid, response_subscriber_gid,
+      node->name, node->namespace_))
+  {
     return nullptr;
   }
 

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
@@ -135,7 +135,7 @@ rmw_create_client(
     }
   }
 
-  std::unique_lock<std::mutex> lck(participant_info->entity_creation_mutex_);
+  std::lock_guard<std::mutex> lck(participant_info->entity_creation_mutex_);
 
   /////
   // Find and check existing topics and types
@@ -472,16 +472,6 @@ rmw_create_client(
   memcpy(const_cast<char *>(rmw_client->service_name), service_name, strlen(service_name) + 1);
 
   {
-    // It's unnecessary to lock `lck` in current scope.
-    // Unlock `lck` first and re-lock it after exiting the scope can avoid `lock-order-inversion`.
-    // https://github.com/ros2/ros2/issues/1488
-    lck.unlock();
-    auto lock_scope_exit = rcpputils::make_scope_exit(
-      [&lck]() {
-        // lock again for cleanup actions
-        lck.lock();
-      });
-
     // Update graph
     std::lock_guard<std::mutex> guard(common_context->node_update_mutex);
     rmw_gid_t request_publisher_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_publisher.cpp
@@ -108,7 +108,7 @@ rmw_create_publisher(
   rmw_ret_t rmw_ret = common_context->update_publisher_graph(
     info->publisher_gid,
     node->name, node->namespace_,
-    [] (rmw_publisher_t * pub, void * msg) {
+    [](rmw_publisher_t * pub, void * msg) {
       return rmw_fastrtps_shared_cpp::__rmw_publish(
         eprosima_fastrtps_identifier,
         pub,

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_publisher.cpp
@@ -116,7 +116,6 @@ rmw_create_publisher(
     });
 
   auto common_context = static_cast<rmw_dds_common::Context *>(node->context->impl->common);
-
   auto info = static_cast<const CustomPublisherInfo *>(publisher->data);
 
   // Update graph

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_publisher.cpp
@@ -103,33 +103,34 @@ rmw_create_publisher(
   auto common_context = static_cast<rmw_dds_common::Context *>(node->context->impl->common);
 
   auto info = static_cast<const CustomPublisherInfo *>(publisher->data);
-  {
-    // Update graph
-    std::lock_guard<std::mutex> guard(common_context->node_update_mutex);
-    rmw_dds_common::msg::ParticipantEntitiesInfo msg =
-      common_context->graph_cache.associate_writer(
-      info->publisher_gid, common_context->gid, node->name, node->namespace_);
-    rmw_ret_t rmw_ret = rmw_fastrtps_shared_cpp::__rmw_publish(
-      eprosima_fastrtps_identifier,
-      common_context->pub,
-      static_cast<void *>(&msg),
-      nullptr);
-    if (RMW_RET_OK != rmw_ret) {
-      rmw_error_state_t error_state = *rmw_get_error_state();
-      rmw_reset_error();
-      static_cast<void>(common_context->graph_cache.dissociate_writer(
-        info->publisher_gid, common_context->gid, node->name, node->namespace_));
-      rmw_ret = rmw_fastrtps_shared_cpp::destroy_publisher(
-        eprosima_fastrtps_identifier, participant_info, publisher);
-      if (RMW_RET_OK != rmw_ret) {
-        RMW_SAFE_FWRITE_TO_STDERR(rmw_get_error_string().str);
-        RMW_SAFE_FWRITE_TO_STDERR(" during '" RCUTILS_STRINGIFY(__function__) "' cleanup\n");
-        rmw_reset_error();
-      }
-      rmw_set_error_state(error_state.message, error_state.file, error_state.line_number);
-      return nullptr;
+
+  // Update graph
+  rmw_ret_t rmw_ret = common_context->update_publisher_graph(
+    info->publisher_gid,
+    node->name, node->namespace_,
+    [] (rmw_publisher_t * pub, void * msg) {
+      return rmw_fastrtps_shared_cpp::__rmw_publish(
+        eprosima_fastrtps_identifier,
+        pub,
+        msg,
+        nullptr);
     }
+  );
+
+  if (RMW_RET_OK != rmw_ret) {
+    rmw_error_state_t error_state = *rmw_get_error_state();
+    rmw_reset_error();
+    rmw_ret = rmw_fastrtps_shared_cpp::destroy_publisher(
+      eprosima_fastrtps_identifier, participant_info, publisher);
+    if (RMW_RET_OK != rmw_ret) {
+      RMW_SAFE_FWRITE_TO_STDERR(rmw_get_error_string().str);
+      RMW_SAFE_FWRITE_TO_STDERR(" during '" RCUTILS_STRINGIFY(__function__) "' cleanup\n");
+      rmw_reset_error();
+    }
+    rmw_set_error_state(error_state.message, error_state.file, error_state.line_number);
+    return nullptr;
   }
+
   return publisher;
 }
 

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_publisher.cpp
@@ -120,7 +120,7 @@ rmw_create_publisher(
   auto info = static_cast<const CustomPublisherInfo *>(publisher->data);
 
   // Update graph
-  if (RMW_RET_OK != common_context->update_publisher_graph(
+  if (RMW_RET_OK != common_context->add_publisher_graph(
       info->publisher_gid,
       node->name, node->namespace_))
   {

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_publisher.cpp
@@ -107,14 +107,7 @@ rmw_create_publisher(
   // Update graph
   rmw_ret_t rmw_ret = common_context->update_publisher_graph(
     info->publisher_gid,
-    node->name, node->namespace_,
-    [](rmw_publisher_t * pub, void * msg) {
-      return rmw_fastrtps_shared_cpp::__rmw_publish(
-        eprosima_fastrtps_identifier,
-        pub,
-        msg,
-        nullptr);
-    }
+    node->name, node->namespace_
   );
 
   if (RMW_RET_OK != rmw_ret) {

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
@@ -471,40 +471,25 @@ rmw_create_service(
   }
   memcpy(const_cast<char *>(rmw_service->service_name), service_name, strlen(service_name) + 1);
 
-  {
-    // Update graph
-    std::lock_guard<std::mutex> guard(common_context->node_update_mutex);
-    rmw_gid_t request_subscriber_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
-      eprosima_fastrtps_identifier, info->request_reader_->guid());
-    common_context->graph_cache.associate_reader(
-      request_subscriber_gid,
-      common_context->gid,
-      node->name,
-      node->namespace_);
-
-    rmw_gid_t response_publisher_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
-      eprosima_fastrtps_identifier, info->response_writer_->guid());
-    rmw_dds_common::msg::ParticipantEntitiesInfo msg =
-      common_context->graph_cache.associate_writer(
-      response_publisher_gid, common_context->gid, node->name, node->namespace_);
-    rmw_ret_t rmw_ret = rmw_fastrtps_shared_cpp::__rmw_publish(
-      eprosima_fastrtps_identifier,
-      common_context->pub,
-      static_cast<void *>(&msg),
-      nullptr);
-    if (RMW_RET_OK != rmw_ret) {
-      common_context->graph_cache.dissociate_writer(
-        response_publisher_gid,
-        common_context->gid,
-        node->name,
-        node->namespace_);
-      common_context->graph_cache.dissociate_reader(
-        request_subscriber_gid,
-        common_context->gid,
-        node->name,
-        node->namespace_);
-      return nullptr;
+  // Update graph
+  rmw_gid_t request_subscriber_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
+    eprosima_fastrtps_identifier, info->request_reader_->guid());
+  rmw_gid_t response_publisher_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
+    eprosima_fastrtps_identifier, info->response_writer_->guid());
+  rmw_ret_t rmw_ret = common_context->update_service_graph(
+    request_subscriber_gid, response_publisher_gid,
+    node->name, node->namespace_,
+    [] (rmw_publisher_t * pub, void * msg) {
+      return rmw_fastrtps_shared_cpp::__rmw_publish(
+        eprosima_fastrtps_identifier,
+        pub,
+        msg,
+        nullptr);
     }
+  );
+
+  if (RMW_RET_OK != rmw_ret) {
+    return nullptr;
   }
 
   cleanup_rmw_service.cancel();

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
@@ -479,7 +479,7 @@ rmw_create_service(
   rmw_ret_t rmw_ret = common_context->update_service_graph(
     request_subscriber_gid, response_publisher_gid,
     node->name, node->namespace_,
-    [] (rmw_publisher_t * pub, void * msg) {
+    [](rmw_publisher_t * pub, void * msg) {
       return rmw_fastrtps_shared_cpp::__rmw_publish(
         eprosima_fastrtps_identifier,
         pub,

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
@@ -476,12 +476,10 @@ rmw_create_service(
     eprosima_fastrtps_identifier, info->request_reader_->guid());
   rmw_gid_t response_publisher_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
     eprosima_fastrtps_identifier, info->response_writer_->guid());
-  rmw_ret_t rmw_ret = common_context->update_service_graph(
-    request_subscriber_gid, response_publisher_gid,
-    node->name, node->namespace_
-  );
-
-  if (RMW_RET_OK != rmw_ret) {
+  if (RMW_RET_OK != common_context->update_service_graph(
+      request_subscriber_gid, response_publisher_gid,
+      node->name, node->namespace_))
+  {
     return nullptr;
   }
 

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
@@ -143,7 +143,7 @@ rmw_create_service(
     }
   }
 
-  std::lock_guard<std::mutex> lck(participant_info->entity_creation_mutex_);
+  std::unique_lock<std::mutex> lck(participant_info->entity_creation_mutex_);
 
   /////
   // Find and check existing topics and types
@@ -472,6 +472,16 @@ rmw_create_service(
   memcpy(const_cast<char *>(rmw_service->service_name), service_name, strlen(service_name) + 1);
 
   {
+    // It's unnecessary to lock `lck` in current scope.
+    // Unlock `lck` first and re-lock it after exiting the scope can avoid `lock-order-inversion`.
+    // https://github.com/ros2/ros2/issues/1488
+    lck.unlock();
+    auto lock_scope_exit = rcpputils::make_scope_exit(
+      [&lck]() {
+        // lock again for cleanup actions
+        lck.lock();
+      });
+
     // Update graph
     std::lock_guard<std::mutex> guard(common_context->node_update_mutex);
     rmw_gid_t request_subscriber_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
@@ -476,7 +476,7 @@ rmw_create_service(
     eprosima_fastrtps_identifier, info->request_reader_->guid());
   rmw_gid_t response_publisher_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
     eprosima_fastrtps_identifier, info->response_writer_->guid());
-  if (RMW_RET_OK != common_context->update_service_graph(
+  if (RMW_RET_OK != common_context->add_service_graph(
       request_subscriber_gid, response_publisher_gid,
       node->name, node->namespace_))
   {

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
@@ -143,7 +143,7 @@ rmw_create_service(
     }
   }
 
-  std::unique_lock<std::mutex> lck(participant_info->entity_creation_mutex_);
+  std::lock_guard<std::mutex> lck(participant_info->entity_creation_mutex_);
 
   /////
   // Find and check existing topics and types
@@ -472,16 +472,6 @@ rmw_create_service(
   memcpy(const_cast<char *>(rmw_service->service_name), service_name, strlen(service_name) + 1);
 
   {
-    // It's unnecessary to lock `lck` in current scope.
-    // Unlock `lck` first and re-lock it after exiting the scope can avoid `lock-order-inversion`.
-    // https://github.com/ros2/ros2/issues/1488
-    lck.unlock();
-    auto lock_scope_exit = rcpputils::make_scope_exit(
-      [&lck]() {
-        // lock again for cleanup actions
-        lck.lock();
-      });
-
     // Update graph
     std::lock_guard<std::mutex> guard(common_context->node_update_mutex);
     rmw_gid_t request_subscriber_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
@@ -478,14 +478,7 @@ rmw_create_service(
     eprosima_fastrtps_identifier, info->response_writer_->guid());
   rmw_ret_t rmw_ret = common_context->update_service_graph(
     request_subscriber_gid, response_publisher_gid,
-    node->name, node->namespace_,
-    [](rmw_publisher_t * pub, void * msg) {
-      return rmw_fastrtps_shared_cpp::__rmw_publish(
-        eprosima_fastrtps_identifier,
-        pub,
-        msg,
-        nullptr);
-    }
+    node->name, node->namespace_
   );
 
   if (RMW_RET_OK != rmw_ret) {

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_subscription.cpp
@@ -103,14 +103,7 @@ rmw_create_subscription(
   // Update graph
   rmw_ret_t rmw_ret = common_context->update_subscriber_graph(
     info->subscription_gid_,
-    node->name, node->namespace_,
-    [](rmw_publisher_t * pub, void * msg) {
-      return rmw_fastrtps_shared_cpp::__rmw_publish(
-        eprosima_fastrtps_identifier,
-        pub,
-        msg,
-        nullptr);
-    }
+    node->name, node->namespace_
   );
 
   if (RMW_RET_OK != rmw_ret) {

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_subscription.cpp
@@ -99,33 +99,34 @@ rmw_create_subscription(
 
   auto common_context = static_cast<rmw_dds_common::Context *>(node->context->impl->common);
   auto info = static_cast<CustomSubscriberInfo *>(subscription->data);
-  {
-    // Update graph
-    std::lock_guard<std::mutex> guard(common_context->node_update_mutex);
-    rmw_dds_common::msg::ParticipantEntitiesInfo msg =
-      common_context->graph_cache.associate_reader(
-      info->subscription_gid_, common_context->gid, node->name, node->namespace_);
-    rmw_ret_t rmw_ret = rmw_fastrtps_shared_cpp::__rmw_publish(
-      eprosima_fastrtps_identifier,
-      common_context->pub,
-      static_cast<void *>(&msg),
-      nullptr);
-    if (RMW_RET_OK != rmw_ret) {
-      rmw_error_state_t error_state = *rmw_get_error_state();
-      rmw_reset_error();
-      static_cast<void>(common_context->graph_cache.dissociate_reader(
-        info->subscription_gid_, common_context->gid, node->name, node->namespace_));
-      rmw_ret = rmw_fastrtps_shared_cpp::destroy_subscription(
-        eprosima_fastrtps_identifier, participant_info, subscription);
-      if (RMW_RET_OK != rmw_ret) {
-        RMW_SAFE_FWRITE_TO_STDERR(rmw_get_error_string().str);
-        RMW_SAFE_FWRITE_TO_STDERR(" during '" RCUTILS_STRINGIFY(__function__) "' cleanup\n");
-        rmw_reset_error();
-      }
-      rmw_set_error_state(error_state.message, error_state.file, error_state.line_number);
-      return nullptr;
+
+  // Update graph
+  rmw_ret_t rmw_ret = common_context->update_subscriber_graph(
+    info->subscription_gid_,
+    node->name, node->namespace_,
+    [] (rmw_publisher_t * pub, void * msg) {
+      return rmw_fastrtps_shared_cpp::__rmw_publish(
+        eprosima_fastrtps_identifier,
+        pub,
+        msg,
+        nullptr);
     }
+  );
+
+  if (RMW_RET_OK != rmw_ret) {
+    rmw_error_state_t error_state = *rmw_get_error_state();
+    rmw_reset_error();
+    rmw_ret = rmw_fastrtps_shared_cpp::destroy_subscription(
+      eprosima_fastrtps_identifier, participant_info, subscription);
+    if (RMW_RET_OK != rmw_ret) {
+      RMW_SAFE_FWRITE_TO_STDERR(rmw_get_error_string().str);
+      RMW_SAFE_FWRITE_TO_STDERR(" during '" RCUTILS_STRINGIFY(__function__) "' cleanup\n");
+      rmw_reset_error();
+    }
+    rmw_set_error_state(error_state.message, error_state.file, error_state.line_number);
+    return nullptr;
   }
+
   info->node_ = node;
   info->common_context_ = common_context;
 

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_subscription.cpp
@@ -116,7 +116,7 @@ rmw_create_subscription(
   auto info = static_cast<CustomSubscriberInfo *>(subscription->data);
 
   // Update graph
-  if (RMW_RET_OK != common_context->update_subscriber_graph(
+  if (RMW_RET_OK != common_context->add_subscriber_graph(
       info->subscription_gid_,
       node->name, node->namespace_))
   {

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_subscription.cpp
@@ -104,7 +104,7 @@ rmw_create_subscription(
   rmw_ret_t rmw_ret = common_context->update_subscriber_graph(
     info->subscription_gid_,
     node->name, node->namespace_,
-    [] (rmw_publisher_t * pub, void * msg) {
+    [](rmw_publisher_t * pub, void * msg) {
       return rmw_fastrtps_shared_cpp::__rmw_publish(
         eprosima_fastrtps_identifier,
         pub,

--- a/rmw_fastrtps_shared_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_client.cpp
@@ -44,27 +44,22 @@ __rmw_destroy_client(
     static_cast<CustomParticipantInfo *>(node->context->impl->participant_info);
   auto info = static_cast<CustomClientInfo *>(client->data);
 
-  {
-    // Update graph
-    std::lock_guard<std::mutex> guard(common_context->node_update_mutex);
-    rmw_gid_t gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
-      identifier, info->request_writer_->guid());
-    common_context->graph_cache.dissociate_writer(
-      gid,
-      common_context->gid,
-      node->name,
-      node->namespace_);
-    gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
-      identifier, info->response_reader_->guid());
-    rmw_dds_common::msg::ParticipantEntitiesInfo msg =
-      common_context->graph_cache.dissociate_reader(
-      gid, common_context->gid, node->name, node->namespace_);
-    final_ret = rmw_fastrtps_shared_cpp::__rmw_publish(
-      identifier,
-      common_context->pub,
-      static_cast<void *>(&msg),
-      nullptr);
-  }
+  // Update graph
+  rmw_gid_t request_publisher_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
+    identifier, info->request_writer_->guid());
+  rmw_gid_t response_subscriber_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
+    identifier, info->response_reader_->guid());
+  final_ret = common_context->destroy_client_graph(
+    request_publisher_gid, response_subscriber_gid,
+    node->name, node->namespace_,
+    [identifier] (rmw_publisher_t * pub, void * msg) {
+      return rmw_fastrtps_shared_cpp::__rmw_publish(
+        identifier,
+        pub,
+        msg,
+        nullptr);
+    }
+  );
 
   auto show_previous_error =
     [&final_ret]()

--- a/rmw_fastrtps_shared_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_client.cpp
@@ -52,7 +52,7 @@ __rmw_destroy_client(
   final_ret = common_context->destroy_client_graph(
     request_publisher_gid, response_subscriber_gid,
     node->name, node->namespace_,
-    [identifier] (rmw_publisher_t * pub, void * msg) {
+    [identifier](rmw_publisher_t * pub, void * msg) {
       return rmw_fastrtps_shared_cpp::__rmw_publish(
         identifier,
         pub,

--- a/rmw_fastrtps_shared_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_client.cpp
@@ -51,14 +51,7 @@ __rmw_destroy_client(
     identifier, info->response_reader_->guid());
   final_ret = common_context->destroy_client_graph(
     request_publisher_gid, response_subscriber_gid,
-    node->name, node->namespace_,
-    [identifier](rmw_publisher_t * pub, void * msg) {
-      return rmw_fastrtps_shared_cpp::__rmw_publish(
-        identifier,
-        pub,
-        msg,
-        nullptr);
-    }
+    node->name, node->namespace_
   );
 
   auto show_previous_error =

--- a/rmw_fastrtps_shared_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_client.cpp
@@ -49,7 +49,7 @@ __rmw_destroy_client(
     identifier, info->request_writer_->guid());
   rmw_gid_t response_subscriber_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
     identifier, info->response_reader_->guid());
-  final_ret = common_context->destroy_client_graph(
+  final_ret = common_context->remove_client_graph(
     request_publisher_gid, response_subscriber_gid,
     node->name, node->namespace_
   );

--- a/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
@@ -108,14 +108,7 @@ __rmw_create_node(
   // node1-update-get-message / node2-update-get-message / node2-publish / node1-publish
   // In that case, the last message published is not accurate.
   rmw_ret_t rmw_ret = common_context->update_node_graph(
-    name, namespace_,
-    [identifier = node_handle->implementation_identifier](rmw_publisher_t * pub, void * msg) {
-      return __rmw_publish(
-        identifier,
-        pub,
-        msg,
-        nullptr);
-    }
+    name, namespace_
   );
   if (RMW_RET_OK != rmw_ret) {
     return nullptr;
@@ -134,14 +127,7 @@ __rmw_destroy_node(
   rmw_ret_t ret = RMW_RET_OK;
   auto common_context = static_cast<rmw_dds_common::Context *>(node->context->impl->common);
   ret = common_context->destroy_node_graph(
-    node->name, node->namespace_,
-    [identifier](rmw_publisher_t * pub, void * msg) {
-      return __rmw_publish(
-        identifier,
-        pub,
-        msg,
-        nullptr);
-    }
+    node->name, node->namespace_
   );
   rmw_free(const_cast<char *>(node->name));
   rmw_free(const_cast<char *>(node->namespace_));

--- a/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
@@ -102,11 +102,6 @@ __rmw_create_node(
 
   node_handle->context = context;
 
-  // Though graph_cache methods are thread safe, both cache update and publishing have to also
-  // be atomic.
-  // If not, the following race condition is possible:
-  // node1-update-get-message / node2-update-get-message / node2-publish / node1-publish
-  // In that case, the last message published is not accurate.
   rmw_ret_t rmw_ret = common_context->add_node_graph(
     name, namespace_
   );

--- a/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
@@ -107,7 +107,7 @@ __rmw_create_node(
   // If not, the following race condition is possible:
   // node1-update-get-message / node2-update-get-message / node2-publish / node1-publish
   // In that case, the last message published is not accurate.
-  rmw_ret_t rmw_ret = common_context->update_node_graph(
+  rmw_ret_t rmw_ret = common_context->add_node_graph(
     name, namespace_
   );
   if (RMW_RET_OK != rmw_ret) {
@@ -126,7 +126,7 @@ __rmw_destroy_node(
   assert(node->implementation_identifier == identifier);
   rmw_ret_t ret = RMW_RET_OK;
   auto common_context = static_cast<rmw_dds_common::Context *>(node->context->impl->common);
-  ret = common_context->destroy_node_graph(
+  ret = common_context->remove_node_graph(
     node->name, node->namespace_
   );
   rmw_free(const_cast<char *>(node->name));

--- a/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
@@ -109,7 +109,7 @@ __rmw_create_node(
   // In that case, the last message published is not accurate.
   rmw_ret_t rmw_ret = common_context->update_node_graph(
     name, namespace_,
-    [identifier=node_handle->implementation_identifier] (rmw_publisher_t * pub, void * msg) {
+    [identifier = node_handle->implementation_identifier](rmw_publisher_t * pub, void * msg) {
       return __rmw_publish(
         identifier,
         pub,
@@ -135,7 +135,7 @@ __rmw_destroy_node(
   auto common_context = static_cast<rmw_dds_common::Context *>(node->context->impl->common);
   ret = common_context->destroy_node_graph(
     node->name, node->namespace_,
-    [identifier] (rmw_publisher_t * pub, void * msg) {
+    [identifier](rmw_publisher_t * pub, void * msg) {
       return __rmw_publish(
         identifier,
         pub,

--- a/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
@@ -70,7 +70,6 @@ __rmw_create_node(
   }
 
   auto common_context = static_cast<rmw_dds_common::Context *>(context->impl->common);
-  rmw_dds_common::GraphCache & graph_cache = common_context->graph_cache;
   rmw_node_t * node_handle = rmw_node_allocate();
   if (nullptr == node_handle) {
     RMW_SET_ERROR_MSG("failed to allocate node");
@@ -103,24 +102,25 @@ __rmw_create_node(
 
   node_handle->context = context;
 
-  {
-    // Though graph_cache methods are thread safe, both cache update and publishing have to also
-    // be atomic.
-    // If not, the following race condition is possible:
-    // node1-update-get-message / node2-update-get-message / node2-publish / node1-publish
-    // In that case, the last message published is not accurate.
-    std::lock_guard<std::mutex> guard(common_context->node_update_mutex);
-    rmw_dds_common::msg::ParticipantEntitiesInfo participant_msg =
-      graph_cache.add_node(common_context->gid, name, namespace_);
-    if (RMW_RET_OK != __rmw_publish(
-        node_handle->implementation_identifier,
-        common_context->pub,
-        static_cast<void *>(&participant_msg),
-        nullptr))
-    {
-      return nullptr;
+  // Though graph_cache methods are thread safe, both cache update and publishing have to also
+  // be atomic.
+  // If not, the following race condition is possible:
+  // node1-update-get-message / node2-update-get-message / node2-publish / node1-publish
+  // In that case, the last message published is not accurate.
+  rmw_ret_t rmw_ret = common_context->update_node_graph(
+    name, namespace_,
+    [identifier=node_handle->implementation_identifier] (rmw_publisher_t * pub, void * msg) {
+      return __rmw_publish(
+        identifier,
+        pub,
+        msg,
+        nullptr);
     }
+  );
+  if (RMW_RET_OK != rmw_ret) {
+    return nullptr;
   }
+
   cleanup_node.cancel();
   return node_handle;
 }
@@ -133,17 +133,16 @@ __rmw_destroy_node(
   assert(node->implementation_identifier == identifier);
   rmw_ret_t ret = RMW_RET_OK;
   auto common_context = static_cast<rmw_dds_common::Context *>(node->context->impl->common);
-  rmw_dds_common::GraphCache & graph_cache = common_context->graph_cache;
-  {
-    std::lock_guard<std::mutex> guard(common_context->node_update_mutex);
-    rmw_dds_common::msg::ParticipantEntitiesInfo participant_msg =
-      graph_cache.remove_node(common_context->gid, node->name, node->namespace_);
-    ret = __rmw_publish(
-      identifier,
-      common_context->pub,
-      static_cast<void *>(&participant_msg),
-      nullptr);
-  }
+  ret = common_context->destroy_node_graph(
+    node->name, node->namespace_,
+    [identifier] (rmw_publisher_t * pub, void * msg) {
+      return __rmw_publish(
+        identifier,
+        pub,
+        msg,
+        nullptr);
+    }
+  );
   rmw_free(const_cast<char *>(node->name));
   rmw_free(const_cast<char *>(node->namespace_));
   rmw_node_free(node);

--- a/rmw_fastrtps_shared_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_publisher.cpp
@@ -54,7 +54,7 @@ __rmw_destroy_publisher(
   rmw_ret_t rmw_ret = common_context->destroy_publisher_graph(
     info->publisher_gid,
     node->name, node->namespace_,
-    [identifier] (rmw_publisher_t * pub, void * msg) {
+    [identifier](rmw_publisher_t * pub, void * msg) {
       return rmw_fastrtps_shared_cpp::__rmw_publish(
         identifier,
         pub,

--- a/rmw_fastrtps_shared_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_publisher.cpp
@@ -51,7 +51,7 @@ __rmw_destroy_publisher(
   auto info = static_cast<const CustomPublisherInfo *>(publisher->data);
 
   // Update graph
-  rmw_ret_t rmw_ret = common_context->destroy_publisher_graph(
+  rmw_ret_t rmw_ret = common_context->remove_publisher_graph(
     info->publisher_gid,
     node->name, node->namespace_
   );

--- a/rmw_fastrtps_shared_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_publisher.cpp
@@ -49,22 +49,23 @@ __rmw_destroy_publisher(
   rmw_error_state_t error_state;
   auto common_context = static_cast<rmw_dds_common::Context *>(node->context->impl->common);
   auto info = static_cast<const CustomPublisherInfo *>(publisher->data);
-  {
-    // Update graph
-    std::lock_guard<std::mutex> guard(common_context->node_update_mutex);
-    rmw_dds_common::msg::ParticipantEntitiesInfo msg =
-      common_context->graph_cache.dissociate_writer(
-      info->publisher_gid, common_context->gid, node->name, node->namespace_);
-    rmw_ret_t publish_ret = rmw_fastrtps_shared_cpp::__rmw_publish(
-      identifier,
-      common_context->pub,
-      &msg,
-      nullptr);
-    if (RMW_RET_OK != publish_ret) {
-      error_state = *rmw_get_error_state();
-      ret = publish_ret;
-      rmw_reset_error();
+
+  // Update graph
+  rmw_ret_t rmw_ret = common_context->destroy_publisher_graph(
+    info->publisher_gid,
+    node->name, node->namespace_,
+    [identifier] (rmw_publisher_t * pub, void * msg) {
+      return rmw_fastrtps_shared_cpp::__rmw_publish(
+        identifier,
+        pub,
+        msg,
+        nullptr);
     }
+  );
+  if (RMW_RET_OK != rmw_ret) {
+    error_state = *rmw_get_error_state();
+    ret = rmw_ret;
+    rmw_reset_error();
   }
 
   auto participant_info =

--- a/rmw_fastrtps_shared_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_publisher.cpp
@@ -53,14 +53,7 @@ __rmw_destroy_publisher(
   // Update graph
   rmw_ret_t rmw_ret = common_context->destroy_publisher_graph(
     info->publisher_gid,
-    node->name, node->namespace_,
-    [identifier](rmw_publisher_t * pub, void * msg) {
-      return rmw_fastrtps_shared_cpp::__rmw_publish(
-        identifier,
-        pub,
-        msg,
-        nullptr);
-    }
+    node->name, node->namespace_
   );
   if (RMW_RET_OK != rmw_ret) {
     error_state = *rmw_get_error_state();

--- a/rmw_fastrtps_shared_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_service.cpp
@@ -56,27 +56,23 @@ __rmw_destroy_service(
   auto participant_info =
     static_cast<CustomParticipantInfo *>(node->context->impl->participant_info);
   auto info = static_cast<CustomServiceInfo *>(service->data);
-  {
-    // Update graph
-    std::lock_guard<std::mutex> guard(common_context->node_update_mutex);
-    rmw_gid_t gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
-      identifier, info->request_reader_->guid());
-    common_context->graph_cache.dissociate_reader(
-      gid,
-      common_context->gid,
-      node->name,
-      node->namespace_);
-    gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
-      identifier, info->response_writer_->guid());
-    rmw_dds_common::msg::ParticipantEntitiesInfo msg =
-      common_context->graph_cache.dissociate_writer(
-      gid, common_context->gid, node->name, node->namespace_);
-    final_ret = rmw_fastrtps_shared_cpp::__rmw_publish(
-      identifier,
-      common_context->pub,
-      static_cast<void *>(&msg),
-      nullptr);
-  }
+
+  // Update graph
+  rmw_gid_t request_subscriber_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
+    identifier, info->request_reader_->guid());
+  rmw_gid_t response_publisher_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
+    identifier, info->response_writer_->guid());
+  final_ret = common_context->destroy_service_graph(
+    request_subscriber_gid, response_publisher_gid,
+    node->name, node->namespace_,
+    [identifier] (rmw_publisher_t * pub, void * msg) {
+      return rmw_fastrtps_shared_cpp::__rmw_publish(
+        identifier,
+        pub,
+        msg,
+        nullptr);
+    }
+  );
 
   auto show_previous_error =
     [&final_ret]()

--- a/rmw_fastrtps_shared_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_service.cpp
@@ -62,7 +62,7 @@ __rmw_destroy_service(
     identifier, info->request_reader_->guid());
   rmw_gid_t response_publisher_gid = rmw_fastrtps_shared_cpp::create_rmw_gid(
     identifier, info->response_writer_->guid());
-  final_ret = common_context->destroy_service_graph(
+  final_ret = common_context->remove_service_graph(
     request_subscriber_gid, response_publisher_gid,
     node->name, node->namespace_
   );

--- a/rmw_fastrtps_shared_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_service.cpp
@@ -64,14 +64,7 @@ __rmw_destroy_service(
     identifier, info->response_writer_->guid());
   final_ret = common_context->destroy_service_graph(
     request_subscriber_gid, response_publisher_gid,
-    node->name, node->namespace_,
-    [identifier](rmw_publisher_t * pub, void * msg) {
-      return rmw_fastrtps_shared_cpp::__rmw_publish(
-        identifier,
-        pub,
-        msg,
-        nullptr);
-    }
+    node->name, node->namespace_
   );
 
   auto show_previous_error =

--- a/rmw_fastrtps_shared_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_service.cpp
@@ -65,7 +65,7 @@ __rmw_destroy_service(
   final_ret = common_context->destroy_service_graph(
     request_subscriber_gid, response_publisher_gid,
     node->name, node->namespace_,
-    [identifier] (rmw_publisher_t * pub, void * msg) {
+    [identifier](rmw_publisher_t * pub, void * msg) {
       return rmw_fastrtps_shared_cpp::__rmw_publish(
         identifier,
         pub,

--- a/rmw_fastrtps_shared_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_subscription.cpp
@@ -55,14 +55,7 @@ __rmw_destroy_subscription(
   // Update graph
   ret = common_context->destroy_subscriber_graph(
     info->subscription_gid_,
-    node->name, node->namespace_,
-    [identifier](rmw_publisher_t * pub, void * msg) {
-      return rmw_fastrtps_shared_cpp::__rmw_publish(
-        identifier,
-        pub,
-        msg,
-        nullptr);
-    }
+    node->name, node->namespace_
   );
   if (RMW_RET_OK != ret) {
     error_state = *rmw_get_error_state();
@@ -212,14 +205,7 @@ __rmw_subscription_set_content_filter(
   // Update graph
   ret = common_context->update_subscriber_graph(
     info->subscription_gid_,
-    node->name, node->namespace_,
-    [identifier](rmw_publisher_t * pub, void * msg) {
-      return rmw_fastrtps_shared_cpp::__rmw_publish(
-        identifier,
-        pub,
-        msg,
-        nullptr);
-    }
+    node->name, node->namespace_
   );
   if (RMW_RET_OK != ret) {
     return RMW_RET_ERROR;

--- a/rmw_fastrtps_shared_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_subscription.cpp
@@ -53,7 +53,7 @@ __rmw_destroy_subscription(
   auto common_context = static_cast<rmw_dds_common::Context *>(node->context->impl->common);
   auto info = static_cast<const CustomSubscriberInfo *>(subscription->data);
   // Update graph
-  ret = common_context->destroy_subscriber_graph(
+  ret = common_context->remove_subscriber_graph(
     info->subscription_gid_,
     node->name, node->namespace_
   );
@@ -203,7 +203,7 @@ __rmw_subscription_set_content_filter(
   const rmw_node_t * node = info->node_;
 
   // Update graph
-  ret = common_context->update_subscriber_graph(
+  ret = common_context->add_subscriber_graph(
     info->subscription_gid_,
     node->name, node->namespace_
   );

--- a/rmw_fastrtps_shared_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_subscription.cpp
@@ -56,7 +56,7 @@ __rmw_destroy_subscription(
   ret = common_context->destroy_subscriber_graph(
     info->subscription_gid_,
     node->name, node->namespace_,
-    [identifier] (rmw_publisher_t * pub, void * msg) {
+    [identifier](rmw_publisher_t * pub, void * msg) {
       return rmw_fastrtps_shared_cpp::__rmw_publish(
         identifier,
         pub,
@@ -213,7 +213,7 @@ __rmw_subscription_set_content_filter(
   ret = common_context->update_subscriber_graph(
     info->subscription_gid_,
     node->name, node->namespace_,
-    [identifier] (rmw_publisher_t * pub, void * msg) {
+    [identifier](rmw_publisher_t * pub, void * msg) {
       return rmw_fastrtps_shared_cpp::__rmw_publish(
         identifier,
         pub,

--- a/rmw_fastrtps_shared_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_subscription.cpp
@@ -52,22 +52,22 @@ __rmw_destroy_subscription(
   rmw_error_string_t error_string;
   auto common_context = static_cast<rmw_dds_common::Context *>(node->context->impl->common);
   auto info = static_cast<const CustomSubscriberInfo *>(subscription->data);
-  {
-    // Update graph
-    std::lock_guard<std::mutex> guard(common_context->node_update_mutex);
-    rmw_dds_common::msg::ParticipantEntitiesInfo msg =
-      common_context->graph_cache.dissociate_reader(
-      info->subscription_gid_, common_context->gid, node->name, node->namespace_);
-    ret = rmw_fastrtps_shared_cpp::__rmw_publish(
-      identifier,
-      common_context->pub,
-      static_cast<void *>(&msg),
-      nullptr);
-    if (RMW_RET_OK != ret) {
-      error_state = *rmw_get_error_state();
-      error_string = rmw_get_error_string();
-      rmw_reset_error();
+  // Update graph
+  ret = common_context->destroy_subscriber_graph(
+    info->subscription_gid_,
+    node->name, node->namespace_,
+    [identifier] (rmw_publisher_t * pub, void * msg) {
+      return rmw_fastrtps_shared_cpp::__rmw_publish(
+        identifier,
+        pub,
+        msg,
+        nullptr);
     }
+  );
+  if (RMW_RET_OK != ret) {
+    error_state = *rmw_get_error_state();
+    error_string = rmw_get_error_string();
+    rmw_reset_error();
   }
 
   auto participant_info =
@@ -145,10 +145,10 @@ __rmw_subscription_set_content_filter(
   eprosima::fastdds::dds::DomainParticipant * dds_participant =
     info->dds_participant_;
   eprosima::fastdds::dds::TopicDescription * des_topic = nullptr;
-  const char * eprosima_fastrtps_identifier = subscription->implementation_identifier;
+  const char * identifier = subscription->implementation_identifier;
 
   rmw_ret_t ret = rmw_fastrtps_shared_cpp::__rmw_destroy_subscription(
-    eprosima_fastrtps_identifier,
+    identifier,
     info->node_,
     subscription,
     true /* reset_cft */);
@@ -204,28 +204,27 @@ __rmw_subscription_set_content_filter(
   /////
   // Update RMW GID
   info->subscription_gid_ = rmw_fastrtps_shared_cpp::create_rmw_gid(
-    eprosima_fastrtps_identifier, info->data_reader_->guid());
+    identifier, info->data_reader_->guid());
 
-  {
-    rmw_dds_common::Context * common_context = info->common_context_;
-    const rmw_node_t * node = info->node_;
+  rmw_dds_common::Context * common_context = info->common_context_;
+  const rmw_node_t * node = info->node_;
 
-    // Update graph
-    std::lock_guard<std::mutex> guard(common_context->node_update_mutex);
-    rmw_dds_common::msg::ParticipantEntitiesInfo msg =
-      common_context->graph_cache.associate_reader(
-      info->subscription_gid_, common_context->gid, node->name, node->namespace_);
-    rmw_ret_t rmw_ret = rmw_fastrtps_shared_cpp::__rmw_publish(
-      eprosima_fastrtps_identifier,
-      common_context->pub,
-      static_cast<void *>(&msg),
-      nullptr);
-    if (RMW_RET_OK != rmw_ret) {
-      static_cast<void>(common_context->graph_cache.dissociate_reader(
-        info->subscription_gid_, common_context->gid, node->name, node->namespace_));
-      return RMW_RET_ERROR;
+  // Update graph
+  ret = common_context->update_subscriber_graph(
+    info->subscription_gid_,
+    node->name, node->namespace_,
+    [identifier] (rmw_publisher_t * pub, void * msg) {
+      return rmw_fastrtps_shared_cpp::__rmw_publish(
+        identifier,
+        pub,
+        msg,
+        nullptr);
     }
+  );
+  if (RMW_RET_OK != ret) {
+    return RMW_RET_ERROR;
   }
+
   cleanup_datareader.cancel();
   return RMW_RET_OK;
 }


### PR DESCRIPTION
to address one warning TSAN about `lock-order-inversion` mentioned at https://github.com/ros2/ros2/issues/1488#issuecomment-1752278901.

<details><summary> TSAN warning log </summary>
<p>

```shell
WARNING: ThreadSanitizer: lock-order-inversion (potential deadlock) (pid=1926091)
  Cycle in lock order graph: M254870179752816080 (0x000000000000) => M277106926251347976 (0x000000000000) => M254870179752816080

  Mutex M277106926251347976 acquired here while holding mutex M254870179752816080 in main thread:
    #0 pthread_mutex_lock ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:4240 (libtsan.so.0+0x53908)
    #1 __gthread_mutex_lock /usr/include/x86_64-linux-gnu/c++/11/bits/gthr-default.h:749 (librmw_fastrtps_cpp.so+0x2669e)
    #2 std::mutex::lock() /usr/include/c++/11/bits/std_mutex.h:100 (librmw_fastrtps_cpp.so+0x26726)
    #3 std::lock_guard<std::mutex>::lock_guard(std::mutex&) /usr/include/c++/11/bits/std_mutex.h:229 (librmw_fastrtps_cpp.so+0x283ec)
    #4 rmw_create_client /home/chenlh/Projects/ROS2/ros2-humble/src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/src/rmw_client.cpp:440 (librmw_fastrtps_cpp.so+0x46b7a)
    #5 rmw_create_client /home/chenlh/Projects/ROS2/ros2-humble/src/ros2/rmw_implementation/rmw_implementation/src/functions.cpp:484 (librmw_implementation.so+0x7e28)
    #6 rcl_client_init /home/chenlh/Projects/ROS2/ros2-humble/src/ros2/rcl/rcl/src/rcl/client.c:107 (librcl.so+0x1909d)
    #7 rcl_action_client_init /home/chenlh/Projects/ROS2/ros2-humble/src/ros2/rcl/rcl_action/src/rcl_action/action_client.c:218 (librcl_action.so+0x6f19)
    #8 TestActionGraphMultiNodeFixture_action_client_init_maybe_fail_Test::TestBody() /home/chenlh/Projects/ROS2/ros2-humble/src/ros2/rcl/rcl_action/test/rcl_action/test_graph.cpp:626 (test_graph__rmw_fastrtps_cpp+0x86fe6)
    #9 void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/chenlh/Projects/ROS2/ros2-humble/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2433 (test_graph__rmw_fastrtps_cpp+0xdbaa7)
    #10 void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/chenlh/Projects/ROS2/ros2-humble/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2469 (test_graph__rmw_fastrtps_cpp+0xd06c0)
    #11 testing::Test::Run() /home/chenlh/Projects/ROS2/ros2-humble/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2508 (test_graph__rmw_fastrtps_cpp+0xa07eb)
    #12 testing::TestInfo::Run() /home/chenlh/Projects/ROS2/ros2-humble/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2684 (test_graph__rmw_fastrtps_cpp+0xa1500)
    #13 testing::TestSuite::Run() /home/chenlh/Projects/ROS2/ros2-humble/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2816 (test_graph__rmw_fastrtps_cpp+0xa1fd2)
    #14 testing::internal::UnitTestImpl::RunAllTests() /home/chenlh/Projects/ROS2/ros2-humble/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5338 (test_graph__rmw_fastrtps_cpp+0xb0868)
    #15 bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/chenlh/Projects/ROS2/ros2-humble/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2433 (test_graph__rmw_fastrtps_cpp+0xdd935)
    #16 bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/chenlh/Projects/ROS2/ros2-humble/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2469 (test_graph__rmw_fastrtps_cpp+0xd22fe)
    #17 testing::UnitTest::Run() /home/chenlh/Projects/ROS2/ros2-humble/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4925 (test_graph__rmw_fastrtps_cpp+0xae93f)
    #18 RUN_ALL_TESTS() /home/chenlh/Projects/ROS2/ros2-humble/install/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2473 (test_graph__rmw_fastrtps_cpp+0x95e1a)
    #19 main /home/chenlh/Projects/ROS2/ros2-humble/install/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:45 (test_graph__rmw_fastrtps_cpp+0x95d0e)

    Hint: use TSAN_OPTIONS=second_deadlock_stack=1 to get more informative warning message

  Mutex M254870179752816080 acquired here while holding mutex M277106926251347976 in main thread:
    #0 pthread_mutex_lock ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:4240 (libtsan.so.0+0x53908)
    #1 __gthread_mutex_lock /usr/include/x86_64-linux-gnu/c++/11/bits/gthr-default.h:749 (librcl_logging_spdlog.so+0x10f5d)
    #2 std::mutex::lock() /usr/include/c++/11/bits/std_mutex.h:100 (librcl_logging_spdlog.so+0x11038)
    #3 std::lock_guard<std::mutex>::lock_guard(std::mutex&) /usr/include/c++/11/bits/std_mutex.h:229 (librcl_logging_spdlog.so+0x120d0)
    #4 rmw_fastrtps_shared_cpp::destroy_subscription(char const*, CustomParticipantInfo*, rmw_subscription_s*, bool) /home/chenlh/Projects/ROS2/ros2-humble/src/ros2/rmw_fastrtps/rmw_fastrtps_shared_cpp/src/subscription.cpp:44 (librmw_fastrtps_shared_cpp.so+0x155af0)
    #5 rmw_create_subscription /home/chenlh/Projects/ROS2/ros2-humble/src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/src/rmw_subscription.cpp:104 (librmw_fastrtps_cpp.so+0x6627b)
    #6 rmw_create_subscription /home/chenlh/Projects/ROS2/ros2-humble/src/ros2/rmw_implementation/rmw_implementation/src/functions.cpp:391 (librmw_implementation.so+0x708b)
    #7 rcl_subscription_init /home/chenlh/Projects/ROS2/ros2-humble/src/ros2/rcl/rcl/src/rcl/subscription.c:101 (librcl.so+0x351bb)
    #8 rcl_action_client_init /home/chenlh/Projects/ROS2/ros2-humble/src/ros2/rcl/rcl_action/src/rcl_action/action_client.c:222 (librcl_action.so+0x7563)
    #9 TestActionGraphMultiNodeFixture_action_client_init_maybe_fail_Test::TestBody() /home/chenlh/Projects/ROS2/ros2-humble/src/ros2/rcl/rcl_action/test/rcl_action/test_graph.cpp:626 (test_graph__rmw_fastrtps_cpp+0x86fe6)
    #10 void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/chenlh/Projects/ROS2/ros2-humble/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2433 (test_graph__rmw_fastrtps_cpp+0xdbaa7)
    #11 void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/chenlh/Projects/ROS2/ros2-humble/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2469 (test_graph__rmw_fastrtps_cpp+0xd06c0)
    #12 testing::Test::Run() /home/chenlh/Projects/ROS2/ros2-humble/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2508 (test_graph__rmw_fastrtps_cpp+0xa07eb)
    #13 testing::TestInfo::Run() /home/chenlh/Projects/ROS2/ros2-humble/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2684 (test_graph__rmw_fastrtps_cpp+0xa1500)
    #14 testing::TestSuite::Run() /home/chenlh/Projects/ROS2/ros2-humble/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2816 (test_graph__rmw_fastrtps_cpp+0xa1fd2)
    #15 testing::internal::UnitTestImpl::RunAllTests() /home/chenlh/Projects/ROS2/ros2-humble/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5338 (test_graph__rmw_fastrtps_cpp+0xb0868)
    #16 bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/chenlh/Projects/ROS2/ros2-humble/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2433 (test_graph__rmw_fastrtps_cpp+0xdd935)
    #17 bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/chenlh/Projects/ROS2/ros2-humble/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2469 (test_graph__rmw_fastrtps_cpp+0xd22fe)
    #18 testing::UnitTest::Run() /home/chenlh/Projects/ROS2/ros2-humble/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4925 (test_graph__rmw_fastrtps_cpp+0xae93f)
    #19 RUN_ALL_TESTS() /home/chenlh/Projects/ROS2/ros2-humble/install/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2473 (test_graph__rmw_fastrtps_cpp+0x95e1a)
    #20 main /home/chenlh/Projects/ROS2/ros2-humble/install/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:45 (test_graph__rmw_fastrtps_cpp+0x95d0e)

SUMMARY: ThreadSanitizer: lock-order-inversion (potential deadlock) /usr/include/x86_64-linux-gnu/c++/11/bits/gthr-default.h:749 in __gthread_mutex_lock

```

</p>
</details>
