### PR TITLE
Switch to Unix line endings.

### DIFF
--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/rmw_common.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/rmw_common.hpp
@@ -17,6 +17,9 @@
 
 #include "./visibility_control.h"
 
+#include "rcutils/allocator.h"
+#include "rcutils/types/string_array.h"
+
 #include "rmw/error_handling.h"
 #include "rmw/event.h"
 #include "rmw/features.h"


### PR DESCRIPTION
Kind of a silly change, but just make sure to use Unix line endings in rmw_common.hpp, which matches all of the rest of the files in this repository.  There is no functional change in this PR.