### PR TITLE
add rmw_get_default_xxx to return the structure with default values.

### DIFF
--- a/rmw_fastrtps_cpp/src/rmw_init.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_init.cpp
@@ -94,7 +94,7 @@ rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
   }
 
   auto restore_context = rcpputils::make_scope_exit(
-    [context]() {*context = rmw_get_zero_initialized_context();});
+    [context]() {*context = rmw_get_default_context();});
 
   context->instance_id = options->instance_id;
   context->implementation_identifier = eprosima_fastrtps_identifier;
@@ -110,7 +110,7 @@ rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
     [context]() {delete context->impl;});
 
   context->impl->is_shutdown = false;
-  context->options = rmw_get_zero_initialized_init_options();
+  context->options = rmw_get_default_init_options();
   rmw_ret_t ret = rmw_init_options_copy(options, &context->options);
   if (RMW_RET_OK != ret) {
     return ret;

--- a/rmw_fastrtps_cpp/test/test_get_native_entities.cpp
+++ b/rmw_fastrtps_cpp/test/test_get_native_entities.cpp
@@ -36,7 +36,7 @@ class TestNativeEntities : public ::testing::Test
 protected:
   void SetUp() override
   {
-    rmw_init_options_t options = rmw_get_zero_initialized_init_options();
+    rmw_init_options_t options = rmw_get_default_init_options();
     rmw_ret_t ret = rmw_init_options_init(&options, rcutils_get_default_allocator());
     ASSERT_EQ(RMW_RET_OK, ret) << rcutils_get_error_string().str;
     OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
@@ -65,7 +65,7 @@ protected:
     EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
   }
 
-  rmw_context_t context{rmw_get_zero_initialized_context()};
+  rmw_context_t context{rmw_get_default_context()};
   rmw_node_t * node{nullptr};
 };
 

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_init.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_init.cpp
@@ -95,7 +95,7 @@ rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
   }
 
   auto restore_context = rcpputils::make_scope_exit(
-    [context]() {*context = rmw_get_zero_initialized_context();});
+    [context]() {*context = rmw_get_default_context();});
 
   context->instance_id = options->instance_id;
   context->implementation_identifier = eprosima_fastrtps_identifier;
@@ -111,7 +111,7 @@ rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
     [context]() {delete context->impl;});
 
   context->impl->is_shutdown = false;
-  context->options = rmw_get_zero_initialized_init_options();
+  context->options = rmw_get_default_init_options();
   rmw_ret_t ret = rmw_init_options_copy(options, &context->options);
   if (RMW_RET_OK != ret) {
     return ret;

--- a/rmw_fastrtps_dynamic_cpp/test/test_get_native_entities.cpp
+++ b/rmw_fastrtps_dynamic_cpp/test/test_get_native_entities.cpp
@@ -36,7 +36,7 @@ class TestNativeEntities : public ::testing::Test
 protected:
   void SetUp() override
   {
-    rmw_init_options_t options = rmw_get_zero_initialized_init_options();
+    rmw_init_options_t options = rmw_get_default_init_options();
     rmw_ret_t ret = rmw_init_options_init(&options, rcutils_get_default_allocator());
     ASSERT_EQ(RMW_RET_OK, ret) << rcutils_get_error_string().str;
     OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
@@ -65,7 +65,7 @@ protected:
     EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
   }
 
-  rmw_context_t context{rmw_get_zero_initialized_context()};
+  rmw_context_t context{rmw_get_default_context()};
   rmw_node_t * node{nullptr};
 };
 

--- a/rmw_fastrtps_shared_cpp/test/test_rmw_init_options.cpp
+++ b/rmw_fastrtps_shared_cpp/test/test_rmw_init_options.cpp
@@ -38,7 +38,7 @@ TEST(RMWInitOptionsTest, init_w_invalid_args_fails) {
     rmw_init_options_init(some_identifier, nullptr, allocator));
   rcutils_reset_error();
 
-  rmw_init_options_t options = rmw_get_zero_initialized_init_options();
+  rmw_init_options_t options = rmw_get_default_init_options();
   rcutils_allocator_t invalid_allocator = rcutils_get_zero_initialized_allocator();
   // Cannot initialize using an invalid allocator.
   EXPECT_EQ(
@@ -49,7 +49,7 @@ TEST(RMWInitOptionsTest, init_w_invalid_args_fails) {
 
 
 TEST(RMWInitOptionsTest, init_twice_fails) {
-  rmw_init_options_t options = rmw_get_zero_initialized_init_options();
+  rmw_init_options_t options = rmw_get_default_init_options();
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
 
   ASSERT_EQ(RMW_RET_OK, rmw_init_options_init(some_identifier, &options, allocator)) <<
@@ -70,7 +70,7 @@ TEST(RMWInitOptionsTest, init_twice_fails) {
 
 
 TEST(RMWInitOptionsTest, init) {
-  rmw_init_options_t options = rmw_get_zero_initialized_init_options();
+  rmw_init_options_t options = rmw_get_default_init_options();
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
 
   ASSERT_EQ(RMW_RET_OK, rmw_init_options_init(some_identifier, &options, allocator)) <<
@@ -90,7 +90,7 @@ TEST(RMWInitOptionsTest, init) {
 TEST(RMWInitOptionsTest, copy_w_invalid_args_fails) {
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
   rmw_init_options_t not_initialized_options = rmw_get_zero_initialized_init_options();
-  rmw_init_options_t initialized_options = rmw_get_zero_initialized_init_options();
+  rmw_init_options_t initialized_options = rmw_get_default_init_options();
 
   ASSERT_EQ(
     RMW_RET_OK,
@@ -146,7 +146,7 @@ TEST(RMWInitOptionsTest, copy_w_invalid_args_fails) {
 
 TEST(RMWInitOptionsTest, copy) {
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
-  rmw_init_options_t preset_options = rmw_get_zero_initialized_init_options();
+  rmw_init_options_t preset_options = rmw_get_default_init_options();
 
   rcutils_reset_error();
   ASSERT_EQ(RMW_RET_OK, rmw_init_options_init(some_identifier, &preset_options, allocator)) <<
@@ -191,7 +191,7 @@ TEST(RMWInitOptionsTest, bad_alloc_on_copy) {
   rcutils_allocator_t failing_allocator = rcutils_get_default_allocator();
   failing_allocator.allocate = failing_allocate;
 
-  rmw_init_options_t preset_options = rmw_get_zero_initialized_init_options();
+  rmw_init_options_t preset_options = rmw_get_default_init_options();
   ASSERT_EQ(
     RMW_RET_OK,
     rmw_init_options_init(some_identifier, &preset_options, failing_allocator)) <<
@@ -217,7 +217,7 @@ TEST(RMWInitOptionsTest, fini_w_invalid_args_fails) {
   EXPECT_EQ(RMW_RET_INVALID_ARGUMENT, rmw_init_options_fini(some_identifier, nullptr));
   rcutils_reset_error();
 
-  rmw_init_options_t options = rmw_get_zero_initialized_init_options();
+  rmw_init_options_t options = rmw_get_default_init_options();
   // Cannot finalize an options instance that has not been initialized.
   EXPECT_EQ(RMW_RET_INVALID_ARGUMENT, rmw_init_options_fini(some_identifier, &options));
   rcutils_reset_error();


### PR DESCRIPTION
aligns with https://github.com/ros2/rmw/pull/379