### PR TITLE
Add tracepoint for publish/subscribe serialized_message

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/rmw_publish.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_publish.cpp
@@ -109,7 +109,9 @@ __rmw_publish_serialized_message(
   data.type = FASTRTPS_SERIALIZED_DATA_TYPE_CDR_BUFFER;
   data.data = &ser;
   data.impl = nullptr;  // not used when type is FASTRTPS_SERIALIZED_DATA_TYPE_CDR_BUFFER
-  TRACETOOLS_TRACEPOINT(rmw_publish, serialized_message);
+  eprosima::fastrtps::Time_t stamp;
+  eprosima::fastrtps::Time_t::now(stamp);
+  TRACETOOLS_TRACEPOINT(rmw_publish, publisher, serialized_message, stamp.to_ns());
   if (!info->data_writer_->write(&data)) {
     RMW_SET_ERROR_MSG("cannot publish data");
     return RMW_RET_ERROR;

--- a/rmw_fastrtps_shared_cpp/src/rmw_publish.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_publish.cpp
@@ -109,6 +109,7 @@ __rmw_publish_serialized_message(
   data.type = FASTRTPS_SERIALIZED_DATA_TYPE_CDR_BUFFER;
   data.data = &ser;
   data.impl = nullptr;  // not used when type is FASTRTPS_SERIALIZED_DATA_TYPE_CDR_BUFFER
+  TRACETOOLS_TRACEPOINT(rmw_publish, serialized_message);
   if (!info->data_writer_->write(&data)) {
     RMW_SET_ERROR_MSG("cannot publish data");
     return RMW_RET_ERROR;

--- a/rmw_fastrtps_shared_cpp/src/rmw_publish.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_publish.cpp
@@ -112,7 +112,7 @@ __rmw_publish_serialized_message(
   eprosima::fastrtps::Time_t stamp;
   eprosima::fastrtps::Time_t::now(stamp);
   TRACETOOLS_TRACEPOINT(rmw_publish, publisher, serialized_message, stamp.to_ns());
-  if (!info->data_writer_->write(&data)) {
+  if (!info->data_writer_->write_w_timestamp(&data, eprosima::fastdds::dds::HANDLE_NIL, stamp)) {
     RMW_SET_ERROR_MSG("cannot publish data");
     return RMW_RET_ERROR;
   }

--- a/rmw_fastrtps_shared_cpp/src/rmw_take.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_take.cpp
@@ -348,7 +348,12 @@ _take_serialized_message(
       break;
     }
   }
-
+  TRACETOOLS_TRACEPOINT(
+    rmw_take,
+    static_cast<const void *>(subscription),
+    static_cast<const void *>(serialized_message),
+    (message_info ? message_info->source_timestamp : 0LL),
+    *taken);
   return RMW_RET_OK;
 }
 


### PR DESCRIPTION
Please, refer to https://github.com/ros2/rclcpp/pull/2448 .
I have added the following trace points.

- `__rmw_publish_serialized_message()` 
  - tracepoint : rmw_publish
- `_take_serialized_message()`
  - tracepoint : rmw_take
