### PR TITLE
Add support for data representation

### DIFF
--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/TypeSupport.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/TypeSupport.hpp
@@ -105,6 +105,12 @@ public:
   }
 
   RMW_FASTRTPS_SHARED_CPP_PUBLIC
+  inline bool is_plain(eprosima::fastdds::dds::DataRepresentationId_t rep) const override
+  {
+    return is_plain_ && rep == eprosima::fastdds::dds::XCDR_DATA_REPRESENTATION;
+  }
+
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
   virtual ~TypeSupport() {}
 
 protected:

--- a/rmw_fastrtps_shared_cpp/src/qos.cpp
+++ b/rmw_fastrtps_shared_cpp/src/qos.cpp
@@ -190,7 +190,15 @@ get_datawriter_qos(
   const rosidl_type_hash_t & type_hash,
   eprosima::fastdds::dds::DataWriterQos & datawriter_qos)
 {
-  return fill_data_entity_qos_from_profile(qos_policies, type_hash, datawriter_qos);
+  if (fill_data_entity_qos_from_profile(qos_policies, type_hash, datawriter_qos)) {
+    // The type support in the RMW implementation is always XCDR1.
+    constexpr auto rep = eprosima::fastdds::dds::XCDR_DATA_REPRESENTATION;
+    datawriter_qos.representation().clear();
+    datawriter_qos.representation().m_value.push_back(rep);
+    return true;
+  }
+
+  return false;
 }
 
 bool

--- a/rmw_fastrtps_shared_cpp/src/qos.cpp
+++ b/rmw_fastrtps_shared_cpp/src/qos.cpp
@@ -181,7 +181,15 @@ get_datareader_qos(
   const rosidl_type_hash_t & type_hash,
   eprosima::fastdds::dds::DataReaderQos & datareader_qos)
 {
-  return fill_data_entity_qos_from_profile(qos_policies, type_hash, datareader_qos);
+  if (fill_data_entity_qos_from_profile(qos_policies, type_hash, datareader_qos)) {
+    // The type support in the RMW implementation is always XCDR1.
+    constexpr auto rep = eprosima::fastdds::dds::XCDR_DATA_REPRESENTATION;
+    datareader_qos.type_consistency().representation.clear();
+    datareader_qos.type_consistency().representation.m_value.push_back(rep);
+    return true;
+  }
+
+  return false;
 }
 
 bool

--- a/rmw_fastrtps_shared_cpp/test/test_rmw_qos_to_dds_attributes.cpp
+++ b/rmw_fastrtps_shared_cpp/test/test_rmw_qos_to_dds_attributes.cpp
@@ -103,6 +103,10 @@ TEST_F(GetDataReaderQoSTest, nominal_conversion) {
     eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS,
     subscriber_qos_.history().kind);
   EXPECT_GE(10, subscriber_qos_.history().depth);
+  ASSERT_EQ(1, subscriber_qos_.type_consistency().representation.m_value.size());
+  EXPECT_EQ(
+    eprosima::fastdds::dds::DataRepresentationId::XCDR_DATA_REPRESENTATION,
+    subscriber_qos_.type_consistency().representation.m_value[0]);
 }
 
 TEST_F(GetDataReaderQoSTest, large_depth_conversion) {
@@ -201,6 +205,10 @@ TEST_F(GetDataWriterQoSTest, nominal_conversion) {
     eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS,
     publisher_qos_.history().kind);
   EXPECT_GE(10, publisher_qos_.history().depth);
+  ASSERT_EQ(1, publisher_qos_.representation().m_value.size());
+  EXPECT_EQ(
+    eprosima::fastdds::dds::DataRepresentationId::XCDR_DATA_REPRESENTATION,
+    publisher_qos_.representation().m_value[0]);
 }
 
 TEST_F(GetDataWriterQoSTest, large_depth_conversion) {


### PR DESCRIPTION
This fixes the failures mentioned [here](https://github.com/ros2/ros2/pull/1560#issue-2286372464) by implementing the new `is_plain` overload of Fast DDS type support interface.

It additionally sets the data representation policy of created DataReader and DataWriter entities to XCDR1, since it is what the type support is using.