### PR TITLE
Add deprecation warning for FASTRTPS_DEFAULT_PROFILES_FILE

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ Furthermore, If `RMW_FASTRTPS_USE_QOS_FROM_XML` is set to 1, and [history memory
 
 There are two ways of telling a ROS 2 application which XML to use:
 
-1. Placing your XML file in the running directory under the name `DEFAULT_FASTRTPS_PROFILES.xml`.
-1. Setting environment variable `FASTRTPS_DEFAULT_PROFILES_FILE` to contain the path to your XML file (relative to the working directory).
+1. Placing your XML file in the running directory under the name `DEFAULT_FASTDDS_PROFILES.xml`.
+1. Setting environment variable `FASTDDS_DEFAULT_PROFILES_FILE` to contain the path to your XML file (relative to the working directory).
 
 To verify the actual QoS settings using rmw:
 
@@ -253,13 +253,13 @@ The following example configures Fast DDS to publish synchronously, to have a pr
     1. In one terminal
 
         ```bash
-        FASTRTPS_DEFAULT_PROFILES_FILE=<path_to_xml_file> RMW_FASTRTPS_USE_QOS_FROM_XML=1 RMW_IMPLEMENTATION=rmw_fastrtps_cpp ros2 run demo_nodes_cpp talker
+        FASTDDS_DEFAULT_PROFILES_FILE=<path_to_xml_file> RMW_FASTRTPS_USE_QOS_FROM_XML=1 RMW_IMPLEMENTATION=rmw_fastrtps_cpp ros2 run demo_nodes_cpp talker
         ```
 
     1. In another terminal
 
         ```bash
-        FASTRTPS_DEFAULT_PROFILES_FILE=<path_to_xml_file> RMW_FASTRTPS_USE_QOS_FROM_XML=1 RMW_IMPLEMENTATION=rmw_fastrtps_cpp ros2 run demo_nodes_cpp listener
+        FASTDDS_DEFAULT_PROFILES_FILE=<path_to_xml_file> RMW_FASTRTPS_USE_QOS_FROM_XML=1 RMW_IMPLEMENTATION=rmw_fastrtps_cpp ros2 run demo_nodes_cpp listener
         ```
 
 ### Change participant discovery options

--- a/rmw_fastrtps_cpp/src/publisher.cpp
+++ b/rmw_fastrtps_cpp/src/publisher.cpp
@@ -226,7 +226,7 @@ rmw_fastrtps_cpp::create_publisher(
   /////
   // Create DataWriter
 
-  // If the user defined an XML file via env "FASTRTPS_DEFAULT_PROFILES_FILE", try to load
+  // If the user defined an XML file via env "FASTDDS_DEFAULT_PROFILES_FILE", try to load
   // datawriter which profile name matches with topic_name. If such profile does not exist,
   // then use the default Fast DDS QoS.
   eprosima::fastdds::dds::DataWriterQos writer_qos = publisher->get_default_datawriter_qos();

--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -298,7 +298,7 @@ rmw_create_client(
   /////
   // Create response DataReader
 
-  // If FASTRTPS_DEFAULT_PROFILES_FILE defined, fill DataReader QoS with a subscriber profile
+  // If FASTDDS_DEFAULT_PROFILES_FILE defined, fill DataReader QoS with a subscriber profile
   // located based on topic name defined by _create_topic_name(). If no profile is found, a search
   // with profile_name "client" is attempted. Else, use the default Fast DDS QoS.
   eprosima::fastdds::dds::DataReaderQos reader_qos = subscriber->get_default_datareader_qos();
@@ -349,7 +349,7 @@ rmw_create_client(
       subscriber->delete_datareader(info->response_reader_);
     });
 
-  // If FASTRTPS_DEFAULT_PROFILES_FILE defined, fill DataWriter QoS with a publisher profile
+  // If FASTDDS_DEFAULT_PROFILES_FILE defined, fill DataWriter QoS with a publisher profile
   // located based on topic name defined by _create_topic_name(). If no profile is found, a search
   // with profile_name "client" is attempted. Else, use the default Fast DDS QoS.
   eprosima::fastdds::dds::DataWriterQos writer_qos = publisher->get_default_datawriter_qos();

--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -294,7 +294,7 @@ rmw_create_service(
   /////
   // Create request DataReader
 
-  // If FASTRTPS_DEFAULT_PROFILES_FILE defined, fill DataReader QoS with a subscriber profile
+  // If FASTDDS_DEFAULT_PROFILES_FILE defined, fill DataReader QoS with a subscriber profile
   // located based on topic name defined by _create_topic_name(). If no profile is found, a search
   // with profile_name "service" is attempted. Else, use the default Fast DDS QoS.
   eprosima::fastdds::dds::DataReaderQos reader_qos = subscriber->get_default_datareader_qos();
@@ -349,7 +349,7 @@ rmw_create_service(
   /////
   // Create response DataWriter
 
-  // If FASTRTPS_DEFAULT_PROFILES_FILE defined, fill DataWriter QoS with a publisher profile
+  // If FASTDDS_DEFAULT_PROFILES_FILE defined, fill DataWriter QoS with a publisher profile
   // located based on topic name defined by _create_topic_name(). If no profile is found, a search
   // with profile_name "service" is attempted. Else, use the default Fast DDS QoS.
   eprosima::fastdds::dds::DataWriterQos writer_qos = publisher->get_default_datawriter_qos();

--- a/rmw_fastrtps_cpp/src/subscription.cpp
+++ b/rmw_fastrtps_cpp/src/subscription.cpp
@@ -367,7 +367,7 @@ __create_dynamic_subscription(
   /////
   // Create DataReader
 
-  // If the user defined an XML file via env "FASTRTPS_DEFAULT_PROFILES_FILE", try to load
+  // If the user defined an XML file via env "FASTDDS_DEFAULT_PROFILES_FILE", try to load
   // datareader which profile name matches with topic_name. If such profile does not exist,
   // then use the default Fast DDS QoS.
   eprosima::fastdds::dds::DataReaderQos reader_qos = subscriber->get_default_datareader_qos();
@@ -629,7 +629,7 @@ __create_subscription(
   /////
   // Create DataReader
 
-  // If the user defined an XML file via env "FASTRTPS_DEFAULT_PROFILES_FILE", try to load
+  // If the user defined an XML file via env "FASTDDS_DEFAULT_PROFILES_FILE", try to load
   // datareader which profile name matches with topic_name. If such profile does not exist,
   // then use the default Fast DDS QoS.
   eprosima::fastdds::dds::DataReaderQos reader_qos = subscriber->get_default_datareader_qos();

--- a/rmw_fastrtps_dynamic_cpp/src/publisher.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/publisher.cpp
@@ -238,7 +238,7 @@ rmw_fastrtps_dynamic_cpp::create_publisher(
   /////
   // Create DataWriter
 
-  // If the user defined an XML file via env "FASTRTPS_DEFAULT_PROFILES_FILE", try to load
+  // If the user defined an XML file via env "FASTDDS_DEFAULT_PROFILES_FILE", try to load
   // datawriter which profile name matches with topic_name. If such profile does not exist,
   // then use the default Fast DDS QoS.
   eprosima::fastdds::dds::DataWriterQos writer_qos = publisher->get_default_datawriter_qos();

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
@@ -327,7 +327,7 @@ rmw_create_client(
   /////
   // Create response DataReader
 
-  // If FASTRTPS_DEFAULT_PROFILES_FILE defined, fill DataReader QoS with a subscriber profile
+  // If FASTDDS_DEFAULT_PROFILES_FILE defined, fill DataReader QoS with a subscriber profile
   // located based on topic name defined by _create_topic_name(). If no profile is found, a search
   // with profile_name "client" is attempted. Else, use the default Fast DDS QoS.
   eprosima::fastdds::dds::DataReaderQos reader_qos = subscriber->get_default_datareader_qos();
@@ -378,7 +378,7 @@ rmw_create_client(
       subscriber->delete_datareader(info->response_reader_);
     });
 
-  // If FASTRTPS_DEFAULT_PROFILES_FILE defined, fill DataWriter QoS with a publisher profile
+  // If FASTDDS_DEFAULT_PROFILES_FILE defined, fill DataWriter QoS with a publisher profile
   // located based on topic name defined by _create_topic_name(). If no profile is found, a search
   // with profile_name "client" is attempted. Else, use the default Fast DDS QoS.
   eprosima::fastdds::dds::DataWriterQos writer_qos = publisher->get_default_datawriter_qos();

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
@@ -323,7 +323,7 @@ rmw_create_service(
   /////
   // Create request DataReader
 
-  // If FASTRTPS_DEFAULT_PROFILES_FILE defined, fill DataReader QoS with a subscriber profile
+  // If FASTDDS_DEFAULT_PROFILES_FILE defined, fill DataReader QoS with a subscriber profile
   // located based on topic name defined by _create_topic_name(). If no profile is found, a search
   // with profile_name "service" is attempted. Else, use the default Fast DDS QoS.
   eprosima::fastdds::dds::DataReaderQos reader_qos = subscriber->get_default_datareader_qos();
@@ -378,7 +378,7 @@ rmw_create_service(
   /////
   // Create response DataWriter
 
-  // If FASTRTPS_DEFAULT_PROFILES_FILE defined, fill DataWriter QoS with a publisher profile
+  // If FASTDDS_DEFAULT_PROFILES_FILE defined, fill DataWriter QoS with a publisher profile
   // located based on topic name defined by _create_topic_name(). If no profile is found, a search
   // with profile_name "service" is attempted. Else, use the default Fast DDS QoS.
   eprosima::fastdds::dds::DataWriterQos writer_qos = publisher->get_default_datawriter_qos();

--- a/rmw_fastrtps_dynamic_cpp/src/subscription.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/subscription.cpp
@@ -247,7 +247,7 @@ create_subscription(
   /////
   // Create DataReader
 
-  // If the user defined an XML file via env "FASTRTPS_DEFAULT_PROFILES_FILE", try to load
+  // If the user defined an XML file via env "FASTDDS_DEFAULT_PROFILES_FILE", try to load
   // datareader which profile name matches with topic_name. If such profile does not exist,
   // then use the default Fast DDS QoS.
   eprosima::fastdds::dds::DataReaderQos reader_qos = subscriber->get_default_datareader_qos();

--- a/rmw_fastrtps_shared_cpp/src/participant.cpp
+++ b/rmw_fastrtps_shared_cpp/src/participant.cpp
@@ -13,9 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <fstream>
 #include <memory>
-#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -163,7 +161,6 @@ rmw_fastrtps_shared_cpp::create_participant(
   // Note: FASTRTPS_DEFAULT_PROFILES_FILE value is processed but it is a deprecated variable. Use FASTDDS_DEFAULT_PROFILES_FILE instead.
   const char * env_value;
   const char * error_str;
-  eprosima::fastdds::dds::DomainParticipantQos domainParticipantQos;
   auto factory = eprosima::fastdds::dds::DomainParticipantFactory::get_shared_instance();
 
   error_str = rcutils_get_env("FASTRTPS_DEFAULT_PROFILES_FILE", &env_value);
@@ -183,7 +180,7 @@ rmw_fastrtps_shared_cpp::create_participant(
   }
   
   factory->load_profiles();
-  domainParticipantQos = factory->get_default_participant_qos();
+  auto domainParticipantQos = factory->get_default_participant_qos();
 
   // Configure discovery
   switch (discovery_options->automatic_discovery_range) {

--- a/rmw_fastrtps_shared_cpp/src/participant.cpp
+++ b/rmw_fastrtps_shared_cpp/src/participant.cpp
@@ -13,7 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <fstream>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -158,9 +160,30 @@ rmw_fastrtps_shared_cpp::create_participant(
   }
 
   // Load default XML profile.
+  // Note: FASTRTPS_DEFAULT_PROFILES_FILE value is processed but it is a deprecated variable. Use FASTDDS_DEFAULT_PROFILES_FILE instead.
+  const char * env_value;
+  const char * error_str;
+  eprosima::fastdds::dds::DomainParticipantQos domainParticipantQos;
   auto factory = eprosima::fastdds::dds::DomainParticipantFactory::get_shared_instance();
+
+  error_str = rcutils_get_env("FASTRTPS_DEFAULT_PROFILES_FILE", &env_value);
+  if (error_str != NULL) {
+    RCUTILS_LOG_DEBUG_NAMED("rmw_fastrtps_shared_cpp", "Error getting env var: %s\n", error_str);
+    return nullptr;
+  }
+  if(env_value != nullptr) {
+    if (strcmp(env_value, "") != 0) {
+      RCUTILS_LOG_WARN_NAMED(
+        "rmw_fastrtps_shared_cpp",
+        "FASTRTPS_DEFAULT_PROFILES_FILE value is used for participant configuration, but it is deprecated and will no longer be supported. Use FASTDDS_DEFAULT_PROFILES_FILE instead.");
+      rcutils_reset_error();
+      std::string env_value_str = std::string(env_value);
+      factory->load_XML_profiles_file(env_value_str);
+    }
+  }
+  
   factory->load_profiles();
-  auto domainParticipantQos = factory->get_default_participant_qos();
+  domainParticipantQos = factory->get_default_participant_qos();
 
   // Configure discovery
   switch (discovery_options->automatic_discovery_range) {
@@ -275,8 +298,7 @@ rmw_fastrtps_shared_cpp::create_participant(
 
   bool leave_middleware_default_qos = false;
   publishing_mode_t publishing_mode = publishing_mode_t::SYNCHRONOUS;
-  const char * env_value;
-  const char * error_str;
+
   error_str = rcutils_get_env("RMW_FASTRTPS_USE_QOS_FROM_XML", &env_value);
   if (error_str != NULL) {
     RCUTILS_LOG_DEBUG_NAMED("rmw_fastrtps_shared_cpp", "Error getting env var: %s\n", error_str);

--- a/rmw_fastrtps_shared_cpp/src/participant.cpp
+++ b/rmw_fastrtps_shared_cpp/src/participant.cpp
@@ -158,7 +158,8 @@ rmw_fastrtps_shared_cpp::create_participant(
   }
 
   // Load default XML profile.
-  // Note: FASTRTPS_DEFAULT_PROFILES_FILE value is processed but it is a deprecated variable. Use FASTDDS_DEFAULT_PROFILES_FILE instead.
+  // Note: FASTRTPS_DEFAULT_PROFILES_FILE value is processed but it is a deprecated variable.
+  // Use FASTDDS_DEFAULT_PROFILES_FILE instead.
   const char * env_value;
   const char * error_str;
   auto factory = eprosima::fastdds::dds::DomainParticipantFactory::get_shared_instance();
@@ -180,7 +181,7 @@ rmw_fastrtps_shared_cpp::create_participant(
       factory->load_XML_profiles_file(env_value_str);
     }
   }
-  
+
   factory->load_profiles();
   auto domainParticipantQos = factory->get_default_participant_qos();
 

--- a/rmw_fastrtps_shared_cpp/src/participant.cpp
+++ b/rmw_fastrtps_shared_cpp/src/participant.cpp
@@ -172,7 +172,9 @@ rmw_fastrtps_shared_cpp::create_participant(
     if (strcmp(env_value, "") != 0) {
       RCUTILS_LOG_WARN_NAMED(
         "rmw_fastrtps_shared_cpp",
-        "FASTRTPS_DEFAULT_PROFILES_FILE value is used for participant configuration, but it is deprecated and will no longer be supported. Use FASTDDS_DEFAULT_PROFILES_FILE instead.");
+        "FASTRTPS_DEFAULT_PROFILES_FILE value is used for participant configuration, "
+        "but it is deprecated and will no longer be supported. "
+        "Use FASTDDS_DEFAULT_PROFILES_FILE instead.");
       rcutils_reset_error();
       std::string env_value_str = std::string(env_value);
       factory->load_XML_profiles_file(env_value_str);


### PR DESCRIPTION
# Main Changes
This PR adds a deprecation warning for FASTRTPS_DEFAULT_PROFILES_FILE environment variable. According to [Fast DDS v3 documentation](https://fast-dds.docs.eprosima.com/en/latest/notes/migration_guide.html#step-1-update-the-package-name-and-cmake-configuration), it has been renamed to FASTDDS_DEFAULT_PROFILES_FILE.