### PR TITLE
Use key annotation in TypeObject build

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/TypeSupport_impl.cpp
+++ b/rmw_fastrtps_shared_cpp/src/TypeSupport_impl.cpp
@@ -344,11 +344,12 @@ TypeIdentifierPair register_type_identifiers(
       continue;
     }
 
+    const auto struct_member = members->members_ + i;
     TypeIdentifierPair type_ids;
     type_ids.type_identifier1(pair.first);
     StructMemberFlag member_flags {TypeObjectUtils::build_struct_member_flag(
         xtypes::TryConstructFailAction::DISCARD,
-        false, false, false, false)};
+        false, false, struct_member->is_key_, false)};
     MemberId member_id {static_cast<MemberId>(i)};
     bool common_var {false};
     CommonStructMember member_common{TypeObjectUtils::build_common_struct_member(


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

This should fix #848 by correctly applying the `@key` annotation for members when building the X-Types information.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #848

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

We don't have communication tests between pure DDS and a ROS node, so I don't think we can add a regression test for #848 