### PR TITLE
Keep reference to `DomainParticipantFactory`

### DIFF
--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "fastdds/dds/domain/DomainParticipant.hpp"
+#include "fastdds/dds/domain/DomainParticipantFactory.hpp"
 #include "fastdds/dds/domain/DomainParticipantListener.hpp"
 #include "fastdds/dds/publisher/Publisher.hpp"
 #include "fastdds/dds/subscriber/Subscriber.hpp"
@@ -91,6 +92,9 @@ typedef struct UseCountTopic
 
 typedef struct CustomParticipantInfo
 {
+  std::shared_ptr<eprosima::fastdds::dds::DomainParticipantFactory> factory_ =
+    eprosima::fastdds::dds::DomainParticipantFactory::get_shared_instance();
+
   eprosima::fastdds::dds::DomainParticipant * participant_{nullptr};
   ParticipantListener * listener_{nullptr};
 

--- a/rmw_fastrtps_shared_cpp/src/participant.cpp
+++ b/rmw_fastrtps_shared_cpp/src/participant.cpp
@@ -73,8 +73,7 @@ __create_participant(
     [participant_info]() {
       if (nullptr != participant_info->participant_) {
         participant_info->participant_->delete_publisher(participant_info->publisher_);
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->delete_participant(
-          participant_info->participant_);
+        participant_info->factory_->delete_participant(participant_info->participant_);
       }
       delete participant_info->listener_;
       delete participant_info;
@@ -99,7 +98,7 @@ __create_participant(
   eprosima::fastdds::dds::StatusMask participant_mask = eprosima::fastdds::dds::StatusMask::none();
 
   participant_info->participant_ =
-    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->create_participant(
+    participant_info->factory_->create_participant(
     static_cast<uint32_t>(domain_id), domainParticipantQos,
     participant_info->listener_, participant_mask);
 
@@ -159,9 +158,9 @@ rmw_fastrtps_shared_cpp::create_participant(
   }
 
   // Load default XML profile.
-  eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->load_profiles();
-  eprosima::fastdds::dds::DomainParticipantQos domainParticipantQos =
-    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->get_default_participant_qos();
+  auto factory = eprosima::fastdds::dds::DomainParticipantFactory::get_shared_instance();
+  factory->load_profiles();
+  auto domainParticipantQos = factory->get_default_participant_qos();
 
   // Configure discovery
   switch (discovery_options->automatic_discovery_range) {
@@ -432,8 +431,7 @@ rmw_fastrtps_shared_cpp::destroy_participant(CustomParticipantInfo * participant
   }
 
   // Delete Domain Participant
-  ret =
-    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->delete_participant(
+  ret = participant_info->factory_->delete_participant(
     participant_info->participant_);
 
   if (ReturnCode_t::RETCODE_OK != ret) {


### PR DESCRIPTION
We've seen several issues related with destruction order lately.

This PR aims to mitigate them by leveraging Fast DDS `DomainParticipantFactory::get_shared_instance()`.

It should then avoid the automatic destruction of the factory (and the participants it created) until all the contexts in the process have been destroyed.

This can be backported to Jazzy and Iron, but not Humble, since `get_shared_instance()` is only available from Fast DDS 2.8.0 onwards.