### PR TITLE
Support topic instances

### DIFF
--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport.hpp
@@ -52,7 +52,7 @@ protected:
 
 private:
   const message_type_support_callbacks_t * members_;
-  const message_type_support_key_callbacks_t*  key_callbacks_;
+  const message_type_support_key_callbacks_t *  key_callbacks_;
   bool has_data_;
 };
 

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport.hpp
@@ -45,14 +45,15 @@ public:
   explicit TypeSupport(const rosidl_message_type_support_t * type_supports);
 
   bool get_key_hash_from_ros_message(
-    void * ros_message, eprosima::fastdds::rtps::InstanceHandle_t * ihandle, bool force_md5, const void * impl) const override;
+    void * ros_message, eprosima::fastdds::rtps::InstanceHandle_t * ihandle, bool force_md5,
+    const void * impl) const override;
 
 protected:
   void set_members(const message_type_support_callbacks_t * members);
 
 private:
   const message_type_support_callbacks_t * members_;
-  const message_type_support_key_callbacks_t *  key_callbacks_;
+  const message_type_support_key_callbacks_t * key_callbacks_;
   bool has_data_;
 };
 

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport.hpp
@@ -44,11 +44,15 @@ public:
 
   explicit TypeSupport(const rosidl_message_type_support_t * type_supports);
 
+  bool get_key_hash_from_ros_message(
+    void * ros_message, eprosima::fastdds::rtps::InstanceHandle_t * ihandle, bool force_md5, const void * impl) const override;
+
 protected:
   void set_members(const message_type_support_callbacks_t * members);
 
 private:
   const message_type_support_callbacks_t * members_;
+  const message_type_support_key_callbacks_t*  key_callbacks_;
   bool has_data_;
 };
 

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport.hpp
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport.hpp
@@ -45,7 +45,9 @@ public:
   explicit TypeSupport(const rosidl_message_type_support_t * type_supports);
 
   bool get_key_hash_from_ros_message(
-    void * ros_message, eprosima::fastdds::rtps::InstanceHandle_t * ihandle, bool force_md5,
+    void * ros_message,
+    eprosima::fastdds::rtps::InstanceHandle_t * ihandle,
+    bool force_md5,
     const void * impl) const override;
 
 protected:

--- a/rmw_fastrtps_cpp/src/publisher.cpp
+++ b/rmw_fastrtps_cpp/src/publisher.cpp
@@ -259,6 +259,15 @@ rmw_fastrtps_cpp::create_publisher(
     return nullptr;
   }
 
