### PR TITLE
Remove an unnecessary constructor.

### DIFF
--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp
@@ -75,12 +75,7 @@ typedef struct CustomServiceInfo
 typedef struct CustomServiceRequest
 {
   eprosima::fastrtps::rtps::SampleIdentity sample_identity_;
-  eprosima::fastcdr::FastBuffer * buffer_;
-
-  CustomServiceRequest()
-  : buffer_(nullptr)
-  {
-  }
+  eprosima::fastcdr::FastBuffer * buffer_{nullptr};
 } CustomServiceRequest;
 
 class ServicePubListener : public eprosima::fastdds::dds::DataWriterListener


### PR DESCRIPTION
We can just use brace initialization here, and this allows us to side-step an uncrustify issue with the constructor.