### PR TITLE
Data sharing is required to enable loaned interface on subscription.

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/rmw_take.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_take.cpp
@@ -44,6 +44,8 @@
 namespace rmw_fastrtps_shared_cpp
 {
 
+using DataSharingKind = eprosima::fastdds::dds::DataSharingKind;
+
 void
 _assign_message_info(
   const char * identifier,
@@ -562,7 +564,8 @@ __init_subscription_for_loans(
 {
   auto info = static_cast<CustomSubscriberInfo *>(subscription->data);
   const auto & qos = info->data_reader_->get_qos();
-  subscription->can_loan_messages = info->type_support_->is_plain();
+  bool has_data_sharing = DataSharingKind::OFF != qos.data_sharing().kind();
+  subscription->can_loan_messages = has_data_sharing && info->type_support_->is_plain();
   if (subscription->can_loan_messages) {
     const auto & allocation_qos = qos.reader_resource_limits().outstanding_reads_allocation;
     info->loan_manager_ = std::make_shared<LoanManager>(allocation_qos);


### PR DESCRIPTION
this is draft PR to try to address,

- https://github.com/ros-planning/navigation2/pull/3863#discussion_r1356135469
- https://github.com/ros-planning/navigation2/pull/3876
- https://github.com/ros-planning/navigation2/pull/3875