### PR TITLE
Drop support for float128.

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/TypeSupport_impl.cpp
+++ b/rmw_fastrtps_shared_cpp/src/TypeSupport_impl.cpp
@@ -419,11 +419,6 @@ MemberIdentifierName GetTypeIdentifier(const MembersType * members, uint32_t ind
         type_name = "double";
         break;
       }
-    case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_LONG_DOUBLE:
-      {
-        type_name = "longdouble";
-        break;
-      }
     case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_CHAR:
       {
         type_name = "char";


### PR DESCRIPTION
See https://github.com/ros2/rosidl_dynamic_typesupport/issues/11 for a description on why we want to do this.