### PR TITLE
Retrieve `HistoryQoS` in discovery when available

### DIFF
--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/qos.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/qos.hpp
@@ -177,12 +177,16 @@ rtps_qos_to_rmw_qos(
   qos->liveliness_lease_duration = dds_duration_to_rmw(rtps_qos.liveliness.lease_duration);
 
   if (rtps_qos.history.has_value()) {
-    if (rtps_qos.history->kind == eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS) {
-      qos->history = RMW_QOS_POLICY_HISTORY_KEEP_LAST;
-    } else if (rtps_qos.history->kind == eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS) {
-      qos->history = RMW_QOS_POLICY_HISTORY_KEEP_ALL;
-    } else {
-      qos->history = RMW_QOS_POLICY_HISTORY_UNKNOWN;
+    switch (rtps_qos.history->kind) {
+      case eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS:
+        qos->history = RMW_QOS_POLICY_HISTORY_KEEP_LAST;
+        break;
+      case eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS:
+        qos->history = RMW_QOS_POLICY_HISTORY_KEEP_ALL;
+        break;
+      default:
+        qos->history = RMW_QOS_POLICY_HISTORY_UNKNOWN;
+        break;
     }
     qos->depth = static_cast<size_t>(rtps_qos.history->depth);
   } else {

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/qos.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/qos.hpp
@@ -176,24 +176,16 @@ rtps_qos_to_rmw_qos(
   }
   qos->liveliness_lease_duration = dds_duration_to_rmw(rtps_qos.liveliness.lease_duration);
 
-  if (rtps_qos.history.has_value())
-  {
-    if (rtps_qos.history->kind == eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS)
-    {
+  if (rtps_qos.history.has_value()) {
+    if (rtps_qos.history->kind == eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS) {
       qos->history = RMW_QOS_POLICY_HISTORY_KEEP_LAST;
-    }
-    else if (rtps_qos.history->kind == eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS)
-    {
+    } else if (rtps_qos.history->kind == eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS) {
       qos->history = RMW_QOS_POLICY_HISTORY_KEEP_ALL;
-    }
-    else
-    {
+    } else {
       qos->history = RMW_QOS_POLICY_HISTORY_UNKNOWN;
     }
     qos->depth = static_cast<size_t>(rtps_qos.history->depth);
-  }
-  else
-  {
+  } else {
     qos->history = RMW_QOS_POLICY_HISTORY_UNKNOWN;
   }
 }

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/qos.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/qos.hpp
@@ -175,6 +175,27 @@ rtps_qos_to_rmw_qos(
       break;
   }
   qos->liveliness_lease_duration = dds_duration_to_rmw(rtps_qos.liveliness.lease_duration);
+
+  if (rtps_qos.history.has_value())
+  {
+    if (rtps_qos.history->kind == eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS)
+    {
+      qos->history = RMW_QOS_POLICY_HISTORY_KEEP_LAST;
+    }
+    else if (rtps_qos.history->kind == eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS)
+    {
+      qos->history = RMW_QOS_POLICY_HISTORY_KEEP_ALL;
+    }
+    else
+    {
+      qos->history = RMW_QOS_POLICY_HISTORY_UNKNOWN;
+    }
+    qos->depth = static_cast<size_t>(rtps_qos.history->depth);
+  }
+  else
+  {
+    qos->history = RMW_QOS_POLICY_HISTORY_UNKNOWN;
+  }
 }
 
 extern template RMW_FASTRTPS_SHARED_CPP_PUBLIC


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

This PR adds the HistoryQoS to the entities discovery callback when available.
Related tests PRs

* https://github.com/ros2/rcl/pull/1242
* https://github.com/ros2/ros2cli/pull/1040

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes https://github.com/ros2/rmw_fastrtps/issues/684

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

No

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
Should be backported only to `Kilted`