### PR TITLE
check a local publication to ignore with serialized message.

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/rmw_take.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_take.cpp
@@ -330,6 +330,15 @@ _take_serialized_message(
       });
 
     if (info_seq[0].valid_data) {
+      if (subscription->options.ignore_local_publications) {
+        auto sample_writer_guid =
+          eprosima::fastdds::rtps::iHandle2GUID(info_seq[0].publication_handle);
+
+        if (sample_writer_guid.guidPrefix == info->data_reader_->guid().guidPrefix) {
+          // This is a local publication. Ignore it
+          continue;
+        }
+      }
       auto buffer_size = static_cast<size_t>(buffer.getBufferSize());
       if (serialized_message->buffer_capacity < buffer_size) {
         auto ret = rmw_serialized_message_resize(serialized_message, buffer_size);


### PR DESCRIPTION
## Description

when it takes the serialized message, it does not check if that comes from the local publication to ignore.

### Is this user-facing behavior change?

yes, only if user takes the serialized data from Fast-DDS.
after this PR, if the `ignore_local_publications` flag is enabled, the local subscription does not receive the message anymore.
this is bug fix to change the behavior into how it is supposed to be.

### Did you use Generative AI?

No

### Additional Information

This needs to backport to all downstream distribution, but note that namespace is different `fastrtps` from `fastdds`.