### PR TITLE
Make rmw_destroy_wait_set return RMW_RET_INVALID_ARGUMENT

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/rmw_wait_set.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_wait_set.cpp
@@ -76,7 +76,7 @@ fail:
 rmw_ret_t
 __rmw_destroy_wait_set(const char * identifier, rmw_wait_set_t * wait_set)
 {
-  RMW_CHECK_ARGUMENT_FOR_NULL(wait_set, RMW_RET_ERROR);
+  RMW_CHECK_ARGUMENT_FOR_NULL(wait_set, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
     wait set handle,
     wait_set->implementation_identifier, identifier,


### PR DESCRIPTION
https://github.com/ros2/rmw/pull/275 changed the `rmw_destroy_wait_set()` API documentation to indicate that it returns `RMW_RET_INVALID_ARGUMENT` if `wait_set` is `NULL`. However, this wasn't the case in practice in the implementations of `rmw_destroy_wait_set()` or in the relevant test.

Change the implementation here to return `RMW_RET_INVALID_ARGUMENT`.

Requires https://github.com/ros2/rmw_implementation/pull/234