### PR TITLE
address RHEL warnings and missing includes.

### DIFF
--- a/rmw_fastrtps_cpp/src/type_support_common.cpp
+++ b/rmw_fastrtps_cpp/src/type_support_common.cpp
@@ -14,6 +14,9 @@
 
 #include <fastcdr/exceptions/Exception.h>
 
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
 #include <string>
 
 #include "rmw/error_handling.h"
@@ -151,10 +154,11 @@ bool TypeSupport::get_key_hash_from_ros_message(
   void * ros_message,
   eprosima::fastdds::rtps::InstanceHandle_t * ihandle,
   bool force_md5,
-  const void * [[maybe_unused]] impl) const
+  const void * impl) const
 {
   assert(ros_message);
   assert(ihandle);
+  (void)impl;
 
   // retrieve estimated serialized size in case key is unbounded
   if (key_is_unbounded_) {

--- a/rmw_fastrtps_dynamic_cpp/src/TypeSupport.hpp
+++ b/rmw_fastrtps_dynamic_cpp/src/TypeSupport.hpp
@@ -16,6 +16,7 @@
 #define TYPESUPPORT_HPP_
 
 #include <cassert>
+#include <cstddef>
 #include <string>
 
 #include "rosidl_runtime_c/string.h"

--- a/rmw_fastrtps_dynamic_cpp/src/TypeSupport_impl.hpp
+++ b/rmw_fastrtps_dynamic_cpp/src/TypeSupport_impl.hpp
@@ -16,6 +16,8 @@
 #define TYPESUPPORT_IMPL_HPP_
 
 #include <cassert>
+#include <cstddef>
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -1129,7 +1131,7 @@ bool TypeSupport<MembersType>::get_key_hash_from_ros_message(
   void * ros_message,
   eprosima::fastdds::rtps::InstanceHandle_t * ihandle,
   bool force_md5,
-  const void * [[maybe_unused]] impl) const
+  const void * impl) const
 {
   assert(ros_message);
   assert(ihandle);
@@ -1137,6 +1139,7 @@ bool TypeSupport<MembersType>::get_key_hash_from_ros_message(
 
   bool ret = false;
 
+  (void)impl;
   if (members_->member_count_ != 0) {
     ret = TypeSupport::get_key_hash_from_ros_message(members_, ros_message, ihandle, force_md5);
   }

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/TypeSupport.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/TypeSupport.hpp
@@ -16,6 +16,7 @@
 #define RMW_FASTRTPS_SHARED_CPP__TYPESUPPORT_HPP_
 
 #include <cassert>
+#include <cstddef>
 #include <string>
 #include <vector>
 

--- a/rmw_fastrtps_shared_cpp/src/TypeSupport_impl.cpp
+++ b/rmw_fastrtps_shared_cpp/src/TypeSupport_impl.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <cassert>
+#include <mutex>
 #include <sstream>
 #include <string>
 #include <utility>


### PR DESCRIPTION
follow up of https://github.com/ros2/rmw_fastrtps/pull/753

this PR only does 2 things.

- do not use `[[maybe_unused]]`, since RHEL is not happy about that. (see https://github.com/ros2/rmw_fastrtps/pull/753#issuecomment-2782182412)
- add missing includes suggested by https://github.com/ros2/rmw_fastrtps/pull/753#pullrequestreview-2747261966