### PR TITLE
Revert "Unique Client GID for Service Introspectino Event. (#779)"

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/rmw_request.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_request.cpp
@@ -129,8 +129,7 @@ __rmw_take_request(
         {
           // Get header
           rmw_fastrtps_shared_cpp::copy_from_fastrtps_guid_to_byte_array(
-            // Keep the original request publisher guid
-            writer_guid,
+            request.sample_identity_.writer_guid(),
             request_header->request_id.writer_guid);
           request_header->request_id.sequence_number =
             ((int64_t)request.sample_identity_.sequence_number().high) <<


### PR DESCRIPTION
This reverts commit 565bbc22357413aa7342e9dd0d6518b71f7f10a6.

We believe this PR might be related to some consistent hangs we have found in the rhel buildfarm jobs, we will try to reproduce before considering to merge this PR.