### PR TITLE
Make rmw_service_server_is_available return RMW_RET_INVALID_ARGUMENT

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/rmw_service_server_is_available.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_service_server_is_available.cpp
@@ -43,7 +43,7 @@ __rmw_service_server_is_available(
 {
   if (!node) {
     RMW_SET_ERROR_MSG("node handle is null");
-    return RMW_RET_ERROR;
+    return RMW_RET_INVALID_ARGUMENT;
   }
 
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
@@ -53,7 +53,7 @@ __rmw_service_server_is_available(
 
   if (!client) {
     RMW_SET_ERROR_MSG("client handle is null");
-    return RMW_RET_ERROR;
+    return RMW_RET_INVALID_ARGUMENT;
   }
 
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
@@ -63,7 +63,7 @@ __rmw_service_server_is_available(
 
   if (!is_available) {
     RMW_SET_ERROR_MSG("is_available is null");
-    return RMW_RET_ERROR;
+    return RMW_RET_INVALID_ARGUMENT;
   }
 
   auto client_info = static_cast<CustomClientInfo *>(client->data);


### PR DESCRIPTION
https://github.com/ros2/rmw/pull/277 changed the `rmw_service_server_is_available()` API documentation to indicate that it returns `RMW_RET_INVALID_ARGUMENT` if `node`, `client`, or `is_available` are `NULL`. However, this wasn't the case in practice in the implementations of `rmw_service_server_is_available()` or in the relevant test.

Change the implementation here to return `RMW_RET_INVALID_ARGUMENT`.

Requires https://github.com/ros2/rmw_implementation/pull/231