### PR TITLE
Quiet compiler warning in Release mode.

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_node.cpp
@@ -118,6 +118,7 @@ __rmw_destroy_node(
   const char * identifier,
   rmw_node_t * node)
 {
+  (void)identifier;
   assert(node->implementation_identifier == identifier);
   rmw_ret_t ret = RMW_RET_OK;
   auto common_context = static_cast<rmw_dds_common::Context *>(node->context->impl->common);


### PR DESCRIPTION
In particular, when building in release mode the assert is compiled out, so 'identifier' is never used.  Just quiet this warning.