### PR TITLE
Use unique mangled names when creating Content Filter Topics

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/utils.cpp
+++ b/rmw_fastrtps_shared_cpp/src/utils.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <atomic>
+#include <cstdint>
 #include <string>
 
 #include "rmw_fastrtps_shared_cpp/utils.hpp"
@@ -110,7 +112,8 @@ create_content_filtered_topic(
 
   auto topic = dynamic_cast<eprosima::fastdds::dds::Topic *>(topic_desc);
   static std::atomic<uint32_t> cft_counter{0};
-  std::string cft_topic_name = topic_name_mangled + CONTENT_FILTERED_TOPIC_POSTFIX + "_" + std::to_string(cft_counter.fetch_add(1));
+  std::string cft_topic_name = topic_name_mangled + CONTENT_FILTERED_TOPIC_POSTFIX + "_" +
+    std::to_string(cft_counter.fetch_add(1));
   eprosima::fastdds::dds::ContentFilteredTopic * filtered_topic =
     participant->create_contentfilteredtopic(
     cft_topic_name,

--- a/rmw_fastrtps_shared_cpp/src/utils.cpp
+++ b/rmw_fastrtps_shared_cpp/src/utils.cpp
@@ -109,7 +109,8 @@ create_content_filtered_topic(
   }
 
   auto topic = dynamic_cast<eprosima::fastdds::dds::Topic *>(topic_desc);
-  std::string cft_topic_name = topic_name_mangled + CONTENT_FILTERED_TOPIC_POSTFIX;
+  static std::atomic<uint32_t> cft_counter{0};
+  std::string cft_topic_name = topic_name_mangled + CONTENT_FILTERED_TOPIC_POSTFIX + "_" + std::to_string(cft_counter.fetch_add(1));
   eprosima::fastdds::dds::ContentFilteredTopic * filtered_topic =
     participant->create_contentfilteredtopic(
     cft_topic_name,


### PR DESCRIPTION
This PR makes every Content Filter Name unique by adding a static atomic counter. With this change, two or more content-filtered subscriptions can be created for the same topic name.

Tests are included in the following related PRs
* https://github.com/ros2/rclcpp/pull/2546
* https://github.com/ros2/rmw_implementation/pull/230