### PR TITLE
Altering liveliness lease_duration

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/qos.cpp
+++ b/rmw_fastrtps_shared_cpp/src/qos.cpp
@@ -141,8 +141,8 @@ bool fill_entity_qos_from_profile(
     // Docs suggest setting no higher than 0.7 * lease_duration, choosing 2/3 to give safe buffer.
     // See doc at https://github.com/eProsima/Fast-RTPS/blob/
     //   a8691a40be6b8460b01edde36ad8563170a3a35a/include/fastrtps/qos/QosPolicies.h#L223-L232
-    double period_in_ns = entity_qos.liveliness().lease_duration.to_ns() * 2.0 / 3.0;
-    double period_in_s = RCUTILS_NS_TO_S(period_in_ns);
+    int64_t period_in_ns = entity_qos.liveliness().lease_duration.to_ns();
+    double period_in_s = RCUITLS_NS_TO_S(period_in_s) * 2.0 / 3.0
     entity_qos.liveliness().announcement_period = eprosima::fastrtps::Duration_t(period_in_s);
   }
 

--- a/rmw_fastrtps_shared_cpp/src/qos.cpp
+++ b/rmw_fastrtps_shared_cpp/src/qos.cpp
@@ -142,7 +142,7 @@ bool fill_entity_qos_from_profile(
     // See doc at https://github.com/eProsima/Fast-RTPS/blob/
     //   a8691a40be6b8460b01edde36ad8563170a3a35a/include/fastrtps/qos/QosPolicies.h#L223-L232
     int64_t period_in_ns = entity_qos.liveliness().lease_duration.to_ns() * 2 / 3;
-    double period_in_s = RCUITLS_NS_TO_S(period_in_s);
+    double period_in_s = RCUTILS_NS_TO_S(period_in_ns);
     entity_qos.liveliness().announcement_period = eprosima::fastrtps::Duration_t(period_in_s);
   }
 

--- a/rmw_fastrtps_shared_cpp/src/qos.cpp
+++ b/rmw_fastrtps_shared_cpp/src/qos.cpp
@@ -141,8 +141,8 @@ bool fill_entity_qos_from_profile(
     // Docs suggest setting no higher than 0.7 * lease_duration, choosing 2/3 to give safe buffer.
     // See doc at https://github.com/eProsima/Fast-RTPS/blob/
     //   a8691a40be6b8460b01edde36ad8563170a3a35a/include/fastrtps/qos/QosPolicies.h#L223-L232
-    int64_t period_in_ns = entity_qos.liveliness().lease_duration.to_ns();
-    double period_in_s = RCUITLS_NS_TO_S(period_in_s) * 2.0 / 3.0
+    int64_t period_in_ns = entity_qos.liveliness().lease_duration.to_ns() * 2 / 3;
+    double period_in_s = RCUITLS_NS_TO_S(period_in_s);
     entity_qos.liveliness().announcement_period = eprosima::fastrtps::Duration_t(period_in_s);
   }
 


### PR DESCRIPTION
This pull request is supposed to solve an issue noted in [this `RCUTILS` pr](https://github.com/ros2/rcutils/pull/460#issuecomment-2080348553) in which a [qos line](https://github.com/ros2/rmw_fastrtps/blob/c48406a5f87fd7ebe5a576fbf627b6c9efcc786e/rmw_fastrtps_shared_cpp/src/qos.cpp#L145) undergoes an incorrect conversion. The original intent was to pass an `int64_t` and sacrifice some accuracy, but I don't believe it's possible due to our limited [constructors for `Duration_t`](https://github.com/eProsima/Fast-DDS/blob/eaa23dbdea6ff2fa8259452be368ac8bcb273cc5/src/cpp/rtps/common/Time_t.cpp#L67-#L86). Instead, I converted to a nanosecond value, then operated on that value by making it 2/3s the original. Then, converting that value to a sec (double) which should fill the `long double` argument. We shouldn't need to operate on the sec (double), after having converted, because while our new version will have less accuracy, `RCUTILS_NS_TO_S` is undergoing changes to become more accurate.