### PR TITLE
Fix some overwritten errors in rmw_fastrtps.

### DIFF
--- a/rmw_fastrtps_cpp/src/publisher.cpp
+++ b/rmw_fastrtps_cpp/src/publisher.cpp
@@ -217,7 +217,7 @@ rmw_fastrtps_cpp::create_publisher(
   // Create and register Topic
   eprosima::fastdds::dds::TopicQos topic_qos = dds_participant->get_default_topic_qos();
   if (!get_topic_qos(*qos_policies, topic_qos)) {
-    RMW_SET_ERROR_MSG("create_publisher() failed setting topic QoS");
+    // get_topic_qos already set the error
     return nullptr;
   }
 

--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -265,7 +265,7 @@ rmw_create_client(
   // Same default topic QoS for both topics
   eprosima::fastdds::dds::TopicQos topic_qos = dds_participant->get_default_topic_qos();
   if (!get_topic_qos(adapted_qos_policies, topic_qos)) {
-    RMW_SET_ERROR_MSG("create_client() failed setting topic QoS");
+    // get_topic_qos already set the error
     return nullptr;
   }
 

--- a/rmw_fastrtps_cpp/src/rmw_serialize.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_serialize.cpp
@@ -44,6 +44,7 @@ rmw_serialize(
   auto data_length = tss.getEstimatedSerializedSize(ros_message, callbacks);
   if (serialized_message->buffer_capacity < data_length) {
     if (rmw_serialized_message_resize(serialized_message, data_length) != RMW_RET_OK) {
+      rmw_reset_error();
       RMW_SET_ERROR_MSG("unable to dynamically resize serialized message");
       return RMW_RET_ERROR;
     }

--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -264,7 +264,7 @@ rmw_create_service(
   // Same default topic QoS for both topics
   eprosima::fastdds::dds::TopicQos topic_qos = dds_participant->get_default_topic_qos();
   if (!get_topic_qos(adapted_qos_policies, topic_qos)) {
-    RMW_SET_ERROR_MSG("create_service() failed setting topic QoS");
+    // get_topic_qos already set the error
     return nullptr;
   }
 

--- a/rmw_fastrtps_cpp/src/subscription.cpp
+++ b/rmw_fastrtps_cpp/src/subscription.cpp
@@ -596,7 +596,7 @@ __create_subscription(
   // Create and register Topic
   eprosima::fastdds::dds::TopicQos topic_qos = dds_participant->get_default_topic_qos();
   if (!get_topic_qos(*qos_policies, topic_qos)) {
-    RMW_SET_ERROR_MSG("create_publisher() failed setting topic QoS");
+    // get_topic_qos already set the error
     return nullptr;
   }
 

--- a/rmw_fastrtps_dynamic_cpp/src/publisher.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/publisher.cpp
@@ -223,9 +223,8 @@ rmw_fastrtps_dynamic_cpp::create_publisher(
   /////
   // Create and register Topic
   eprosima::fastdds::dds::TopicQos topic_qos = dds_participant->get_default_topic_qos();
-
   if (!get_topic_qos(*qos_policies, topic_qos)) {
-    RMW_SET_ERROR_MSG("create_publisher() failed setting topic QoS");
+    // get_topic_qos already set the error
     return nullptr;
   }
 

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
@@ -296,7 +296,7 @@ rmw_create_client(
   // Same default topic QoS for both topics
   eprosima::fastdds::dds::TopicQos topic_qos = dds_participant->get_default_topic_qos();
   if (!get_topic_qos(adapted_qos_policies, topic_qos)) {
-    RMW_SET_ERROR_MSG("create_client() failed setting topic QoS");
+    // get_topic_qos already set the error
     return nullptr;
   }
 

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_serialize.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_serialize.cpp
@@ -45,6 +45,7 @@ rmw_serialize(
   auto data_length = tss->getEstimatedSerializedSize(ros_message, ts->data);
   if (serialized_message->buffer_capacity < data_length) {
     if (rmw_serialized_message_resize(serialized_message, data_length) != RMW_RET_OK) {
+      rmw_reset_error();
       RMW_SET_ERROR_MSG("unable to dynamically resize serialized message");
       type_registry.return_message_type_support(ts);
       return RMW_RET_ERROR;

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
@@ -295,7 +295,7 @@ rmw_create_service(
   // Same default topic QoS for both topics
   eprosima::fastdds::dds::TopicQos topic_qos = dds_participant->get_default_topic_qos();
   if (!get_topic_qos(adapted_qos_policies, topic_qos)) {
-    RMW_SET_ERROR_MSG("create_service() failed setting topic QoS");
+    // get_topic_qos already set the error
     return nullptr;
   }
 

--- a/rmw_fastrtps_dynamic_cpp/src/subscription.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/subscription.cpp
@@ -235,7 +235,7 @@ create_subscription(
   // Create and register Topic
   eprosima::fastdds::dds::TopicQos topic_qos = dds_participant->get_default_topic_qos();
   if (!get_topic_qos(*qos_policies, topic_qos)) {
-    RMW_SET_ERROR_MSG("create_publisher() failed setting topic QoS");
+    // get_topic_qos already set the error
     return nullptr;
   }
 


### PR DESCRIPTION
There are 2 different kinds of errors fixed in here:

1.  When trying to get the topic QoS settings, the function get_topic_qos() always sets an error when it fails.  Thus the higher level functions do not also need to set an error.

2.  When rmw_serialize() calls rmw_serialized_message_resize(), it may fail deep in rcutils calls.  Those are very low-level error messages, and not that useful, so instead we clear those out and report an error at this rmw_fastrtps layer.