### PR TITLE
Add tracing instrumentation to rmw_fastrtps_dynamic_cpp

### DIFF
--- a/rmw_fastrtps_dynamic_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_dynamic_cpp/CMakeLists.txt
@@ -36,6 +36,7 @@ find_package(rcpputils REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(rmw_dds_common REQUIRED)
 find_package(rmw_fastrtps_shared_cpp REQUIRED)
+find_package(tracetools REQUIRED)
 
 find_package(fastrtps_cmake_module REQUIRED)
 find_package(fastcdr 2 REQUIRED CONFIG)
@@ -111,6 +112,7 @@ target_link_libraries(rmw_fastrtps_dynamic_cpp PUBLIC
 )
 target_link_libraries(rmw_fastrtps_dynamic_cpp PRIVATE
   rmw_dds_common::rmw_dds_common_library
+  tracetools::tracetools
 )
 
 configure_rmw_library(rmw_fastrtps_dynamic_cpp)

--- a/rmw_fastrtps_dynamic_cpp/package.xml
+++ b/rmw_fastrtps_dynamic_cpp/package.xml
@@ -31,6 +31,7 @@
   <build_depend>rosidl_runtime_c</build_depend>
   <build_depend>rosidl_typesupport_introspection_c</build_depend>
   <build_depend>rosidl_typesupport_introspection_cpp</build_depend>
+  <build_depend>tracetools</build_depend>
 
   <build_export_depend>fastcdr</build_export_depend>
   <build_export_depend>fastrtps</build_export_depend>
@@ -43,12 +44,14 @@
   <build_export_depend>rosidl_runtime_c</build_export_depend>
   <build_export_depend>rosidl_typesupport_introspection_c</build_export_depend>
   <build_export_depend>rosidl_typesupport_introspection_cpp</build_export_depend>
+  <build_export_depend>tracetools</build_export_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>osrf_testing_tools_cpp</test_depend>
   <test_depend>test_msgs</test_depend>
+  <exec_depend>tracetools</exec_depend>
 
   <member_of_group>rmw_implementation_packages</member_of_group>
 

--- a/rmw_fastrtps_dynamic_cpp/src/publisher.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/publisher.cpp
@@ -45,6 +45,8 @@
 
 #include "rmw_fastrtps_dynamic_cpp/identifier.hpp"
 
+#include "tracetools/tracetools.h"
+
 #include "publisher.hpp"
 #include "type_support_common.hpp"
 #include "type_support_registry.hpp"
@@ -326,5 +328,10 @@ rmw_fastrtps_dynamic_cpp::create_publisher(
   cleanup_datawriter.cancel();
   return_type_support.cancel();
   cleanup_info.cancel();
+
+  TRACETOOLS_TRACEPOINT(
+    rmw_publisher_init,
+    static_cast<const void *>(rmw_publisher),
+    info->publisher_gid.data);
   return rmw_publisher;
 }

--- a/rmw_fastrtps_dynamic_cpp/src/subscription.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/subscription.cpp
@@ -51,6 +51,8 @@
 
 #include "rmw_fastrtps_dynamic_cpp/identifier.hpp"
 
+#include "tracetools/tracetools.h"
+
 #include "subscription.hpp"
 #include "type_support_common.hpp"
 #include "type_support_registry.hpp"
@@ -365,6 +367,11 @@ create_subscription(
   cleanup_datareader.cancel();
   return_type_support.cancel();
   cleanup_info.cancel();
+
+  TRACETOOLS_TRACEPOINT(
+    rmw_subscription_init,
+    static_cast<const void *>(rmw_subscription),
+    info->subscription_gid_.data);
   return rmw_subscription;
 }
 


### PR DESCRIPTION
`rmw_fastrtps_cpp` is already instrumented. Since some of the tracing instrumentation is in `rmw_fastrtps_shared_cpp` (thus covering both `rmw_fastrtps_cpp` and `rmw_fastrtps_dynamic_cpp`), instrumenting `rmw_fastrtps_dynamic_cpp` is rather simple.

Part of https://github.com/ros2/ros2_tracing/pull/127