### PR TITLE
Instrument client/service for end-to-end request/response tracking

### DIFF
--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -42,6 +42,7 @@
 
 #include "rmw_fastrtps_shared_cpp/custom_client_info.hpp"
 #include "rmw_fastrtps_shared_cpp/custom_participant_info.hpp"
+#include "rmw_fastrtps_shared_cpp/guid_utils.hpp"
 #include "rmw_fastrtps_shared_cpp/names.hpp"
 #include "rmw_fastrtps_shared_cpp/namespace_prefix.hpp"
 #include "rmw_fastrtps_shared_cpp/qos.hpp"
@@ -50,6 +51,8 @@
 #include "rmw_fastrtps_shared_cpp/utils.hpp"
 
 #include "rmw_fastrtps_cpp/identifier.hpp"
+
+#include "tracetools/tracetools.h"
 
 #include "./type_support_common.hpp"
 
@@ -458,6 +461,11 @@ rmw_create_client(
   cleanup_datawriter.cancel();
   cleanup_datareader.cancel();
   cleanup_info.cancel();
+  if (TRACETOOLS_TRACEPOINT_ENABLED(rmw_client_init)) {
+    rmw_gid_t gid{};
+    rmw_fastrtps_shared_cpp::copy_from_fastrtps_guid_to_byte_array(info->reader_guid_, gid.data);
+    TRACETOOLS_DO_TRACEPOINT(rmw_client_init, static_cast<const void *>(rmw_client), gid.data);
+  }
   return rmw_client;
 }
 

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
@@ -44,6 +44,7 @@
 
 #include "rmw_fastrtps_shared_cpp/custom_client_info.hpp"
 #include "rmw_fastrtps_shared_cpp/custom_participant_info.hpp"
+#include "rmw_fastrtps_shared_cpp/guid_utils.hpp"
 #include "rmw_fastrtps_shared_cpp/names.hpp"
 #include "rmw_fastrtps_shared_cpp/namespace_prefix.hpp"
 #include "rmw_fastrtps_shared_cpp/qos.hpp"
@@ -52,6 +53,8 @@
 #include "rmw_fastrtps_shared_cpp/utils.hpp"
 
 #include "rmw_fastrtps_dynamic_cpp/identifier.hpp"
+
+#include "tracetools/tracetools.h"
 
 #include "client_service_common.hpp"
 #include "type_support_common.hpp"
@@ -489,6 +492,11 @@ rmw_create_client(
   return_response_type_support.cancel();
   return_request_type_support.cancel();
   cleanup_info.cancel();
+  if (TRACETOOLS_TRACEPOINT_ENABLED(rmw_client_init)) {
+    rmw_gid_t gid{};
+    rmw_fastrtps_shared_cpp::copy_from_fastrtps_guid_to_byte_array(info->reader_guid_, gid.data);
+    TRACETOOLS_DO_TRACEPOINT(rmw_client_init, static_cast<const void *>(rmw_client), gid.data);
+  }
   return rmw_client;
 }
 

--- a/rmw_fastrtps_shared_cpp/src/rmw_request.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_request.cpp
@@ -31,6 +31,8 @@
 #include "rmw_fastrtps_shared_cpp/rmw_common.hpp"
 #include "rmw_fastrtps_shared_cpp/TypeSupport.hpp"
 
+#include "tracetools/tracetools.h"
+
 namespace rmw_fastrtps_shared_cpp
 {
 rmw_ret_t
@@ -63,6 +65,12 @@ __rmw_send_request(
     returnedValue = RMW_RET_OK;
     *sequence_id = ((int64_t)wparams.sample_identity().sequence_number().high) << 32 |
       wparams.sample_identity().sequence_number().low;
+    // This would ideally go before the write() call, but we can only get the sequence number after
+    TRACETOOLS_TRACEPOINT(
+      rmw_send_request,
+      static_cast<const void *>(client),
+      static_cast<const void *>(ros_request),
+      *sequence_id);
   } else {
     RMW_SET_ERROR_MSG("cannot publish data");
   }
@@ -144,7 +152,13 @@ __rmw_take_request(
     delete request.buffer_;
   }
 
-
+  TRACETOOLS_TRACEPOINT(
+    rmw_take_request,
+    static_cast<const void *>(service),
+    static_cast<const void *>(ros_request),
+    request_header->request_id.writer_guid,
+    request_header->request_id.sequence_number,
+    *taken);
   return RMW_RET_OK;
 }
 

--- a/rmw_fastrtps_shared_cpp/src/rmw_response.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_response.cpp
@@ -29,6 +29,8 @@
 #include "rmw_fastrtps_shared_cpp/rmw_common.hpp"
 #include "rmw_fastrtps_shared_cpp/TypeSupport.hpp"
 
+#include "tracetools/tracetools.h"
+
 namespace rmw_fastrtps_shared_cpp
 {
 rmw_ret_t
@@ -93,6 +95,13 @@ __rmw_take_response(
     }
   }
 
+  TRACETOOLS_TRACEPOINT(
+    rmw_take_response,
+    static_cast<const void *>(client),
+    static_cast<const void *>(ros_response),
+    request_header->request_id.sequence_number,
+    request_header->source_timestamp,
+    *taken);
   return RMW_RET_OK;
 }
 
@@ -155,6 +164,16 @@ __rmw_send_response(
     }
   }
 
+  eprosima::fastrtps::Time_t timestamp;
+  eprosima::fastrtps::Time_t::now(timestamp);
+  wparams.source_timestamp(timestamp);
+  TRACETOOLS_TRACEPOINT(
+    rmw_send_response,
+    static_cast<const void *>(service),
+    static_cast<const void *>(ros_response),
+    request_header->writer_guid,
+    request_header->sequence_number,
+    wparams.source_timestamp().to_ns());
   rmw_fastrtps_shared_cpp::SerializedData data;
   data.type = FASTRTPS_SERIALIZED_DATA_TYPE_ROS_MESSAGE;
   data.data = const_cast<void *>(ros_response);


### PR DESCRIPTION
This adds instrumentation to clients and services using `tracetools` for end-to-end tracking of requests/responses. For more information, see https://github.com/ros2/ros2_tracing/pull/145.

Requires https://github.com/ros2/ros2_tracing/pull/145