### PR TITLE
Cleanup one test in rmw_fastrtps_shared_cpp.

### DIFF
--- a/rmw_fastrtps_shared_cpp/test/test_rmw_qos_to_dds_attributes.cpp
+++ b/rmw_fastrtps_shared_cpp/test/test_rmw_qos_to_dds_attributes.cpp
@@ -131,6 +131,7 @@ TEST_F(GetDataReaderQoSTest, large_depth_conversion) {
   if (max_depth < std::numeric_limits<size_t>::max()) {
     qos_profile_.depth = max_depth + 1;
     EXPECT_FALSE(get_datareader_qos(qos_profile_, zero_type_hash, subscriber_qos_));
+    rmw_reset_error();
   }
 }
 


### PR DESCRIPTION
Just so it doesn't have an ugly warning message in the logs.