+  // Apply resource limits QoS if the type is keyed
+  if (fastdds_type->m_isGetKeyDefined &&
+      !participant_info->leave_middleware_default_qos)
+  {
+    rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
+      writer_qos.history(),
+      writer_qos.resource_limits());
+  }
+
   // Creates DataWriter with a mask enabling publication_matched calls for the listener
   info->data_writer_ = publisher->create_datawriter(
     info->topic_,

--- a/rmw_fastrtps_cpp/src/publisher.cpp
+++ b/rmw_fastrtps_cpp/src/publisher.cpp
@@ -261,7 +261,7 @@ rmw_fastrtps_cpp::create_publisher(
 
   // Apply resource limits QoS if the type is keyed
   if (fastdds_type->m_isGetKeyDefined &&
-      !participant_info->leave_middleware_default_qos)
+    !participant_info->leave_middleware_default_qos)
   {
     rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
       writer_qos.history(),

--- a/rmw_fastrtps_cpp/src/publisher.cpp
+++ b/rmw_fastrtps_cpp/src/publisher.cpp
@@ -260,7 +260,7 @@ rmw_fastrtps_cpp::create_publisher(
   }
 
   // Apply resource limits QoS if the type is keyed
-  if (fastdds_type->m_isGetKeyDefined &&
+  if (fastdds_type->is_compute_key_provided &&
     !participant_info->leave_middleware_default_qos)
   {
     rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(

--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -330,7 +330,7 @@ rmw_create_client(
 
   // Apply resource limits QoS if the type is keyed
   if (response_fastdds_type->m_isGetKeyDefined &&
-      !participant_info->leave_middleware_default_qos)
+    !participant_info->leave_middleware_default_qos)
   {
     rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
       reader_qos.history(),
@@ -397,7 +397,7 @@ rmw_create_client(
 
   // Apply resource limits QoS if the type is keyed
   if (request_fastdds_type->m_isGetKeyDefined &&
-      !participant_info->leave_middleware_default_qos)
+    !participant_info->leave_middleware_default_qos)
   {
     rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
       writer_qos.history(),

--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -328,6 +328,15 @@ rmw_create_client(
     return nullptr;
   }
 
+  // Apply resource limits QoS if the type is keyed
+  if (response_fastdds_type->m_isGetKeyDefined &&
+      !participant_info->leave_middleware_default_qos)
+  {
+    rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
+      reader_qos.history(),
+      reader_qos.resource_limits());
+  }
+
   // Creates DataReader
   info->response_reader_ = subscriber->create_datareader(
     response_topic_desc,
@@ -384,6 +393,15 @@ rmw_create_client(
   {
     RMW_SET_ERROR_MSG("create_client() failed setting request DataWriter QoS");
     return nullptr;
+  }
+
+  // Apply resource limits QoS if the type is keyed
+  if (request_fastdds_type->m_isGetKeyDefined &&
+      !participant_info->leave_middleware_default_qos)
+  {
+    rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
+      writer_qos.history(),
+      writer_qos.resource_limits());
   }
 
   // Creates DataWriter with a mask enabling publication_matched calls for the listener

--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -329,7 +329,7 @@ rmw_create_client(
   }
 
   // Apply resource limits QoS if the type is keyed
-  if (response_fastdds_type->m_isGetKeyDefined &&
+  if (response_fastdds_type->is_compute_key_provided &&
     !participant_info->leave_middleware_default_qos)
   {
     rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
@@ -396,7 +396,7 @@ rmw_create_client(
   }
 
   // Apply resource limits QoS if the type is keyed
-  if (request_fastdds_type->m_isGetKeyDefined &&
+  if (request_fastdds_type->is_compute_key_provided &&
     !participant_info->leave_middleware_default_qos)
   {
     rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(

--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -325,7 +325,7 @@ rmw_create_service(
   }
 
   // Apply resource limits QoS if the type is keyed
-  if (request_fastdds_type->m_isGetKeyDefined &&
+  if (request_fastdds_type->is_compute_key_provided &&
     !participant_info->leave_middleware_default_qos)
   {
     rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
@@ -396,7 +396,7 @@ rmw_create_service(
   }
 
   // Apply resource limits QoS if the type is keyed
-  if (response_fastdds_type->m_isGetKeyDefined &&
+  if (response_fastdds_type->is_compute_key_provided &&
     !participant_info->leave_middleware_default_qos)
   {
     rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(

--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -324,6 +324,15 @@ rmw_create_service(
     return nullptr;
   }
 
+  // Apply resource limits QoS if the type is keyed
+  if (request_fastdds_type->m_isGetKeyDefined &&
+      !participant_info->leave_middleware_default_qos)
+  {
+    rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
+      reader_qos.history(),
+      reader_qos.resource_limits());
+  }
+
   // Creates DataReader
   info->request_reader_ = subscriber->create_datareader(
     request_topic_desc,
@@ -384,6 +393,15 @@ rmw_create_service(
   {
     RMW_SET_ERROR_MSG("create_service() failed setting response DataWriter QoS");
     return nullptr;
+  }
+
+  // Apply resource limits QoS if the type is keyed
+  if (response_fastdds_type->m_isGetKeyDefined &&
+      !participant_info->leave_middleware_default_qos)
+  {
+    rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
+      writer_qos.history(),
+      writer_qos.resource_limits());
   }
 
   // Creates DataWriter with a mask enabling publication_matched calls for the listener

--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -326,7 +326,7 @@ rmw_create_service(
 
   // Apply resource limits QoS if the type is keyed
   if (request_fastdds_type->m_isGetKeyDefined &&
-      !participant_info->leave_middleware_default_qos)
+    !participant_info->leave_middleware_default_qos)
   {
     rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
       reader_qos.history(),
@@ -397,7 +397,7 @@ rmw_create_service(
 
   // Apply resource limits QoS if the type is keyed
   if (response_fastdds_type->m_isGetKeyDefined &&
-      !participant_info->leave_middleware_default_qos)
+    !participant_info->leave_middleware_default_qos)
   {
     rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
       writer_qos.history(),

--- a/rmw_fastrtps_cpp/src/subscription.cpp
+++ b/rmw_fastrtps_cpp/src/subscription.cpp
@@ -394,7 +394,7 @@ __create_dynamic_subscription(
 
   // Apply resource limits QoS if the type is keyed
   if (fastdds_type->m_isGetKeyDefined &&
-      !participant_info->leave_middleware_default_qos)
+    !participant_info->leave_middleware_default_qos)
   {
     rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
       reader_qos.history(),
@@ -665,7 +665,7 @@ __create_subscription(
 
   // Apply resource limits QoS if the type is keyed
   if (fastdds_type->m_isGetKeyDefined &&
-      !participant_info->leave_middleware_default_qos)
+    !participant_info->leave_middleware_default_qos)
   {
     rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
       reader_qos.history(),

--- a/rmw_fastrtps_cpp/src/subscription.cpp
+++ b/rmw_fastrtps_cpp/src/subscription.cpp
@@ -393,7 +393,7 @@ __create_dynamic_subscription(
   }
 
   // Apply resource limits QoS if the type is keyed
-  if (fastdds_type->m_isGetKeyDefined &&
+  if (fastdds_type->is_compute_key_provided &&
     !participant_info->leave_middleware_default_qos)
   {
     rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
@@ -664,7 +664,7 @@ __create_subscription(
   }
 
   // Apply resource limits QoS if the type is keyed
-  if (fastdds_type->m_isGetKeyDefined &&
+  if (fastdds_type->is_compute_key_provided &&
     !participant_info->leave_middleware_default_qos)
   {
     rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(

--- a/rmw_fastrtps_cpp/src/subscription.cpp
+++ b/rmw_fastrtps_cpp/src/subscription.cpp
@@ -392,6 +392,15 @@ __create_dynamic_subscription(
     return nullptr;
   }
 
+  // Apply resource limits QoS if the type is keyed
+  if (fastdds_type->m_isGetKeyDefined &&
+      !participant_info->leave_middleware_default_qos)
+  {
+    rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
+      reader_qos.history(),
+      reader_qos.resource_limits());
+  }
+
   info->datareader_qos_ = reader_qos;
 
   // create_datareader
@@ -652,6 +661,15 @@ __create_subscription(
   {
     RMW_SET_ERROR_MSG("create_subscription() failed setting data reader QoS");
     return nullptr;
+  }
+
+  // Apply resource limits QoS if the type is keyed
+  if (fastdds_type->m_isGetKeyDefined &&
+      !participant_info->leave_middleware_default_qos)
+  {
+    rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
+      reader_qos.history(),
+      reader_qos.resource_limits());
   }
 
   info->datareader_qos_ = reader_qos;

--- a/rmw_fastrtps_cpp/src/type_support_common.cpp
+++ b/rmw_fastrtps_cpp/src/type_support_common.cpp
@@ -31,6 +31,11 @@ TypeSupport::TypeSupport(
   is_compute_key_provided = false;
   max_size_bound_ = false;
   is_plain_ = false;
+  key_is_unbounded_ = false;
+  key_max_serialized_size_ = 0;
+  members_ = nullptr;
+  key_callbacks_ = nullptr;
+  has_data_ = false;
 }
 
 void TypeSupport::set_members(const message_type_support_callbacks_t * members)
@@ -60,6 +65,18 @@ void TypeSupport::set_members(const message_type_support_callbacks_t * members)
   max_serialized_type_size = 4 + data_size;
   // Account for RTPS submessage alignment
   max_serialized_type_size = (max_serialized_type_size + 3) & ~3;
+
+  if (nullptr != members->key_callbacks)
+  {
+    key_callbacks_ = members->key_callbacks;
+    is_compute_key_provided = true;
+
+    key_max_serialized_size_ = key_callbacks_->max_serialized_size_key(key_is_unbounded_);
+    if (!key_is_unbounded_)
+    {
+      key_buffer_.reserve(key_max_serialized_size_);
+    }
+  }
 }
 
 size_t TypeSupport::getEstimatedSerializedSize(const void * ros_message, const void * impl) const
@@ -127,6 +144,61 @@ bool TypeSupport::deserializeROSmessage(
       "'Bad alloc' exception deserializing message of type %s.",
       get_name().c_str());
     return false;
+  }
+
+  return true;
+}
+
+bool TypeSupport::get_key_hash_from_ros_message(
+    void * ros_message,
+    eprosima::fastdds::rtps::InstanceHandle_t * ihandle,
+    bool force_md5,
+    const void * impl) const
+{
+  assert(ros_message);
+  (void)impl;
+
+  // retrieve estimated serialized size in case key is unbounded
+  if (key_is_unbounded_)
+  {
+    key_max_serialized_size_ = (std::max) (
+      key_max_serialized_size_,
+      key_callbacks_->get_serialized_size_key(ros_message));
+    key_buffer_.reserve(key_max_serialized_size_);
+  }
+
+  eprosima::fastcdr::FastBuffer fast_buffer(
+    reinterpret_cast<char *>(key_buffer_.data()),
+    key_max_serialized_size_);
+
+  eprosima::fastcdr::Cdr ser(
+    fast_buffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN, eprosima::fastcdr::CdrVersion::XCDRv1);
+
+  key_callbacks_->cdr_serialize_key(ros_message, ser);
+
+  const size_t max_serialized_key_length = 16;
+
+  auto ser_length = ser.get_serialized_data_length();
+
+  // check for md5
+  if (force_md5 || key_max_serialized_size_ > max_serialized_key_length)
+  {
+    md5_.init();
+    md5_.update(key_buffer_.data(), static_cast<unsigned int>(ser_length));
+    md5_.finalize();
+
+    for (uint8_t i = 0; i < max_serialized_key_length; ++i)
+    {
+      ihandle->value[i] = md5_.digest[i];
+    }
+  }
+  else
+  {
+    memset(ihandle->value, 0, max_serialized_key_length);
+    for (uint8_t i = 0; i < ser_length; ++i)
+    {
+        ihandle->value[i] = key_buffer_[i];
+    }
   }
 
   return true;

--- a/rmw_fastrtps_cpp/src/type_support_common.cpp
+++ b/rmw_fastrtps_cpp/src/type_support_common.cpp
@@ -66,14 +66,12 @@ void TypeSupport::set_members(const message_type_support_callbacks_t * members)
   // Account for RTPS submessage alignment
   max_serialized_type_size = (max_serialized_type_size + 3) & ~3;
 
-  if (nullptr != members->key_callbacks)
-  {
+  if (nullptr != members->key_callbacks) {
     key_callbacks_ = members->key_callbacks;
     is_compute_key_provided = true;
 
     key_max_serialized_size_ = key_callbacks_->max_serialized_size_key(key_is_unbounded_);
-    if (!key_is_unbounded_)
-    {
+    if (!key_is_unbounded_) {
       key_buffer_.reserve(key_max_serialized_size_);
     }
   }
@@ -150,17 +148,16 @@ bool TypeSupport::deserializeROSmessage(
 }
 
 bool TypeSupport::get_key_hash_from_ros_message(
-    void * ros_message,
-    eprosima::fastdds::rtps::InstanceHandle_t * ihandle,
-    bool force_md5,
-    const void * impl) const
+  void * ros_message,
+  eprosima::fastdds::rtps::InstanceHandle_t * ihandle,
+  bool force_md5,
+  const void * impl) const
 {
   assert(ros_message);
   (void)impl;
 
   // retrieve estimated serialized size in case key is unbounded
-  if (key_is_unbounded_)
-  {
+  if (key_is_unbounded_) {
     key_max_serialized_size_ = (std::max) (
       key_max_serialized_size_,
       key_callbacks_->get_serialized_size_key(ros_message));
@@ -181,23 +178,18 @@ bool TypeSupport::get_key_hash_from_ros_message(
   auto ser_length = ser.get_serialized_data_length();
 
   // check for md5
-  if (force_md5 || key_max_serialized_size_ > max_serialized_key_length)
-  {
+  if (force_md5 || key_max_serialized_size_ > max_serialized_key_length) {
     md5_.init();
     md5_.update(key_buffer_.data(), static_cast<unsigned int>(ser_length));
     md5_.finalize();
 
-    for (uint8_t i = 0; i < max_serialized_key_length; ++i)
-    {
+    for (uint8_t i = 0; i < max_serialized_key_length; ++i) {
       ihandle->value[i] = md5_.digest[i];
     }
-  }
-  else
-  {
+  } else {
     memset(ihandle->value, 0, max_serialized_key_length);
-    for (uint8_t i = 0; i < ser_length; ++i)
-    {
-        ihandle->value[i] = key_buffer_[i];
+    for (uint8_t i = 0; i < ser_length; ++i) {
+      ihandle->value[i] = key_buffer_[i];
     }
   }
 

--- a/rmw_fastrtps_cpp/src/type_support_common.cpp
+++ b/rmw_fastrtps_cpp/src/type_support_common.cpp
@@ -151,11 +151,10 @@ bool TypeSupport::get_key_hash_from_ros_message(
   void * ros_message,
   eprosima::fastdds::rtps::InstanceHandle_t * ihandle,
   bool force_md5,
-  const void * impl) const
+  const void * [[maybe_unused]] impl) const
 {
   assert(ros_message);
   assert(ihandle);
-  (void)impl;
 
   // retrieve estimated serialized size in case key is unbounded
   if (key_is_unbounded_) {

--- a/rmw_fastrtps_cpp/src/type_support_common.cpp
+++ b/rmw_fastrtps_cpp/src/type_support_common.cpp
@@ -154,6 +154,7 @@ bool TypeSupport::get_key_hash_from_ros_message(
   const void * impl) const
 {
   assert(ros_message);
+  assert(ihandle);
   (void)impl;
 
   // retrieve estimated serialized size in case key is unbounded

--- a/rmw_fastrtps_dynamic_cpp/src/MessageTypeSupport_impl.hpp
+++ b/rmw_fastrtps_dynamic_cpp/src/MessageTypeSupport_impl.hpp
@@ -61,6 +61,14 @@ MessageTypeSupport<MembersType>::MessageTypeSupport(
   } else {
     this->max_serialized_type_size++;
   }
+
+  if (this->members_->has_any_key_member_)
+  {
+    this->key_max_serialized_size_ = this->calculateMaxSerializedKeySize(members);
+    this->m_isGetKeyDefined = true;
+    this->key_buffer_.reserve(this->key_max_serialized_size_);
+  }
+
   // Account for RTPS submessage alignment
   this->max_serialized_type_size = (this->max_serialized_type_size + 3) & ~3;
 }

--- a/rmw_fastrtps_dynamic_cpp/src/MessageTypeSupport_impl.hpp
+++ b/rmw_fastrtps_dynamic_cpp/src/MessageTypeSupport_impl.hpp
@@ -64,7 +64,7 @@ MessageTypeSupport<MembersType>::MessageTypeSupport(
 
   if (this->members_->has_any_key_member_) {
     this->key_max_serialized_size_ = this->calculateMaxSerializedKeySize(members);
-    this->m_isGetKeyDefined = true;
+    this->is_compute_key_provided = true;
     this->key_buffer_.reserve(this->key_max_serialized_size_);
   }
 

--- a/rmw_fastrtps_dynamic_cpp/src/MessageTypeSupport_impl.hpp
+++ b/rmw_fastrtps_dynamic_cpp/src/MessageTypeSupport_impl.hpp
@@ -62,8 +62,7 @@ MessageTypeSupport<MembersType>::MessageTypeSupport(
     this->max_serialized_type_size++;
   }
 
-  if (this->members_->has_any_key_member_)
-  {
+  if (this->members_->has_any_key_member_) {
     this->key_max_serialized_size_ = this->calculateMaxSerializedKeySize(members);
     this->m_isGetKeyDefined = true;
     this->key_buffer_.reserve(this->key_max_serialized_size_);

--- a/rmw_fastrtps_dynamic_cpp/src/ServiceTypeSupport_impl.hpp
+++ b/rmw_fastrtps_dynamic_cpp/src/ServiceTypeSupport_impl.hpp
@@ -62,6 +62,14 @@ RequestTypeSupport<ServiceMembersType, MessageMembersType>::RequestTypeSupport(
   } else {
     this->max_serialized_type_size++;
   }
+
+  if (this->members_->has_any_key_member_)
+  {
+    this->key_max_serialized_size_ = this->calculateMaxSerializedKeySize(this->members_);
+    this->m_isGetKeyDefined = true;
+    this->key_buffer_.reserve(this->key_max_serialized_size_);
+  }
+
   // Account for RTPS submessage alignment
   this->max_serialized_type_size = (this->max_serialized_type_size + 3) & ~3;
 }
@@ -98,6 +106,14 @@ ResponseTypeSupport<ServiceMembersType, MessageMembersType>::ResponseTypeSupport
   } else {
     this->max_serialized_type_size++;
   }
+
+  if (this->members_->has_any_key_member_)
+  {
+    this->key_max_serialized_size_ = this->calculateMaxSerializedKeySize(this->members_);
+    this->m_isGetKeyDefined = true;
+    this->key_buffer_.reserve(this->key_max_serialized_size_);
+  }
+
   // Account for RTPS submessage alignment
   this->max_serialized_type_size = (this->max_serialized_type_size + 3) & ~3;
 }

--- a/rmw_fastrtps_dynamic_cpp/src/ServiceTypeSupport_impl.hpp
+++ b/rmw_fastrtps_dynamic_cpp/src/ServiceTypeSupport_impl.hpp
@@ -63,8 +63,7 @@ RequestTypeSupport<ServiceMembersType, MessageMembersType>::RequestTypeSupport(
     this->max_serialized_type_size++;
   }
 
-  if (this->members_->has_any_key_member_)
-  {
+  if (this->members_->has_any_key_member_) {
     this->key_max_serialized_size_ = this->calculateMaxSerializedKeySize(this->members_);
     this->m_isGetKeyDefined = true;
     this->key_buffer_.reserve(this->key_max_serialized_size_);
@@ -107,8 +106,7 @@ ResponseTypeSupport<ServiceMembersType, MessageMembersType>::ResponseTypeSupport
     this->max_serialized_type_size++;
   }
 
-  if (this->members_->has_any_key_member_)
-  {
+  if (this->members_->has_any_key_member_) {
     this->key_max_serialized_size_ = this->calculateMaxSerializedKeySize(this->members_);
     this->m_isGetKeyDefined = true;
     this->key_buffer_.reserve(this->key_max_serialized_size_);

--- a/rmw_fastrtps_dynamic_cpp/src/ServiceTypeSupport_impl.hpp
+++ b/rmw_fastrtps_dynamic_cpp/src/ServiceTypeSupport_impl.hpp
@@ -65,7 +65,7 @@ RequestTypeSupport<ServiceMembersType, MessageMembersType>::RequestTypeSupport(
 
   if (this->members_->has_any_key_member_) {
     this->key_max_serialized_size_ = this->calculateMaxSerializedKeySize(this->members_);
-    this->m_isGetKeyDefined = true;
+    this->is_compute_key_provided = true;
     this->key_buffer_.reserve(this->key_max_serialized_size_);
   }
 
@@ -108,7 +108,7 @@ ResponseTypeSupport<ServiceMembersType, MessageMembersType>::ResponseTypeSupport
 
   if (this->members_->has_any_key_member_) {
     this->key_max_serialized_size_ = this->calculateMaxSerializedKeySize(this->members_);
-    this->m_isGetKeyDefined = true;
+    this->is_compute_key_provided = true;
     this->key_buffer_.reserve(this->key_max_serialized_size_);
   }
 

--- a/rmw_fastrtps_dynamic_cpp/src/TypeSupport.hpp
+++ b/rmw_fastrtps_dynamic_cpp/src/TypeSupport.hpp
@@ -190,7 +190,9 @@ public:
     eprosima::fastcdr::Cdr & deser, void * ros_message, const void * impl) const override;
 
   bool get_key_hash_from_ros_message(
-    void * ros_message, eprosima::fastrtps::rtps::InstanceHandle_t * ihandle, bool force_md5,
+    void * ros_message,
+    eprosima::fastrtps::rtps::InstanceHandle_t * ihandle,
+    bool force_md5,
     const void * impl) const override;
 
 protected:

--- a/rmw_fastrtps_dynamic_cpp/src/TypeSupport.hpp
+++ b/rmw_fastrtps_dynamic_cpp/src/TypeSupport.hpp
@@ -140,7 +140,8 @@ public:
     eprosima::fastcdr::Cdr & deser, void * ros_message, const void * impl) const override;
 
   bool get_key_hash_from_ros_message(
-    void * ros_message, eprosima::fastrtps::rtps::InstanceHandle_t * ihandle, bool force_md5, const void * impl) const override;
+    void * ros_message, eprosima::fastrtps::rtps::InstanceHandle_t * ihandle, bool force_md5,
+    const void * impl) const override;
 };
 
 class BaseTypeSupport : public rmw_fastrtps_shared_cpp::TypeSupport
@@ -189,7 +190,8 @@ public:
     eprosima::fastcdr::Cdr & deser, void * ros_message, const void * impl) const override;
 
   bool get_key_hash_from_ros_message(
-    void * ros_message, eprosima::fastrtps::rtps::InstanceHandle_t * ihandle, bool force_md5, const void * impl) const override;
+    void * ros_message, eprosima::fastrtps::rtps::InstanceHandle_t * ihandle, bool force_md5,
+    const void * impl) const override;
 
 protected:
   // Meant for messages typesupport
@@ -206,12 +208,11 @@ protected:
   const MembersType * members_;
 
 private:
-
   size_t calculateMaxSerializedSize(
     const MembersType * members,
     size_t current_alignment,
     bool compute_key,
-    bool& is_key_unbounded);
+    bool & is_key_unbounded);
 
   size_t getEstimatedSerializedSize(
     const MembersType * members,

--- a/rmw_fastrtps_dynamic_cpp/src/TypeSupport.hpp
+++ b/rmw_fastrtps_dynamic_cpp/src/TypeSupport.hpp
@@ -138,6 +138,9 @@ public:
 
   bool deserializeROSmessage(
     eprosima::fastcdr::Cdr & deser, void * ros_message, const void * impl) const override;
+
+  bool get_key_hash_from_ros_message(
+    void * ros_message, eprosima::fastrtps::rtps::InstanceHandle_t * ihandle, bool force_md5, const void * impl) const override;
 };
 
 class BaseTypeSupport : public rmw_fastrtps_shared_cpp::TypeSupport
@@ -185,6 +188,9 @@ public:
   bool deserializeROSmessage(
     eprosima::fastcdr::Cdr & deser, void * ros_message, const void * impl) const override;
 
+  bool get_key_hash_from_ros_message(
+    void * ros_message, eprosima::fastrtps::rtps::InstanceHandle_t * ihandle, bool force_md5, const void * impl) const override;
+
 protected:
   // Meant for messages typesupport
   explicit TypeSupport(const void * ros_type_support);
@@ -195,24 +201,59 @@ protected:
     const void * ros_message_type_supports);
 
   size_t calculateMaxSerializedSize(const MembersType * members, size_t current_alignment);
+  size_t calculateMaxSerializedKeySize(const MembersType * members);
 
   const MembersType * members_;
 
 private:
+
+  size_t calculateMaxSerializedSize(
+    const MembersType * members,
+    size_t current_alignment,
+    bool compute_key,
+    bool& is_key_unbounded);
+
   size_t getEstimatedSerializedSize(
     const MembersType * members,
     const void * ros_message,
     size_t current_alignment) const;
+
+  size_t getEstimatedSerializedKeySize(
+    const MembersType * members,
+    const void * ros_message) const;
+
+  size_t getEstimatedSerializedSize(
+    const MembersType * members,
+    const void * ros_message,
+    size_t current_alignment,
+    bool compute_key) const;
 
   bool serializeROSmessage(
     eprosima::fastcdr::Cdr & ser,
     const MembersType * members,
     const void * ros_message) const;
 
+  bool serializeKeyROSmessage(
+    eprosima::fastcdr::Cdr & ser,
+    const MembersType * members,
+    const void * ros_message) const;
+
+  bool serializeROSmessage(
+    eprosima::fastcdr::Cdr & ser,
+    const MembersType * members,
+    const void * ros_message,
+    bool compute_key) const;
+
   bool deserializeROSmessage(
     eprosima::fastcdr::Cdr & deser,
     const MembersType * members,
     void * ros_message) const;
+
+  bool get_key_hash_from_ros_message(
+    const MembersType * members,
+    void * ros_message,
+    eprosima::fastrtps::rtps::InstanceHandle_t * ihandle,
+    bool force_md5) const;
 };
 
 }  // namespace rmw_fastrtps_dynamic_cpp

--- a/rmw_fastrtps_dynamic_cpp/src/TypeSupport.hpp
+++ b/rmw_fastrtps_dynamic_cpp/src/TypeSupport.hpp
@@ -140,7 +140,7 @@ public:
     eprosima::fastcdr::Cdr & deser, void * ros_message, const void * impl) const override;
 
   bool get_key_hash_from_ros_message(
-    void * ros_message, eprosima::fastrtps::rtps::InstanceHandle_t * ihandle, bool force_md5,
+    void * ros_message, eprosima::fastdds::rtps::InstanceHandle_t * ihandle, bool force_md5,
     const void * impl) const override;
 };
 
@@ -191,7 +191,7 @@ public:
 
   bool get_key_hash_from_ros_message(
     void * ros_message,
-    eprosima::fastrtps::rtps::InstanceHandle_t * ihandle,
+    eprosima::fastdds::rtps::InstanceHandle_t * ihandle,
     bool force_md5,
     const void * impl) const override;
 
@@ -255,7 +255,7 @@ private:
   bool get_key_hash_from_ros_message(
     const MembersType * members,
     void * ros_message,
-    eprosima::fastrtps::rtps::InstanceHandle_t * ihandle,
+    eprosima::fastdds::rtps::InstanceHandle_t * ihandle,
     bool force_md5) const;
 };
 

--- a/rmw_fastrtps_dynamic_cpp/src/TypeSupport_impl.hpp
+++ b/rmw_fastrtps_dynamic_cpp/src/TypeSupport_impl.hpp
@@ -340,7 +340,7 @@ bool TypeSupport<MembersType>::get_key_hash_from_ros_message(
   // get estimated serialized size in case key is unbounded
   if (this->key_is_unbounded_)
   {
-    this->key_max_serialized_size_ = this->getEstimatedSerializedKeySize(members, ros_message);
+    this->key_max_serialized_size_ = (std::max) (this->key_max_serialized_size_, this->getEstimatedSerializedKeySize(members, ros_message));
     key_buffer_.reserve(this->key_max_serialized_size_);
   }
 
@@ -1005,7 +1005,6 @@ size_t TypeSupport<MembersType>::calculateMaxSerializedSize(
 
           if (compute_key)
           {
-            std::cout << "Setting is key unbounded !" << std::endl;
             is_key_unbounded = true;
           }
 

--- a/rmw_fastrtps_dynamic_cpp/src/TypeSupport_impl.hpp
+++ b/rmw_fastrtps_dynamic_cpp/src/TypeSupport_impl.hpp
@@ -1126,8 +1126,10 @@ bool TypeSupport<MembersType>::deserializeROSmessage(
 
 template<typename MembersType>
 bool TypeSupport<MembersType>::get_key_hash_from_ros_message(
-  void * ros_message, eprosima::fastdds::rtps::InstanceHandle_t * ihandle, bool force_md5,
-  const void * impl) const
+  void * ros_message,
+  eprosima::fastdds::rtps::InstanceHandle_t * ihandle,
+  bool force_md5,
+  const void * [[maybe_unused]] impl) const
 {
   assert(ros_message);
   assert(ihandle);
@@ -1135,7 +1137,6 @@ bool TypeSupport<MembersType>::get_key_hash_from_ros_message(
 
   bool ret = false;
 
-  (void)impl;
   if (members_->member_count_ != 0) {
     ret = TypeSupport::get_key_hash_from_ros_message(members_, ros_message, ihandle, force_md5);
   }

--- a/rmw_fastrtps_dynamic_cpp/src/TypeSupport_impl.hpp
+++ b/rmw_fastrtps_dynamic_cpp/src/TypeSupport_impl.hpp
@@ -337,6 +337,7 @@ bool TypeSupport<MembersType>::get_key_hash_from_ros_message(
 {
   assert(members);
   assert(ros_message);
+  assert(ihandle);
 
   // get estimated serialized size in case key is unbounded
   if (this->key_is_unbounded_) {
@@ -1129,6 +1130,7 @@ bool TypeSupport<MembersType>::get_key_hash_from_ros_message(
   const void * impl) const
 {
   assert(ros_message);
+  assert(ihandle);
   assert(members_);
 
   bool ret = false;

--- a/rmw_fastrtps_dynamic_cpp/src/TypeSupport_impl.hpp
+++ b/rmw_fastrtps_dynamic_cpp/src/TypeSupport_impl.hpp
@@ -916,7 +916,7 @@ template<typename MembersType>
 size_t TypeSupport<MembersType>::calculateMaxSerializedSize(
   const MembersType * members, size_t current_alignment)
 {
-  bool is_key_unbounded{false}; //unused
+  bool is_key_unbounded{false};  // unused
   return calculateMaxSerializedSize(members, current_alignment, false, is_key_unbounded);
 }
 
@@ -1128,7 +1128,6 @@ bool TypeSupport<MembersType>::get_key_hash_from_ros_message(
   void * ros_message, eprosima::fastrtps::rtps::InstanceHandle_t * ihandle, bool force_md5,
   const void * impl) const
 {
-
   assert(ros_message);
   assert(members_);
 

--- a/rmw_fastrtps_dynamic_cpp/src/TypeSupport_impl.hpp
+++ b/rmw_fastrtps_dynamic_cpp/src/TypeSupport_impl.hpp
@@ -332,7 +332,7 @@ template<typename MembersType>
 bool TypeSupport<MembersType>::get_key_hash_from_ros_message(
   const MembersType * members,
   void * ros_message,
-  eprosima::fastrtps::rtps::InstanceHandle_t * ihandle,
+  eprosima::fastdds::rtps::InstanceHandle_t * ihandle,
   bool force_md5) const
 {
   assert(members);
@@ -1126,7 +1126,7 @@ bool TypeSupport<MembersType>::deserializeROSmessage(
 
 template<typename MembersType>
 bool TypeSupport<MembersType>::get_key_hash_from_ros_message(
-  void * ros_message, eprosima::fastrtps::rtps::InstanceHandle_t * ihandle, bool force_md5,
+  void * ros_message, eprosima::fastdds::rtps::InstanceHandle_t * ihandle, bool force_md5,
   const void * impl) const
 {
   assert(ros_message);

--- a/rmw_fastrtps_dynamic_cpp/src/TypeSupport_impl.hpp
+++ b/rmw_fastrtps_dynamic_cpp/src/TypeSupport_impl.hpp
@@ -234,8 +234,7 @@ bool TypeSupport<MembersType>::serializeROSmessage(
   for (uint32_t i = 0; i < members->member_count_; ++i) {
     const auto member = members->members_ + i;
 
-    if (compute_key && !member->is_key_ && members->has_any_key_member_)
-    {
+    if (compute_key && !member->is_key_ && members->has_any_key_member_) {
       continue;
     }
 
@@ -314,7 +313,9 @@ bool TypeSupport<MembersType>::serializeROSmessage(
               return false;
             }
             for (size_t index = 0; index < array_size; ++index) {
-              serializeROSmessage(ser, sub_members, member->get_function(field, index), compute_key);
+              serializeROSmessage(
+                ser, sub_members, member->get_function(field, index),
+                compute_key);
             }
           }
         }
@@ -338,9 +339,10 @@ bool TypeSupport<MembersType>::get_key_hash_from_ros_message(
   assert(ros_message);
 
   // get estimated serialized size in case key is unbounded
-  if (this->key_is_unbounded_)
-  {
-    this->key_max_serialized_size_ = (std::max) (this->key_max_serialized_size_, this->getEstimatedSerializedKeySize(members, ros_message));
+  if (this->key_is_unbounded_) {
+    this->key_max_serialized_size_ =
+      (std::max) (this->key_max_serialized_size_,
+      this->getEstimatedSerializedKeySize(members, ros_message));
     key_buffer_.reserve(this->key_max_serialized_size_);
   }
 
@@ -355,25 +357,22 @@ bool TypeSupport<MembersType>::get_key_hash_from_ros_message(
   serializeKeyROSmessage(ser, members_, ros_message);
 
   // check for md5
-  if (force_md5 || this->key_max_serialized_size_ > 16)
-  {
-      md5_.init();
+  if (force_md5 || this->key_max_serialized_size_ > 16) {
+    md5_.init();
 
-      md5_.update(this->key_buffer_.data(), static_cast<unsigned int>(ser.get_serialized_data_length()));
+    md5_.update(
+      this->key_buffer_.data(),
+      static_cast<unsigned int>(ser.get_serialized_data_length()));
 
-      md5_.finalize();
+    md5_.finalize();
 
-      for (uint8_t i = 0; i < 16; ++i)
-      {
-          ihandle->value[i] = md5_.digest[i];
-      }
-  }
-  else
-  {
-      for (uint8_t i = 0; i < 16; ++i)
-      {
-          ihandle->value[i] = this->key_buffer_[i];
-      }
+    for (uint8_t i = 0; i < 16; ++i) {
+      ihandle->value[i] = md5_.digest[i];
+    }
+  } else {
+    for (uint8_t i = 0; i < 16; ++i) {
+      ihandle->value[i] = this->key_buffer_[i];
+    }
   }
 
   return true;
@@ -576,8 +575,7 @@ size_t TypeSupport<MembersType>::getEstimatedSerializedSize(
     const auto member = members->members_ + i;
     void * field = const_cast<char *>(static_cast<const char *>(ros_message)) + member->offset_;
 
-    if (compute_key && !member->is_key_ && members->has_any_key_member_)
-    {
+    if (compute_key && !member->is_key_ && members->has_any_key_member_) {
       continue;
     }
 
@@ -627,7 +625,9 @@ size_t TypeSupport<MembersType>::getEstimatedSerializedSize(
         {
           auto sub_members = static_cast<const MembersType *>(member->members_->data);
           if (!member->is_array_) {
-            current_alignment += getEstimatedSerializedSize(sub_members, field, current_alignment, compute_key);
+            current_alignment += getEstimatedSerializedSize(
+              sub_members, field, current_alignment,
+              compute_key);
           } else {
             size_t array_size = 0;
 
@@ -932,7 +932,7 @@ size_t TypeSupport<MembersType>::calculateMaxSerializedSize(
   const MembersType * members,
   size_t current_alignment,
   bool compute_key,
-  bool& is_key_unbounded)
+  bool & is_key_unbounded)
 {
   assert(members);
 
@@ -946,8 +946,7 @@ size_t TypeSupport<MembersType>::calculateMaxSerializedSize(
 
     size_t array_size = 1;
 
-    if (compute_key && !member->is_key_ && members->has_any_key_member_)
-    {
+    if (compute_key && !member->is_key_ && members->has_any_key_member_) {
       continue;
     }
 
@@ -1003,8 +1002,7 @@ size_t TypeSupport<MembersType>::calculateMaxSerializedSize(
           this->max_size_bound_ = false;
           this->is_plain_ = false;
 
-          if (compute_key)
-          {
+          if (compute_key) {
             is_key_unbounded = true;
           }
 
@@ -1023,7 +1021,9 @@ size_t TypeSupport<MembersType>::calculateMaxSerializedSize(
         {
           auto sub_members = static_cast<const MembersType *>(member->members_->data);
           for (size_t index = 0; index < array_size; ++index) {
-            size_t curr = calculateMaxSerializedSize(sub_members, current_alignment, compute_key, is_key_unbounded);
+            size_t curr = calculateMaxSerializedSize(
+              sub_members, current_alignment, compute_key,
+              is_key_unbounded);
             current_alignment += curr;
             last_member_size += curr;
           }
@@ -1125,7 +1125,8 @@ bool TypeSupport<MembersType>::deserializeROSmessage(
 
 template<typename MembersType>
 bool TypeSupport<MembersType>::get_key_hash_from_ros_message(
-    void * ros_message, eprosima::fastrtps::rtps::InstanceHandle_t * ihandle, bool force_md5, const void * impl) const
+  void * ros_message, eprosima::fastrtps::rtps::InstanceHandle_t * ihandle, bool force_md5,
+  const void * impl) const
 {
 
   assert(ros_message);
@@ -1134,8 +1135,7 @@ bool TypeSupport<MembersType>::get_key_hash_from_ros_message(
   bool ret = false;
 
   (void)impl;
-  if (members_->member_count_ != 0)
-  {
+  if (members_->member_count_ != 0) {
     ret = TypeSupport::get_key_hash_from_ros_message(members_, ros_message, ihandle, force_md5);
   }
 

--- a/rmw_fastrtps_dynamic_cpp/src/TypeSupport_impl.hpp
+++ b/rmw_fastrtps_dynamic_cpp/src/TypeSupport_impl.hpp
@@ -76,6 +76,7 @@ TypeSupport<MembersType>::TypeSupport(
   is_compute_key_provided = false;
   max_size_bound_ = false;
   is_plain_ = false;
+  key_is_unbounded_ = false;
 }
 
 // C++ specialization
@@ -208,11 +209,36 @@ bool TypeSupport<MembersType>::serializeROSmessage(
   const MembersType * members,
   const void * ros_message) const
 {
+  return serializeROSmessage(ser, members, ros_message, false);
+}
+
+template<typename MembersType>
+bool TypeSupport<MembersType>::serializeKeyROSmessage(
+  eprosima::fastcdr::Cdr & ser,
+  const MembersType * members,
+  const void * ros_message) const
+{
+  return serializeROSmessage(ser, members, ros_message, true);
+}
+
+template<typename MembersType>
+bool TypeSupport<MembersType>::serializeROSmessage(
+  eprosima::fastcdr::Cdr & ser,
+  const MembersType * members,
+  const void * ros_message,
+  bool compute_key) const
+{
   assert(members);
   assert(ros_message);
 
   for (uint32_t i = 0; i < members->member_count_; ++i) {
     const auto member = members->members_ + i;
+
+    if (compute_key && !member->is_key_ && members->has_any_key_member_)
+    {
+      continue;
+    }
+
     void * field = const_cast<char *>(static_cast<const char *>(ros_message)) + member->offset_;
     switch (member->type_id_) {
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_BOOL:
@@ -266,7 +292,7 @@ bool TypeSupport<MembersType>::serializeROSmessage(
         {
           auto sub_members = static_cast<const MembersType *>(member->members_->data);
           if (!member->is_array_) {
-            serializeROSmessage(ser, sub_members, field);
+            serializeROSmessage(ser, sub_members, field, compute_key);
           } else {
             size_t array_size = 0;
 
@@ -288,7 +314,7 @@ bool TypeSupport<MembersType>::serializeROSmessage(
               return false;
             }
             for (size_t index = 0; index < array_size; ++index) {
-              serializeROSmessage(ser, sub_members, member->get_function(field, index));
+              serializeROSmessage(ser, sub_members, member->get_function(field, index), compute_key);
             }
           }
         }
@@ -296,6 +322,58 @@ bool TypeSupport<MembersType>::serializeROSmessage(
       default:
         throw std::runtime_error("unknown type");
     }
+  }
+
+  return true;
+}
+
+template<typename MembersType>
+bool TypeSupport<MembersType>::get_key_hash_from_ros_message(
+  const MembersType * members,
+  void * ros_message,
+  eprosima::fastrtps::rtps::InstanceHandle_t * ihandle,
+  bool force_md5) const
+{
+  assert(members);
+  assert(ros_message);
+
+  // get estimated serialized size in case key is unbounded
+  if (this->key_is_unbounded_)
+  {
+    this->key_max_serialized_size_ = this->getEstimatedSerializedKeySize(members, ros_message);
+    key_buffer_.reserve(this->key_max_serialized_size_);
+  }
+
+  eprosima::fastcdr::FastBuffer buffer(
+    reinterpret_cast<char *>(this->key_buffer_.data()),
+    this->key_max_serialized_size_);
+
+  eprosima::fastcdr::Cdr ser(
+    buffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN, eprosima::fastcdr::CdrVersion::XCDRv1);
+
+  // serialize
+  serializeKeyROSmessage(ser, members_, ros_message);
+
+  // check for md5
+  if (force_md5 || this->key_max_serialized_size_ > 16)
+  {
+      md5_.init();
+
+      md5_.update(this->key_buffer_.data(), static_cast<unsigned int>(ser.get_serialized_data_length()));
+
+      md5_.finalize();
+
+      for (uint8_t i = 0; i < 16; ++i)
+      {
+          ihandle->value[i] = md5_.digest[i];
+      }
+  }
+  else
+  {
+      for (uint8_t i = 0; i < 16; ++i)
+      {
+          ihandle->value[i] = this->key_buffer_[i];
+      }
   }
 
   return true;
@@ -471,6 +549,24 @@ size_t TypeSupport<MembersType>::getEstimatedSerializedSize(
   const void * ros_message,
   size_t current_alignment) const
 {
+  return getEstimatedSerializedSize(members, ros_message, current_alignment, false);
+}
+
+template<typename MembersType>
+size_t TypeSupport<MembersType>::getEstimatedSerializedKeySize(
+  const MembersType * members,
+  const void * ros_message) const
+{
+  return getEstimatedSerializedSize(members, ros_message, 0, true);
+}
+
+template<typename MembersType>
+size_t TypeSupport<MembersType>::getEstimatedSerializedSize(
+  const MembersType * members,
+  const void * ros_message,
+  size_t current_alignment,
+  bool compute_key) const
+{
   assert(members);
   assert(ros_message);
 
@@ -479,6 +575,12 @@ size_t TypeSupport<MembersType>::getEstimatedSerializedSize(
   for (uint32_t i = 0; i < members->member_count_; ++i) {
     const auto member = members->members_ + i;
     void * field = const_cast<char *>(static_cast<const char *>(ros_message)) + member->offset_;
+
+    if (compute_key && !member->is_key_ && members->has_any_key_member_)
+    {
+      continue;
+    }
+
     switch (member->type_id_) {
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_BOOL:
         current_alignment = next_field_align<bool>(member, field, current_alignment);
@@ -525,7 +627,7 @@ size_t TypeSupport<MembersType>::getEstimatedSerializedSize(
         {
           auto sub_members = static_cast<const MembersType *>(member->members_->data);
           if (!member->is_array_) {
-            current_alignment += getEstimatedSerializedSize(sub_members, field, current_alignment);
+            current_alignment += getEstimatedSerializedSize(sub_members, field, current_alignment, compute_key);
           } else {
             size_t array_size = 0;
 
@@ -550,7 +652,8 @@ size_t TypeSupport<MembersType>::getEstimatedSerializedSize(
               current_alignment += getEstimatedSerializedSize(
                 sub_members,
                 member->get_function(field, index),
-                current_alignment);
+                current_alignment,
+                compute_key);
             }
           }
         }
@@ -813,6 +916,24 @@ template<typename MembersType>
 size_t TypeSupport<MembersType>::calculateMaxSerializedSize(
   const MembersType * members, size_t current_alignment)
 {
+  bool is_key_unbounded{false}; //unused
+  return calculateMaxSerializedSize(members, current_alignment, false, is_key_unbounded);
+}
+
+template<typename MembersType>
+size_t TypeSupport<MembersType>::calculateMaxSerializedKeySize(
+  const MembersType * members)
+{
+  return calculateMaxSerializedSize(members, 0, true, this->key_is_unbounded_);
+}
+
+template<typename MembersType>
+size_t TypeSupport<MembersType>::calculateMaxSerializedSize(
+  const MembersType * members,
+  size_t current_alignment,
+  bool compute_key,
+  bool& is_key_unbounded)
+{
   assert(members);
 
   size_t initial_alignment = current_alignment;
@@ -824,6 +945,12 @@ size_t TypeSupport<MembersType>::calculateMaxSerializedSize(
     const auto * member = members->members_ + i;
 
     size_t array_size = 1;
+
+    if (compute_key && !member->is_key_ && members->has_any_key_member_)
+    {
+      continue;
+    }
+
     if (member->is_array_) {
       array_size = member->array_size_;
 
@@ -875,6 +1002,13 @@ size_t TypeSupport<MembersType>::calculateMaxSerializedSize(
         {
           this->max_size_bound_ = false;
           this->is_plain_ = false;
+
+          if (compute_key)
+          {
+            std::cout << "Setting is key unbounded !" << std::endl;
+            is_key_unbounded = true;
+          }
+
           size_t character_size =
             (member->type_id_ == rosidl_typesupport_introspection_cpp::ROS_TYPE_WSTRING) ? 4 : 1;
           size_t extra_char =
@@ -890,7 +1024,7 @@ size_t TypeSupport<MembersType>::calculateMaxSerializedSize(
         {
           auto sub_members = static_cast<const MembersType *>(member->members_->data);
           for (size_t index = 0; index < array_size; ++index) {
-            size_t curr = calculateMaxSerializedSize(sub_members, current_alignment);
+            size_t curr = calculateMaxSerializedSize(sub_members, current_alignment, compute_key, is_key_unbounded);
             current_alignment += curr;
             last_member_size += curr;
           }
@@ -988,6 +1122,25 @@ bool TypeSupport<MembersType>::deserializeROSmessage(
   }
 
   return true;
+}
+
+template<typename MembersType>
+bool TypeSupport<MembersType>::get_key_hash_from_ros_message(
+    void * ros_message, eprosima::fastrtps::rtps::InstanceHandle_t * ihandle, bool force_md5, const void * impl) const
+{
+
+  assert(ros_message);
+  assert(members_);
+
+  bool ret = false;
+
+  (void)impl;
+  if (members_->member_count_ != 0)
+  {
+    ret = TypeSupport::get_key_hash_from_ros_message(members_, ros_message, ihandle, force_md5);
+  }
+
+  return ret;
 }
 
 }  // namespace rmw_fastrtps_dynamic_cpp

--- a/rmw_fastrtps_dynamic_cpp/src/publisher.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/publisher.cpp
@@ -271,6 +271,15 @@ rmw_fastrtps_dynamic_cpp::create_publisher(
     return nullptr;
   }
 
+  // Apply resource limits QoS if the type is keyed
+  if (fastdds_type->m_isGetKeyDefined &&
+      !participant_info->leave_middleware_default_qos)
+  {
+    rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
+      writer_qos.history(),
+      writer_qos.resource_limits());
+  }
+
   // Creates DataWriter (with publisher name to not change name policy)
   info->data_writer_ = publisher->create_datawriter(
     info->topic_,

--- a/rmw_fastrtps_dynamic_cpp/src/publisher.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/publisher.cpp
@@ -272,7 +272,7 @@ rmw_fastrtps_dynamic_cpp::create_publisher(
   }
 
   // Apply resource limits QoS if the type is keyed
-  if (fastdds_type->m_isGetKeyDefined &&
+  if (fastdds_type->is_compute_key_provided &&
     !participant_info->leave_middleware_default_qos)
   {
     rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(

--- a/rmw_fastrtps_dynamic_cpp/src/publisher.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/publisher.cpp
@@ -273,7 +273,7 @@ rmw_fastrtps_dynamic_cpp::create_publisher(
 
   // Apply resource limits QoS if the type is keyed
   if (fastdds_type->m_isGetKeyDefined &&
-      !participant_info->leave_middleware_default_qos)
+    !participant_info->leave_middleware_default_qos)
   {
     rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
       writer_qos.history(),

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
@@ -358,7 +358,7 @@ rmw_create_client(
   }
 
   // Apply resource limits QoS if the type is keyed
-  if (response_fastdds_type->m_isGetKeyDefined &&
+  if (response_fastdds_type->is_compute_key_provided &&
     !participant_info->leave_middleware_default_qos)
   {
     rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
@@ -425,7 +425,7 @@ rmw_create_client(
   }
 
   // Apply resource limits QoS if the type is keyed
-  if (request_fastdds_type->m_isGetKeyDefined &&
+  if (request_fastdds_type->is_compute_key_provided &&
     !participant_info->leave_middleware_default_qos)
   {
     rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
@@ -359,7 +359,7 @@ rmw_create_client(
 
   // Apply resource limits QoS if the type is keyed
   if (response_fastdds_type->m_isGetKeyDefined &&
-      !participant_info->leave_middleware_default_qos)
+    !participant_info->leave_middleware_default_qos)
   {
     rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
       reader_qos.history(),
@@ -426,7 +426,7 @@ rmw_create_client(
 
   // Apply resource limits QoS if the type is keyed
   if (request_fastdds_type->m_isGetKeyDefined &&
-      !participant_info->leave_middleware_default_qos)
+    !participant_info->leave_middleware_default_qos)
   {
     rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
       writer_qos.history(),

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
@@ -357,6 +357,15 @@ rmw_create_client(
     return nullptr;
   }
 
+  // Apply resource limits QoS if the type is keyed
+  if (response_fastdds_type->m_isGetKeyDefined &&
+      !participant_info->leave_middleware_default_qos)
+  {
+    rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
+      reader_qos.history(),
+      reader_qos.resource_limits());
+  }
+
   // Creates DataReader
   info->response_reader_ = subscriber->create_datareader(
     response_topic_desc,
@@ -413,6 +422,15 @@ rmw_create_client(
   {
     RMW_SET_ERROR_MSG("create_client() failed setting request DataWriter QoS");
     return nullptr;
+  }
+
+  // Apply resource limits QoS if the type is keyed
+  if (request_fastdds_type->m_isGetKeyDefined &&
+      !participant_info->leave_middleware_default_qos)
+  {
+    rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
+      writer_qos.history(),
+      writer_qos.resource_limits());
   }
 
   // Creates DataWriter

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
@@ -353,6 +353,15 @@ rmw_create_service(
     return nullptr;
   }
 
+  // Apply resource limits QoS if the type is keyed
+  if (request_fastdds_type->m_isGetKeyDefined &&
+      !participant_info->leave_middleware_default_qos)
+  {
+    rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
+      reader_qos.history(),
+      reader_qos.resource_limits());
+  }
+
   // Creates DataReader
   info->request_reader_ = subscriber->create_datareader(
     request_topic_desc,
@@ -413,6 +422,15 @@ rmw_create_service(
   {
     RMW_SET_ERROR_MSG("create_service() failed setting response DataWriter QoS");
     return nullptr;
+  }
+
+  // Apply resource limits QoS if the type is keyed
+  if (response_fastdds_type->m_isGetKeyDefined &&
+      !participant_info->leave_middleware_default_qos)
+  {
+    rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
+      writer_qos.history(),
+      writer_qos.resource_limits());
   }
 
   // Creates DataWriter

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
@@ -355,7 +355,7 @@ rmw_create_service(
 
   // Apply resource limits QoS if the type is keyed
   if (request_fastdds_type->m_isGetKeyDefined &&
-      !participant_info->leave_middleware_default_qos)
+    !participant_info->leave_middleware_default_qos)
   {
     rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
       reader_qos.history(),
@@ -426,7 +426,7 @@ rmw_create_service(
 
   // Apply resource limits QoS if the type is keyed
   if (response_fastdds_type->m_isGetKeyDefined &&
-      !participant_info->leave_middleware_default_qos)
+    !participant_info->leave_middleware_default_qos)
   {
     rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
       writer_qos.history(),

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
@@ -354,7 +354,7 @@ rmw_create_service(
   }
 
   // Apply resource limits QoS if the type is keyed
-  if (request_fastdds_type->m_isGetKeyDefined &&
+  if (request_fastdds_type->is_compute_key_provided &&
     !participant_info->leave_middleware_default_qos)
   {
     rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
@@ -425,7 +425,7 @@ rmw_create_service(
   }
 
   // Apply resource limits QoS if the type is keyed
-  if (response_fastdds_type->m_isGetKeyDefined &&
+  if (response_fastdds_type->is_compute_key_provided &&
     !participant_info->leave_middleware_default_qos)
   {
     rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(

--- a/rmw_fastrtps_dynamic_cpp/src/subscription.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/subscription.cpp
@@ -273,7 +273,7 @@ create_subscription(
   }
 
   // Apply resource limits QoS if the type is keyed
-  if (fastdds_type->m_isGetKeyDefined &&
+  if (fastdds_type->is_compute_key_provided &&
     !participant_info->leave_middleware_default_qos)
   {
     rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(

--- a/rmw_fastrtps_dynamic_cpp/src/subscription.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/subscription.cpp
@@ -274,7 +274,7 @@ create_subscription(
 
   // Apply resource limits QoS if the type is keyed
   if (fastdds_type->m_isGetKeyDefined &&
-      !participant_info->leave_middleware_default_qos)
+    !participant_info->leave_middleware_default_qos)
   {
     rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
       reader_qos.history(),

--- a/rmw_fastrtps_dynamic_cpp/src/subscription.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/subscription.cpp
@@ -272,6 +272,15 @@ create_subscription(
     return nullptr;
   }
 
+  // Apply resource limits QoS if the type is keyed
+  if (fastdds_type->m_isGetKeyDefined &&
+      !participant_info->leave_middleware_default_qos)
+  {
+    rmw_fastrtps_shared_cpp::apply_qos_resource_limits_for_keys(
+      reader_qos.history(),
+      reader_qos.resource_limits());
+  }
+
   eprosima::fastdds::dds::DataReaderQos original_qos = reader_qos;
   switch (subscription_options->require_unique_network_flow_endpoints) {
     default:

--- a/rmw_fastrtps_dynamic_cpp/src/type_support_proxy.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/type_support_proxy.cpp
@@ -24,6 +24,8 @@ TypeSupportProxy::TypeSupportProxy(rmw_fastrtps_shared_cpp::TypeSupport * inner_
   max_serialized_type_size = inner_type->max_serialized_type_size;
   is_plain_ = inner_type->is_plain(eprosima::fastdds::dds::XCDR_DATA_REPRESENTATION);
   max_size_bound_ = inner_type->is_bounded();
+  m_isGetKeyDefined = inner_type->m_isGetKeyDefined;
+  key_is_unbounded_ = inner_type->is_key_unbounded();
 }
 
 size_t TypeSupportProxy::getEstimatedSerializedSize(
@@ -45,6 +47,13 @@ bool TypeSupportProxy::deserializeROSmessage(
 {
   auto type_impl = static_cast<const rmw_fastrtps_shared_cpp::TypeSupport *>(impl);
   return type_impl->deserializeROSmessage(deser, ros_message, impl);
+}
+
+bool TypeSupportProxy::get_key_hash_from_ros_message(
+    void * ros_message, eprosima::fastrtps::rtps::InstanceHandle_t * ihandle, bool force_md5, const void * impl) const
+{
+  auto type_impl = static_cast<const rmw_fastrtps_shared_cpp::TypeSupport *>(impl);
+  return type_impl->get_key_hash_from_ros_message(ros_message, ihandle, force_md5, impl);
 }
 
 }  // namespace rmw_fastrtps_dynamic_cpp

--- a/rmw_fastrtps_dynamic_cpp/src/type_support_proxy.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/type_support_proxy.cpp
@@ -50,7 +50,9 @@ bool TypeSupportProxy::deserializeROSmessage(
 }
 
 bool TypeSupportProxy::get_key_hash_from_ros_message(
-  void * ros_message, eprosima::fastdds::rtps::InstanceHandle_t * ihandle, bool force_md5,
+  void * ros_message,
+  eprosima::fastdds::rtps::InstanceHandle_t * ihandle,
+  bool force_md5,
   const void * impl) const
 {
   auto type_impl = static_cast<const rmw_fastrtps_shared_cpp::TypeSupport *>(impl);

--- a/rmw_fastrtps_dynamic_cpp/src/type_support_proxy.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/type_support_proxy.cpp
@@ -24,7 +24,7 @@ TypeSupportProxy::TypeSupportProxy(rmw_fastrtps_shared_cpp::TypeSupport * inner_
   max_serialized_type_size = inner_type->max_serialized_type_size;
   is_plain_ = inner_type->is_plain(eprosima::fastdds::dds::XCDR_DATA_REPRESENTATION);
   max_size_bound_ = inner_type->is_bounded();
-  m_isGetKeyDefined = inner_type->m_isGetKeyDefined;
+  is_compute_key_provided = inner_type->is_compute_key_provided;
   key_is_unbounded_ = inner_type->is_key_unbounded();
 }
 
@@ -50,7 +50,7 @@ bool TypeSupportProxy::deserializeROSmessage(
 }
 
 bool TypeSupportProxy::get_key_hash_from_ros_message(
-  void * ros_message, eprosima::fastrtps::rtps::InstanceHandle_t * ihandle, bool force_md5,
+  void * ros_message, eprosima::fastdds::rtps::InstanceHandle_t * ihandle, bool force_md5,
   const void * impl) const
 {
   auto type_impl = static_cast<const rmw_fastrtps_shared_cpp::TypeSupport *>(impl);

--- a/rmw_fastrtps_dynamic_cpp/src/type_support_proxy.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/type_support_proxy.cpp
@@ -50,7 +50,8 @@ bool TypeSupportProxy::deserializeROSmessage(
 }
 
 bool TypeSupportProxy::get_key_hash_from_ros_message(
-    void * ros_message, eprosima::fastrtps::rtps::InstanceHandle_t * ihandle, bool force_md5, const void * impl) const
+  void * ros_message, eprosima::fastrtps::rtps::InstanceHandle_t * ihandle, bool force_md5,
+  const void * impl) const
 {
   auto type_impl = static_cast<const rmw_fastrtps_shared_cpp::TypeSupport *>(impl);
   return type_impl->get_key_hash_from_ros_message(ros_message, ihandle, force_md5, impl);

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/TypeSupport.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/TypeSupport.hpp
@@ -146,6 +146,7 @@ protected:
   mutable size_t key_max_serialized_size_ {0};
   mutable eprosima::fastdds::MD5 md5_;
   mutable std::vector<uint8_t> key_buffer_;
+  mutable std::mutex mtx_;
 };
 
 }  // namespace rmw_fastrtps_shared_cpp

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/TypeSupport.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/TypeSupport.hpp
@@ -63,7 +63,9 @@ public:
     eprosima::fastcdr::Cdr & deser, void * ros_message, const void * impl) const = 0;
 
   virtual bool get_key_hash_from_ros_message(
-    void * ros_message, eprosima::fastdds::rtps::InstanceHandle_t * ihandle, bool force_md5,
+    void * ros_message,
+    eprosima::fastdds::rtps::InstanceHandle_t * ihandle,
+    bool force_md5,
     const void * impl) const = 0;
 
   RMW_FASTRTPS_SHARED_CPP_PUBLIC

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/TypeSupport.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/TypeSupport.hpp
@@ -62,7 +62,8 @@ public:
     eprosima::fastcdr::Cdr & deser, void * ros_message, const void * impl) const = 0;
 
   virtual bool get_key_hash_from_ros_message(
-  void * ros_message, eprosima::fastdds::rtps::InstanceHandle_t * ihandle, bool force_md5, const void * impl) const = 0;
+    void * ros_message, eprosima::fastdds::rtps::InstanceHandle_t * ihandle, bool force_md5,
+    const void * impl) const = 0;
 
   RMW_FASTRTPS_SHARED_CPP_PUBLIC
   bool compute_key(

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/TypeSupport.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/TypeSupport.hpp
@@ -24,6 +24,7 @@
 
 #include "fastcdr/FastBuffer.h"
 #include "fastcdr/Cdr.h"
+#include "fastdds/utils/md5.hpp"
 
 #include "rcutils/logging_macros.h"
 
@@ -60,15 +61,14 @@ public:
   virtual bool deserializeROSmessage(
     eprosima::fastcdr::Cdr & deser, void * ros_message, const void * impl) const = 0;
 
+  virtual bool get_key_hash_from_ros_message(
+  void * ros_message, eprosima::fastdds::rtps::InstanceHandle_t * ihandle, bool force_md5, const void * impl) const = 0;
+
   RMW_FASTRTPS_SHARED_CPP_PUBLIC
   bool compute_key(
     const void * const data,
     eprosima::fastdds::rtps::InstanceHandle_t & ihandle,
-    bool force_md5 = false) override
-  {
-    (void)data; (void)ihandle; (void)force_md5;
-    return false;
-  }
+    bool force_md5 = false) override;
 
   RMW_FASTRTPS_SHARED_CPP_PUBLIC
   bool compute_key(
@@ -125,6 +125,12 @@ public:
   }
 
   RMW_FASTRTPS_SHARED_CPP_PUBLIC
+  inline bool is_key_unbounded() const
+  {
+    return key_is_unbounded_;
+  }
+
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   virtual ~TypeSupport() {}
 
 protected:
@@ -136,6 +142,10 @@ protected:
   bool max_size_bound_ {false};
   bool is_plain_ {false};
   const rosidl_message_type_support_t * type_supports_ {nullptr};
+  bool key_is_unbounded_ {false};
+  mutable size_t key_max_serialized_size_ {0};
+  mutable eprosima::fastdds::MD5 md5_;
+  mutable std::vector<uint8_t> key_buffer_;
 };
 
 }  // namespace rmw_fastrtps_shared_cpp

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/TypeSupport.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/TypeSupport.hpp
@@ -17,6 +17,7 @@
 
 #include <cassert>
 #include <string>
+#include <vector>
 
 #include "fastdds/dds/topic/TopicDataType.hpp"
 #include "fastdds/rtps/common/InstanceHandle.hpp"

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/utils.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/utils.hpp
@@ -131,7 +131,7 @@ create_datareader(
 * Max samples per instance is set to history depth if KEEP_LAST
 * else UNLIMITED.
 *
-* \param[in]       history_qos       History entitiy QoS.
+* \param[in]       history_qos      History entitiy QoS.
 * \param[in, out]  res_limits_qos   Resource limits entitiy QoS.
 *
 */

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/utils.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/utils.hpp
@@ -126,6 +126,21 @@ create_datareader(
   CustomDataReaderListener * listener,
   eprosima::fastdds::dds::DataReader ** data_reader);
 
+/**
+* Apply specific resource limits when using keys.
+* Max samples per instance is set to history depth if KEEP_LAST
+* else UNLIMITED.
+*
+* \param[in]       hitory_qos       History entitiy QoS.
+* \param[in, out]  res_limits_qos   Resource limits entitiy QoS.
+*
+*/
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
+void
+apply_qos_resource_limits_for_keys(
+  const eprosima::fastdds::dds::HistoryQosPolicy & history_qos,
+  eprosima::fastdds::dds::ResourceLimitsQosPolicy & res_limits_qos);
+
 }  // namespace rmw_fastrtps_shared_cpp
 
 #endif  // RMW_FASTRTPS_SHARED_CPP__UTILS_HPP_

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/utils.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/utils.hpp
@@ -131,7 +131,7 @@ create_datareader(
 * Max samples per instance is set to history depth if KEEP_LAST
 * else UNLIMITED.
 *
-* \param[in]       hitory_qos       History entitiy QoS.
+* \param[in]       history_qos       History entitiy QoS.
 * \param[in, out]  res_limits_qos   Resource limits entitiy QoS.
 *
 */

--- a/rmw_fastrtps_shared_cpp/src/TypeSupport_impl.cpp
+++ b/rmw_fastrtps_shared_cpp/src/TypeSupport_impl.cpp
@@ -67,27 +67,26 @@ void * TypeSupport::create_data()
 }
 
 bool TypeSupport::compute_key(
-    const void * const data,
-    eprosima::fastdds::rtps::InstanceHandle_t & ihandle,
-    bool force_md5)
+  const void * const data,
+  eprosima::fastdds::rtps::InstanceHandle_t & ihandle,
+  bool force_md5)
 {
   assert(data);
 
   bool ret = false;
 
-  if (!is_compute_key_provided)
-  {
-      return ret;
+  if (!is_compute_key_provided) {
+    return ret;
   }
 
   auto ser_data = static_cast<const SerializedData *>(data);
 
-  switch (ser_data->type)
-  {
+  switch (ser_data->type) {
     case FASTDDS_SERIALIZED_DATA_TYPE_ROS_MESSAGE:
       {
         std::lock_guard lock(this->mtx_);
-        ret = this->get_key_hash_from_ros_message(ser_data->data, &ihandle, force_md5, ser_data->impl);
+        ret =
+          this->get_key_hash_from_ros_message(ser_data->data, &ihandle, force_md5, ser_data->impl);
         break;
       }
 

--- a/rmw_fastrtps_shared_cpp/src/TypeSupport_impl.cpp
+++ b/rmw_fastrtps_shared_cpp/src/TypeSupport_impl.cpp
@@ -66,6 +66,59 @@ void * TypeSupport::create_data()
   return new eprosima::fastcdr::FastBuffer();
 }
 
+bool TypeSupport::compute_key(
+    const void * const data,
+    eprosima::fastdds::rtps::InstanceHandle_t & ihandle,
+    bool force_md5)
+{
+  assert(data);
+
+  bool ret = false;
+
+  if (!is_compute_key_provided)
+  {
+      return ret;
+  }
+
+  auto ser_data = static_cast<const SerializedData *>(data);
+
+  switch (ser_data->type)
+  {
+    case FASTDDS_SERIALIZED_DATA_TYPE_ROS_MESSAGE:
+      {
+        ret = this->get_key_hash_from_ros_message(ser_data->data, &ihandle, force_md5, ser_data->impl);
+        break;
+      }
+
+    case FASTDDS_SERIALIZED_DATA_TYPE_CDR_BUFFER:
+      {
+        // TODO
+        // We would need a get_key_hash_from_payload method
+        break;
+      }
+
+    case FASTDDS_SERIALIZED_DATA_TYPE_DYNAMIC_MESSAGE:
+      {
+
+        auto m_type = std::make_shared<eprosima::fastdds::dds::DynamicPubSubType>();
+
+        // Retrieves the key (ihandle) from the dynamic data stored in data->data
+        return m_type->compute_key(
+          static_cast<eprosima::fastdds::dds::DynamicData *>(ser_data->data),
+          ihandle,
+          force_md5);
+
+        break;
+      }
+    default:
+      {
+        break;
+      }
+  }
+
+  return ret;
+}
+
 bool TypeSupport::serialize(
   const void * const data, eprosima::fastdds::rtps::SerializedPayload_t & payload,
   eprosima::fastdds::dds::DataRepresentationId_t data_representation)

--- a/rmw_fastrtps_shared_cpp/src/TypeSupport_impl.cpp
+++ b/rmw_fastrtps_shared_cpp/src/TypeSupport_impl.cpp
@@ -92,14 +92,13 @@ bool TypeSupport::compute_key(
 
     case FASTDDS_SERIALIZED_DATA_TYPE_CDR_BUFFER:
       {
-        // TODO
-        // We would need a get_key_hash_from_payload method
+        // TODO(MiguelCompany): In order to support keys in rmw_publish_serialized_message,
+        // we would need a get_key_hash_from_payload method
         break;
       }
 
     case FASTDDS_SERIALIZED_DATA_TYPE_DYNAMIC_MESSAGE:
       {
-
         auto m_type = std::make_shared<eprosima::fastdds::dds::DynamicPubSubType>();
 
         // Retrieves the key (ihandle) from the dynamic data stored in data->data

--- a/rmw_fastrtps_shared_cpp/src/TypeSupport_impl.cpp
+++ b/rmw_fastrtps_shared_cpp/src/TypeSupport_impl.cpp
@@ -86,6 +86,7 @@ bool TypeSupport::compute_key(
   {
     case FASTDDS_SERIALIZED_DATA_TYPE_ROS_MESSAGE:
       {
+        std::lock_guard lock(this->mtx_);
         ret = this->get_key_hash_from_ros_message(ser_data->data, &ihandle, force_md5, ser_data->impl);
         break;
       }

--- a/rmw_fastrtps_shared_cpp/src/utils.cpp
+++ b/rmw_fastrtps_shared_cpp/src/utils.cpp
@@ -181,5 +181,21 @@ create_datareader(
   return true;
 }
 
+void
+apply_qos_resource_limits_for_keys(
+  const eprosima::fastdds::dds::HistoryQosPolicy & history_qos,
+  eprosima::fastdds::dds::ResourceLimitsQosPolicy & res_limits_qos)
+{
+  res_limits_qos.max_instances = 0;
+  res_limits_qos.max_samples = 0;
+  if (history_qos.kind == eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS)
+  {
+    res_limits_qos.max_samples_per_instance = history_qos.depth;
+  }
+  else
+  {
+    res_limits_qos.max_samples_per_instance = 0;
+  }
+}
 
 }  // namespace rmw_fastrtps_shared_cpp

--- a/rmw_fastrtps_shared_cpp/src/utils.cpp
+++ b/rmw_fastrtps_shared_cpp/src/utils.cpp
@@ -188,12 +188,9 @@ apply_qos_resource_limits_for_keys(
 {
   res_limits_qos.max_instances = 0;
   res_limits_qos.max_samples = 0;
-  if (history_qos.kind == eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS)
-  {
+  if (history_qos.kind == eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS) {
     res_limits_qos.max_samples_per_instance = history_qos.depth;
-  }
-  else
-  {
+  } else {
     res_limits_qos.max_samples_per_instance = 0;
   }
 }


### PR DESCRIPTION
This PR adds the necessary code to support topic instances in `rmw_fastrtps_cpp` and `rmw_fastrtps_dynamic_cpp`

* Part of ros2/ros2#1538:
    * Depends on ros2/rosidl#796
    * Depends on ros2/rosidl_typesupport_fastrtps#116
