### PR TITLE
Add support for rosidl::Buffer-aware per-endpoint pub/sub

### DIFF
--- a/rmw_fastrtps_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_cpp/CMakeLists.txt
@@ -47,8 +47,10 @@ find_package(rosidl_dynamic_typesupport_fastrtps REQUIRED)
 find_package(rosidl_runtime_c REQUIRED)
 find_package(rosidl_typesupport_fastrtps_c REQUIRED)
 find_package(rosidl_typesupport_fastrtps_cpp REQUIRED)
+find_package(rosidl_buffer_backend_registry REQUIRED)
 
 add_library(rmw_fastrtps_cpp
+  src/buffer_endpoint_registry.cpp
   src/get_client.cpp
   src/get_participant.cpp
   src/get_publisher.cpp
@@ -106,11 +108,16 @@ target_link_libraries(rmw_fastrtps_cpp PUBLIC
 target_link_libraries(rmw_fastrtps_cpp PRIVATE
   rcpputils::rcpputils
   rcutils::rcutils
+  rosidl_buffer_backend_registry::rosidl_buffer_backend_registry
   rmw_dds_common::rmw_dds_common_library
   rosidl_dynamic_typesupport::rosidl_dynamic_typesupport
   rosidl_dynamic_typesupport_fastrtps::rosidl_dynamic_typesupport_fastrtps
   rosidl_typesupport_fastrtps_c::rosidl_typesupport_fastrtps_c
   tracetools::tracetools
+)
+
+target_include_directories(rmw_fastrtps_cpp PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 target_include_directories(rmw_fastrtps_cpp PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"

--- a/rmw_fastrtps_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_cpp/CMakeLists.txt
@@ -50,6 +50,7 @@ find_package(rosidl_typesupport_fastrtps_cpp REQUIRED)
 find_package(rosidl_buffer_backend_registry REQUIRED)
 
 add_library(rmw_fastrtps_cpp
+  src/buffer_backend_loader.cpp
   src/buffer_endpoint_registry.cpp
   src/get_client.cpp
   src/get_participant.cpp

--- a/rmw_fastrtps_cpp/package.xml
+++ b/rmw_fastrtps_cpp/package.xml
@@ -31,6 +31,7 @@
   <build_depend>rosidl_typesupport_fastrtps_c</build_depend>
   <build_depend>rosidl_typesupport_fastrtps_cpp</build_depend>
   <build_depend>tracetools</build_depend>
+  <build_depend>rosidl_buffer_backend_registry</build_depend>
 
   <build_export_depend>fastcdr</build_export_depend>
   <build_export_depend>fastdds</build_export_depend>
@@ -52,6 +53,7 @@
   <exec_depend>rosidl_dynamic_typesupport</exec_depend>
   <exec_depend>rosidl_dynamic_typesupport_fastrtps</exec_depend>
   <exec_depend>tracetools</exec_depend>
+  <exec_depend>rosidl_buffer_backend_registry</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/rmw_fastrtps_cpp/src/buffer_backend_context.hpp
+++ b/rmw_fastrtps_cpp/src/buffer_backend_context.hpp
@@ -1,0 +1,40 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BUFFER_BACKEND_CONTEXT_HPP_
+#define BUFFER_BACKEND_CONTEXT_HPP_
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "rosidl_buffer_backend/buffer_backend.hpp"
+#include "rosidl_buffer_backend_registry/buffer_backend_registry.hpp"
+#include "rosidl_typesupport_fastrtps_cpp/buffer_serialization.hpp"
+
+namespace rmw_fastrtps_cpp
+{
+
+/// Per-rmw_context bundle of buffer backend state.
+/// Stored as a void* in rmw_context_impl_s::buffer_serialization_context.
+struct BufferBackendContext
+{
+  rosidl_typesupport_fastrtps_cpp::BufferSerializationContext serialization_context;
+  std::unique_ptr<rosidl_buffer_backend_registry::BufferBackendRegistry> registry;
+  std::unordered_map<std::string, std::shared_ptr<rosidl::BufferBackend>> backend_instances;
+};
+
+}  // namespace rmw_fastrtps_cpp
+
+#endif  // BUFFER_BACKEND_CONTEXT_HPP_

--- a/rmw_fastrtps_cpp/src/buffer_backend_loader.cpp
+++ b/rmw_fastrtps_cpp/src/buffer_backend_loader.cpp
@@ -1,0 +1,105 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "buffer_backend_loader.hpp"
+
+#include <memory>
+#include <string>
+
+#include "rcutils/logging_macros.h"
+#include "rosidl_buffer_backend_registry/buffer_backend_registry.hpp"
+#include "rosidl_typesupport_fastrtps_cpp/buffer_serialization.hpp"
+
+namespace rmw_fastrtps_cpp
+{
+
+static const char * kLoggerName = "rmw_fastrtps_cpp.buffer_backend_loader";
+
+void initialize_buffer_backends()
+{
+  auto & registry = rosidl_buffer_backend_registry::BufferBackendRegistry::get_instance();
+  registry.load_plugins();
+
+  auto & backend_ops = rosidl_typesupport_fastrtps_cpp::get_backend_descriptor_ops();
+  auto backend_names = registry.get_backend_names();
+  RCUTILS_LOG_INFO_NAMED(
+    kLoggerName, "Buffer backends: found %zu backend(s)", backend_names.size());
+
+  for (const auto & backend_name : backend_names) {
+    auto backend = registry.get_backend(backend_name);
+    if (!backend) {
+      RCUTILS_LOG_ERROR_NAMED(
+        kLoggerName, "Backend '%s' pointer is null", backend_name.c_str());
+      continue;
+    }
+
+    std::string backend_type = backend->get_backend_type();
+    RCUTILS_LOG_INFO_NAMED(
+      kLoggerName, "Processing backend '%s' (type: %s)",
+      backend_name.c_str(), backend_type.c_str());
+
+    rosidl_typesupport_fastrtps_cpp::BufferDescriptorOps ops;
+
+    auto backend_ptr = backend;
+    ops.create_descriptor_with_endpoint = [backend_ptr](
+      const std::shared_ptr<void> & impl,
+      const rmw_topic_endpoint_info_t & endpoint_info) -> std::shared_ptr<void> {
+        return backend_ptr->create_descriptor_with_endpoint(impl, endpoint_info);
+      };
+    ops.from_descriptor_with_endpoint = [backend_ptr](
+      const std::shared_ptr<void> & descriptor,
+      const rmw_topic_endpoint_info_t & endpoint_info) -> std::shared_ptr<void> {
+        return backend_ptr->from_descriptor_with_endpoint(descriptor, endpoint_info);
+      };
+
+    backend_ops[backend_type] = ops;
+
+    auto & serializers = rosidl_typesupport_fastrtps_cpp::get_descriptor_serializers();
+    if (serializers.find(backend_type) != serializers.end()) {
+      RCUTILS_LOG_INFO_NAMED(
+        kLoggerName, "  FastCDR descriptor serializers registered for '%s'",
+        backend_type.c_str());
+    } else {
+      RCUTILS_LOG_ERROR_NAMED(
+        kLoggerName,
+        "  Backend '%s' did not register FastCDR descriptor serializers. "
+        "Ensure the backend constructor calls "
+        "rosidl_typesupport_fastrtps_cpp::register_buffer_descriptor<DescriptorMsgT>()",
+        backend_type.c_str());
+    }
+  }
+}
+
+void shutdown_buffer_backends()
+{
+  try {
+    auto & backend_ops = rosidl_typesupport_fastrtps_cpp::get_backend_descriptor_ops();
+    backend_ops.clear();
+
+    auto & serializers = rosidl_typesupport_fastrtps_cpp::get_descriptor_serializers();
+    serializers.clear();
+  } catch (const std::exception & e) {
+    RCUTILS_LOG_ERROR_NAMED(
+      kLoggerName, "Warning during buffer backend shutdown: %s", e.what());
+  }
+
+  try {
+    rosidl_buffer_backend_registry::BufferBackendRegistry::get_instance().clear_global_state();
+  } catch (const std::exception & e) {
+    RCUTILS_LOG_ERROR_NAMED(
+      kLoggerName, "Warning clearing backend registry: %s", e.what());
+  }
+}
+
+}  // namespace rmw_fastrtps_cpp

--- a/rmw_fastrtps_cpp/src/buffer_backend_loader.cpp
+++ b/rmw_fastrtps_cpp/src/buffer_backend_loader.cpp
@@ -69,7 +69,8 @@ void initialize_buffer_backends(BufferBackendContext & context)
       };
     ops.from_descriptor_with_endpoint = [backend_ptr](
       const void * descriptor,
-      const rmw_topic_endpoint_info_t & endpoint_info) -> std::shared_ptr<void> {
+      const rmw_topic_endpoint_info_t & endpoint_info)
+      -> std::unique_ptr<void, void (*)(void *)> {
         return backend_ptr->from_descriptor_with_endpoint(descriptor, endpoint_info);
       };
 

--- a/rmw_fastrtps_cpp/src/buffer_backend_loader.cpp
+++ b/rmw_fastrtps_cpp/src/buffer_backend_loader.cpp
@@ -15,29 +15,37 @@
 #include "buffer_backend_loader.hpp"
 
 #include <memory>
+#include <cstring>
 #include <string>
+#include <stdexcept>
+#include <utility>
 
+#include "rcutils/error_handling.h"
 #include "rcutils/logging_macros.h"
 #include "rosidl_buffer_backend_registry/buffer_backend_registry.hpp"
+#include "rosidl_typesupport_fastrtps_cpp/identifier.hpp"
+#include "rosidl_typesupport_fastrtps_cpp/message_type_support_decl.hpp"
 #include "rosidl_typesupport_fastrtps_cpp/buffer_serialization.hpp"
+#include "rosidl_runtime_c/message_type_support_struct.h"
 
 namespace rmw_fastrtps_cpp
 {
 
 static const char * kLoggerName = "rmw_fastrtps_cpp.buffer_backend_loader";
 
-void initialize_buffer_backends()
+void initialize_buffer_backends(BufferBackendContext & context)
 {
-  auto & registry = rosidl_buffer_backend_registry::BufferBackendRegistry::get_instance();
-  registry.load_plugins();
+  context.registry = std::make_unique<rosidl_buffer_backend_registry::BufferBackendRegistry>();
+  auto & registry = *context.registry;
 
-  auto & backend_ops = rosidl_typesupport_fastrtps_cpp::get_backend_descriptor_ops();
+  auto & backend_ops = context.serialization_context.descriptor_ops;
+  auto & serializers = context.serialization_context.descriptor_serializers;
   auto backend_names = registry.get_backend_names();
   RCUTILS_LOG_INFO_NAMED(
     kLoggerName, "Buffer backends: found %zu backend(s)", backend_names.size());
 
   for (const auto & backend_name : backend_names) {
-    auto backend = registry.get_backend(backend_name);
+    auto backend = registry.create_backend_instance(backend_name);
     if (!backend) {
       RCUTILS_LOG_ERROR_NAMED(
         kLoggerName, "Backend '%s' pointer is null", backend_name.c_str());
@@ -49,7 +57,9 @@ void initialize_buffer_backends()
       kLoggerName, "Processing backend '%s' (type: %s)",
       backend_name.c_str(), backend_type.c_str());
 
-    rosidl_typesupport_fastrtps_cpp::BufferDescriptorOps ops;
+    context.backend_instances[backend_type] = backend;
+
+    rosidl::BufferDescriptorOps ops;
 
     auto backend_ptr = backend;
     ops.create_descriptor_with_endpoint = [backend_ptr](
@@ -65,40 +75,91 @@ void initialize_buffer_backends()
 
     backend_ops[backend_type] = ops;
 
-    auto & serializers = rosidl_typesupport_fastrtps_cpp::get_descriptor_serializers();
-    if (serializers.find(backend_type) != serializers.end()) {
-      RCUTILS_LOG_INFO_NAMED(
-        kLoggerName, "  FastCDR descriptor serializers registered for '%s'",
-        backend_type.c_str());
-    } else {
+    const rosidl_message_type_support_t * descriptor_ts =
+      backend->get_descriptor_type_support();
+    if (!descriptor_ts) {
       RCUTILS_LOG_ERROR_NAMED(
         kLoggerName,
-        "  Backend '%s' did not register FastCDR descriptor serializers. "
-        "Ensure the backend constructor calls "
-        "rosidl_typesupport_fastrtps_cpp::register_buffer_descriptor<DescriptorMsgT>()",
+        "  Backend '%s' returned null descriptor type support",
         backend_type.c_str());
+      continue;
     }
+    const rosidl_message_type_support_t * fastrtps_descriptor_ts = get_message_typesupport_handle(
+      descriptor_ts, rosidl_typesupport_fastrtps_cpp::typesupport_identifier);
+    if (!fastrtps_descriptor_ts) {
+      RCUTILS_LOG_ERROR_NAMED(
+        kLoggerName,
+        "  Backend '%s' descriptor type support could not be resolved to "
+        "rosidl_typesupport_fastrtps_cpp",
+        backend_type.c_str());
+      rcutils_reset_error();
+      continue;
+    }
+
+    const auto * callbacks = static_cast<const message_type_support_callbacks_t *>(
+      fastrtps_descriptor_ts->data);
+    if (!callbacks) {
+      RCUTILS_LOG_ERROR_NAMED(
+        kLoggerName,
+        "  Backend '%s' descriptor callbacks are null",
+        backend_type.c_str());
+      continue;
+    }
+
+    rosidl_typesupport_fastrtps_cpp::BufferDescriptorSerializers desc_ser;
+    auto backend_ptr_for_desc = backend;
+    desc_ser.serialize = [callbacks](
+      eprosima::fastcdr::Cdr & cdr,
+      const std::shared_ptr<void> & desc_ptr,
+      const rmw_topic_endpoint_info_t & endpoint_info,
+      const rosidl_typesupport_fastrtps_cpp::BufferSerializationContext & serialization_context)
+      {
+        if (!desc_ptr) {
+          throw std::runtime_error("Descriptor pointer is null");
+        }
+        if (callbacks->cdr_serialize_with_endpoint) {
+          callbacks->cdr_serialize_with_endpoint(
+            desc_ptr.get(), cdr, endpoint_info, serialization_context);
+        } else {
+          callbacks->cdr_serialize(desc_ptr.get(), cdr);
+        }
+      };
+    desc_ser.deserialize = [callbacks, backend_ptr_for_desc](
+      eprosima::fastcdr::Cdr & cdr,
+      const rmw_topic_endpoint_info_t & endpoint_info,
+      const rosidl_typesupport_fastrtps_cpp::BufferSerializationContext & serialization_context)
+      -> std::shared_ptr<void>
+      {
+        auto desc = backend_ptr_for_desc->create_empty_descriptor();
+        if (!desc) {
+          throw std::runtime_error("Backend returned null descriptor instance");
+        }
+        if (callbacks->cdr_deserialize_with_endpoint) {
+          callbacks->cdr_deserialize_with_endpoint(
+            cdr, desc.get(), endpoint_info, serialization_context);
+        } else {
+          callbacks->cdr_deserialize(cdr, desc.get());
+        }
+        return desc;
+      };
+    serializers[backend_type] = std::move(desc_ser);
+
+    RCUTILS_LOG_INFO_NAMED(
+      kLoggerName, "  FastCDR descriptor serializers registered for '%s'",
+      backend_type.c_str());
   }
 }
 
-void shutdown_buffer_backends()
+void shutdown_buffer_backends(BufferBackendContext & context)
 {
   try {
-    auto & backend_ops = rosidl_typesupport_fastrtps_cpp::get_backend_descriptor_ops();
-    backend_ops.clear();
-
-    auto & serializers = rosidl_typesupport_fastrtps_cpp::get_descriptor_serializers();
-    serializers.clear();
+    context.serialization_context.descriptor_ops.clear();
+    context.serialization_context.descriptor_serializers.clear();
+    context.backend_instances.clear();
+    context.registry.reset();
   } catch (const std::exception & e) {
     RCUTILS_LOG_ERROR_NAMED(
-      kLoggerName, "Warning during buffer backend shutdown: %s", e.what());
-  }
-
-  try {
-    rosidl_buffer_backend_registry::BufferBackendRegistry::get_instance().clear_global_state();
-  } catch (const std::exception & e) {
-    RCUTILS_LOG_ERROR_NAMED(
-      kLoggerName, "Warning clearing backend registry: %s", e.what());
+      kLoggerName, "Error during buffer backend shutdown: %s", e.what());
   }
 }
 

--- a/rmw_fastrtps_cpp/src/buffer_backend_loader.cpp
+++ b/rmw_fastrtps_cpp/src/buffer_backend_loader.cpp
@@ -41,7 +41,7 @@ void initialize_buffer_backends(BufferBackendContext & context)
   auto & backend_ops = context.serialization_context.descriptor_ops;
   auto & serializers = context.serialization_context.descriptor_serializers;
   auto backend_names = registry.get_backend_names();
-  RCUTILS_LOG_INFO_NAMED(
+  RCUTILS_LOG_DEBUG_NAMED(
     kLoggerName, "Buffer backends: found %zu backend(s)", backend_names.size());
 
   for (const auto & backend_name : backend_names) {
@@ -53,7 +53,7 @@ void initialize_buffer_backends(BufferBackendContext & context)
     }
 
     std::string backend_type = backend->get_backend_type();
-    RCUTILS_LOG_INFO_NAMED(
+    RCUTILS_LOG_DEBUG_NAMED(
       kLoggerName, "Processing backend '%s' (type: %s)",
       backend_name.c_str(), backend_type.c_str());
 
@@ -145,7 +145,7 @@ void initialize_buffer_backends(BufferBackendContext & context)
       };
     serializers[backend_type] = std::move(desc_ser);
 
-    RCUTILS_LOG_INFO_NAMED(
+    RCUTILS_LOG_DEBUG_NAMED(
       kLoggerName, "  FastCDR descriptor serializers registered for '%s'",
       backend_type.c_str());
   }

--- a/rmw_fastrtps_cpp/src/buffer_backend_loader.cpp
+++ b/rmw_fastrtps_cpp/src/buffer_backend_loader.cpp
@@ -63,12 +63,12 @@ void initialize_buffer_backends(BufferBackendContext & context)
 
     auto backend_ptr = backend;
     ops.create_descriptor_with_endpoint = [backend_ptr](
-      const std::shared_ptr<void> & impl,
+      const void * impl,
       const rmw_topic_endpoint_info_t & endpoint_info) -> std::shared_ptr<void> {
         return backend_ptr->create_descriptor_with_endpoint(impl, endpoint_info);
       };
     ops.from_descriptor_with_endpoint = [backend_ptr](
-      const std::shared_ptr<void> & descriptor,
+      const void * descriptor,
       const rmw_topic_endpoint_info_t & endpoint_info) -> std::shared_ptr<void> {
         return backend_ptr->from_descriptor_with_endpoint(descriptor, endpoint_info);
       };

--- a/rmw_fastrtps_cpp/src/buffer_backend_loader.hpp
+++ b/rmw_fastrtps_cpp/src/buffer_backend_loader.hpp
@@ -1,0 +1,34 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BUFFER_BACKEND_LOADER_HPP_
+#define BUFFER_BACKEND_LOADER_HPP_
+
+namespace rmw_fastrtps_cpp
+{
+
+/// Load buffer backend plugins and register them with FastCDR serialization.
+/// Populates the global BackendDescriptorOps and DescriptorSerializers maps
+/// in rosidl_typesupport_fastrtps_cpp so that buffer-aware message types can
+/// serialize/deserialize vendor-specific descriptors.
+void initialize_buffer_backends();
+
+/// Clear global serialization maps to release plugin references before unloading.
+/// Must be called before BufferBackendRegistry singleton is destroyed to prevent
+/// ClassLoader from trying to unload while objects still exist.
+void shutdown_buffer_backends();
+
+}  // namespace rmw_fastrtps_cpp
+
+#endif  // BUFFER_BACKEND_LOADER_HPP_

--- a/rmw_fastrtps_cpp/src/buffer_backend_loader.hpp
+++ b/rmw_fastrtps_cpp/src/buffer_backend_loader.hpp
@@ -15,19 +15,18 @@
 #ifndef BUFFER_BACKEND_LOADER_HPP_
 #define BUFFER_BACKEND_LOADER_HPP_
 
+#include "buffer_backend_context.hpp"
+
 namespace rmw_fastrtps_cpp
 {
 
 /// Load buffer backend plugins and register them with FastCDR serialization.
-/// Populates the global BackendDescriptorOps and DescriptorSerializers maps
-/// in rosidl_typesupport_fastrtps_cpp so that buffer-aware message types can
-/// serialize/deserialize vendor-specific descriptors.
-void initialize_buffer_backends();
+/// Populates an RMW-context-local serialization map so multiple contexts in the
+/// same process do not share mutable global descriptor state.
+void initialize_buffer_backends(BufferBackendContext & context);
 
-/// Clear global serialization maps to release plugin references before unloading.
-/// Must be called before BufferBackendRegistry singleton is destroyed to prevent
-/// ClassLoader from trying to unload while objects still exist.
-void shutdown_buffer_backends();
+/// Clear context-local serialization maps.
+void shutdown_buffer_backends(BufferBackendContext & context);
 
 }  // namespace rmw_fastrtps_cpp
 

--- a/rmw_fastrtps_cpp/src/buffer_endpoint_registry.cpp
+++ b/rmw_fastrtps_cpp/src/buffer_endpoint_registry.cpp
@@ -31,12 +31,6 @@ bool gid_equal(const rmw_gid_t & a, const rmw_gid_t & b)
 }
 }  // namespace
 
-BufferEndpointRegistry & BufferEndpointRegistry::get_instance()
-{
-  static BufferEndpointRegistry instance;
-  return instance;
-}
-
 void BufferEndpointRegistry::register_subscriber_discovery_callback(
   const std::string & topic_name,
   const rmw_gid_t & publisher_gid,

--- a/rmw_fastrtps_cpp/src/buffer_endpoint_registry.cpp
+++ b/rmw_fastrtps_cpp/src/buffer_endpoint_registry.cpp
@@ -15,21 +15,13 @@
 #include "buffer_endpoint_registry.hpp"
 
 #include <algorithm>
-#include <cstring>
 #include <vector>
 
 #include "rcutils/logging_macros.h"
+#include "rmw/rmw.h"
 
 namespace rmw_fastrtps_cpp
 {
-
-namespace
-{
-bool gid_equal(const rmw_gid_t & a, const rmw_gid_t & b)
-{
-  return std::memcmp(a.data, b.data, RMW_GID_STORAGE_SIZE) == 0;
-}
-}  // namespace
 
 void BufferEndpointRegistry::register_subscriber_discovery_callback(
   const std::string & topic_name,
@@ -89,7 +81,17 @@ void BufferEndpointRegistry::unregister_callbacks(const rmw_gid_t & gid)
         entries.erase(
           std::remove_if(
             entries.begin(), entries.end(),
-            [&gid](const CallbackEntry & e) {return gid_equal(e.registrant_gid, gid);}),
+            [&gid](const CallbackEntry & e) {
+              bool equal = false;
+              rmw_ret_t ret = rmw_compare_gids_equal(&e.registrant_gid, &gid, &equal);
+              if (RMW_RET_OK != ret) {
+                RCUTILS_LOG_ERROR_NAMED(
+                  "rmw_fastrtps_cpp",
+                  "BufferEndpointRegistry: rmw_compare_gids_equal failed in unregister_callbacks");
+                return false;
+              }
+              return equal;
+            }),
           entries.end());
       }
     };
@@ -105,7 +107,15 @@ void BufferEndpointRegistry::notify_subscriber_discovered(const BufferEndpointIn
     std::lock_guard<std::mutex> lock(mutex_);
 
     for (const auto & existing : known_subscribers_) {
-      if (gid_equal(existing.gid, info.gid)) {
+      bool equal = false;
+      rmw_ret_t ret = rmw_compare_gids_equal(&existing.gid, &info.gid, &equal);
+      if (RMW_RET_OK != ret) {
+        RCUTILS_LOG_ERROR_NAMED(
+          "rmw_fastrtps_cpp",
+          "BufferEndpointRegistry: rmw_compare_gids_equal failed in notify_subscriber_discovered");
+        continue;
+      }
+      if (equal) {
         RCUTILS_LOG_DEBUG_NAMED(
           "rmw_fastrtps_cpp",
           "BufferEndpointRegistry: subscriber on '%s' already known, skipping",
@@ -144,7 +154,15 @@ void BufferEndpointRegistry::notify_publisher_discovered(const BufferEndpointInf
     std::lock_guard<std::mutex> lock(mutex_);
 
     for (const auto & existing : known_publishers_) {
-      if (gid_equal(existing.gid, info.gid)) {
+      bool equal = false;
+      rmw_ret_t ret = rmw_compare_gids_equal(&existing.gid, &info.gid, &equal);
+      if (RMW_RET_OK != ret) {
+        RCUTILS_LOG_ERROR_NAMED(
+          "rmw_fastrtps_cpp",
+          "BufferEndpointRegistry: rmw_compare_gids_equal failed in notify_publisher_discovered");
+        continue;
+      }
+      if (equal) {
         RCUTILS_LOG_DEBUG_NAMED(
           "rmw_fastrtps_cpp",
           "BufferEndpointRegistry: publisher on '%s' already known, skipping",

--- a/rmw_fastrtps_cpp/src/buffer_endpoint_registry.cpp
+++ b/rmw_fastrtps_cpp/src/buffer_endpoint_registry.cpp
@@ -95,7 +95,7 @@ void BufferEndpointRegistry::unregister_callbacks(const rmw_gid_t & gid)
         entries.erase(
           std::remove_if(
             entries.begin(), entries.end(),
-            [&gid](const CallbackEntry & e) { return gid_equal(e.registrant_gid, gid); }),
+            [&gid](const CallbackEntry & e) {return gid_equal(e.registrant_gid, gid);}),
           entries.end());
       }
     };

--- a/rmw_fastrtps_cpp/src/buffer_endpoint_registry.cpp
+++ b/rmw_fastrtps_cpp/src/buffer_endpoint_registry.cpp
@@ -1,0 +1,185 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "buffer_endpoint_registry.hpp"
+
+#include <algorithm>
+#include <cstring>
+#include <vector>
+
+#include "rcutils/logging_macros.h"
+
+namespace rmw_fastrtps_cpp
+{
+
+namespace
+{
+bool gid_equal(const rmw_gid_t & a, const rmw_gid_t & b)
+{
+  return std::memcmp(a.data, b.data, RMW_GID_STORAGE_SIZE) == 0;
+}
+}  // namespace
+
+BufferEndpointRegistry & BufferEndpointRegistry::get_instance()
+{
+  static BufferEndpointRegistry instance;
+  return instance;
+}
+
+void BufferEndpointRegistry::register_subscriber_discovery_callback(
+  const std::string & topic_name,
+  const rmw_gid_t & publisher_gid,
+  BufferEndpointDiscoveryCallback callback)
+{
+  // Collect matching known endpoints while holding the lock, then fire outside.
+  std::vector<BufferEndpointInfo> to_fire;
+  BufferEndpointDiscoveryCallback cb_copy;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    subscriber_callbacks_[topic_name].push_back({publisher_gid, callback});
+    cb_copy = subscriber_callbacks_[topic_name].back().callback;
+
+    for (const auto & info : known_subscribers_) {
+      if (info.topic_name == topic_name) {
+        to_fire.push_back(info);
+      }
+    }
+  }
+
+  for (const auto & info : to_fire) {
+    cb_copy(info);
+  }
+}
+
+void BufferEndpointRegistry::register_publisher_discovery_callback(
+  const std::string & topic_name,
+  const rmw_gid_t & subscriber_gid,
+  BufferEndpointDiscoveryCallback callback)
+{
+  std::vector<BufferEndpointInfo> to_fire;
+  BufferEndpointDiscoveryCallback cb_copy;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    publisher_callbacks_[topic_name].push_back({subscriber_gid, callback});
+    cb_copy = publisher_callbacks_[topic_name].back().callback;
+
+    for (const auto & info : known_publishers_) {
+      if (info.topic_name == topic_name) {
+        to_fire.push_back(info);
+      }
+    }
+  }
+
+  for (const auto & info : to_fire) {
+    cb_copy(info);
+  }
+}
+
+void BufferEndpointRegistry::unregister_callbacks(const rmw_gid_t & gid)
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  auto remove_from = [&gid](auto & map) {
+      for (auto & [topic, entries] : map) {
+        entries.erase(
+          std::remove_if(
+            entries.begin(), entries.end(),
+            [&gid](const CallbackEntry & e) { return gid_equal(e.registrant_gid, gid); }),
+          entries.end());
+      }
+    };
+
+  remove_from(subscriber_callbacks_);
+  remove_from(publisher_callbacks_);
+}
+
+void BufferEndpointRegistry::notify_subscriber_discovered(const BufferEndpointInfo & info)
+{
+  std::vector<BufferEndpointDiscoveryCallback> callbacks;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    for (const auto & existing : known_subscribers_) {
+      if (gid_equal(existing.gid, info.gid)) {
+        RCUTILS_LOG_DEBUG_NAMED(
+          "rmw_fastrtps_cpp",
+          "BufferEndpointRegistry: subscriber on '%s' already known, skipping",
+          info.topic_name.c_str());
+        return;
+      }
+    }
+    known_subscribers_.push_back(info);
+
+    auto it = subscriber_callbacks_.find(info.topic_name);
+    if (it == subscriber_callbacks_.end()) {
+      RCUTILS_LOG_DEBUG_NAMED(
+        "rmw_fastrtps_cpp",
+        "BufferEndpointRegistry: no publisher callbacks registered for topic '%s'",
+        info.topic_name.c_str());
+      return;
+    }
+    for (const auto & entry : it->second) {
+      callbacks.push_back(entry.callback);
+    }
+  }
+
+  RCUTILS_LOG_DEBUG_NAMED(
+    "rmw_fastrtps_cpp",
+    "BufferEndpointRegistry: firing %zu publisher callback(s) for discovered subscriber on '%s'",
+    callbacks.size(), info.topic_name.c_str());
+  for (const auto & cb : callbacks) {
+    cb(info);
+  }
+}
+
+void BufferEndpointRegistry::notify_publisher_discovered(const BufferEndpointInfo & info)
+{
+  std::vector<BufferEndpointDiscoveryCallback> callbacks;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    for (const auto & existing : known_publishers_) {
+      if (gid_equal(existing.gid, info.gid)) {
+        RCUTILS_LOG_DEBUG_NAMED(
+          "rmw_fastrtps_cpp",
+          "BufferEndpointRegistry: publisher on '%s' already known, skipping",
+          info.topic_name.c_str());
+        return;
+      }
+    }
+    known_publishers_.push_back(info);
+
+    auto it = publisher_callbacks_.find(info.topic_name);
+    if (it == publisher_callbacks_.end()) {
+      RCUTILS_LOG_DEBUG_NAMED(
+        "rmw_fastrtps_cpp",
+        "BufferEndpointRegistry: no subscriber callbacks registered for topic '%s'",
+        info.topic_name.c_str());
+      return;
+    }
+    for (const auto & entry : it->second) {
+      callbacks.push_back(entry.callback);
+    }
+  }
+
+  RCUTILS_LOG_DEBUG_NAMED(
+    "rmw_fastrtps_cpp",
+    "BufferEndpointRegistry: firing %zu subscriber callback(s) for discovered publisher on '%s'",
+    callbacks.size(), info.topic_name.c_str());
+  for (const auto & cb : callbacks) {
+    cb(info);
+  }
+}
+
+}  // namespace rmw_fastrtps_cpp

--- a/rmw_fastrtps_cpp/src/buffer_endpoint_registry.hpp
+++ b/rmw_fastrtps_cpp/src/buffer_endpoint_registry.hpp
@@ -1,0 +1,98 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RMW_FASTRTPS_CPP__BUFFER_ENDPOINT_REGISTRY_HPP_
+#define RMW_FASTRTPS_CPP__BUFFER_ENDPOINT_REGISTRY_HPP_
+
+#include <functional>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "rmw/types.h"
+
+namespace rmw_fastrtps_cpp
+{
+
+/// Information about a discovered buffer-aware endpoint.
+struct BufferEndpointInfo
+{
+  rmw_gid_t gid{};
+  std::string topic_name;
+  /// Backend type -> aux info string (empty map means CPU-only).
+  std::unordered_map<std::string, std::string> backend_aux_info;
+};
+
+/// Callback invoked when a buffer-aware endpoint is discovered.
+using BufferEndpointDiscoveryCallback = std::function<void (const BufferEndpointInfo &)>;
+
+/// Per-process registry for buffer-aware endpoint discovery callbacks.
+///
+/// When a buffer-aware publisher is created, it registers a "subscriber discovered"
+/// callback on the topic so it can create per-subscriber DataWriters.  Symmetrically,
+/// buffer-aware subscribers register a "publisher discovered" callback.
+///
+/// The DDS ParticipantListener discovery path feeds newly discovered endpoints
+/// into this registry so the appropriate callbacks fire.
+class BufferEndpointRegistry
+{
+public:
+  static BufferEndpointRegistry & get_instance();
+
+  /// Register a callback for when a buffer-aware subscriber is discovered on a topic.
+  void register_subscriber_discovery_callback(
+    const std::string & topic_name,
+    const rmw_gid_t & publisher_gid,
+    BufferEndpointDiscoveryCallback callback);
+
+  /// Register a callback for when a buffer-aware publisher is discovered on a topic.
+  void register_publisher_discovery_callback(
+    const std::string & topic_name,
+    const rmw_gid_t & subscriber_gid,
+    BufferEndpointDiscoveryCallback callback);
+
+  /// Unregister all discovery callbacks associated with a GID.
+  void unregister_callbacks(const rmw_gid_t & gid);
+
+  /// Notify that a buffer-aware subscriber has been discovered.
+  void notify_subscriber_discovered(const BufferEndpointInfo & info);
+
+  /// Notify that a buffer-aware publisher has been discovered.
+  void notify_publisher_discovered(const BufferEndpointInfo & info);
+
+private:
+  BufferEndpointRegistry() = default;
+
+  struct CallbackEntry
+  {
+    rmw_gid_t registrant_gid{};
+    BufferEndpointDiscoveryCallback callback;
+  };
+
+  std::mutex mutex_;
+
+  /// topic_name -> list of (publisher_gid, callback) entries that want subscriber notifications.
+  std::unordered_map<std::string, std::vector<CallbackEntry>> subscriber_callbacks_;
+  /// topic_name -> list of (subscriber_gid, callback) entries that want publisher notifications.
+  std::unordered_map<std::string, std::vector<CallbackEntry>> publisher_callbacks_;
+
+  /// Already-discovered buffer-aware endpoints, used to retroactively fire callbacks.
+  std::vector<BufferEndpointInfo> known_subscribers_;
+  std::vector<BufferEndpointInfo> known_publishers_;
+};
+
+}  // namespace rmw_fastrtps_cpp
+
+#endif  // RMW_FASTRTPS_CPP__BUFFER_ENDPOINT_REGISTRY_HPP_

--- a/rmw_fastrtps_cpp/src/buffer_endpoint_registry.hpp
+++ b/rmw_fastrtps_cpp/src/buffer_endpoint_registry.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RMW_FASTRTPS_CPP__BUFFER_ENDPOINT_REGISTRY_HPP_
-#define RMW_FASTRTPS_CPP__BUFFER_ENDPOINT_REGISTRY_HPP_
+#ifndef BUFFER_ENDPOINT_REGISTRY_HPP_
+#define BUFFER_ENDPOINT_REGISTRY_HPP_
 
 #include <functional>
 #include <mutex>
@@ -95,4 +95,4 @@ private:
 
 }  // namespace rmw_fastrtps_cpp
 
-#endif  // RMW_FASTRTPS_CPP__BUFFER_ENDPOINT_REGISTRY_HPP_
+#endif  // BUFFER_ENDPOINT_REGISTRY_HPP_

--- a/rmw_fastrtps_cpp/src/buffer_endpoint_registry.hpp
+++ b/rmw_fastrtps_cpp/src/buffer_endpoint_registry.hpp
@@ -38,18 +38,18 @@ struct BufferEndpointInfo
 /// Callback invoked when a buffer-aware endpoint is discovered.
 using BufferEndpointDiscoveryCallback = std::function<void (const BufferEndpointInfo &)>;
 
-/// Per-process registry for buffer-aware endpoint discovery callbacks.
+/// Per-context registry for buffer-aware endpoint discovery callbacks.
 ///
 /// When a buffer-aware publisher is created, it registers a "subscriber discovered"
 /// callback on the topic so it can create per-subscriber DataWriters.  Symmetrically,
 /// buffer-aware subscribers register a "publisher discovered" callback.
 ///
 /// The DDS ParticipantListener discovery path feeds newly discovered endpoints
-/// into this registry so the appropriate callbacks fire.
+/// into the owning context's registry so the appropriate callbacks fire.
 class BufferEndpointRegistry
 {
 public:
-  static BufferEndpointRegistry & get_instance();
+  BufferEndpointRegistry() = default;
 
   /// Register a callback for when a buffer-aware subscriber is discovered on a topic.
   void register_subscriber_discovery_callback(
@@ -73,8 +73,6 @@ public:
   void notify_publisher_discovered(const BufferEndpointInfo & info);
 
 private:
-  BufferEndpointRegistry() = default;
-
   struct CallbackEntry
   {
     rmw_gid_t registrant_gid{};

--- a/rmw_fastrtps_cpp/src/buffer_endpoint_registry.hpp
+++ b/rmw_fastrtps_cpp/src/buffer_endpoint_registry.hpp
@@ -31,8 +31,8 @@ struct BufferEndpointInfo
 {
   rmw_gid_t gid{};
   std::string topic_name;
-  /// Backend type -> aux info string (empty map means CPU-only).
-  std::unordered_map<std::string, std::string> backend_aux_info;
+  /// Backend type -> backend metadata string (empty map means CPU-only).
+  std::unordered_map<std::string, std::string> backend_metadata;
 };
 
 /// Callback invoked when a buffer-aware endpoint is discovered.

--- a/rmw_fastrtps_cpp/src/init_rmw_context_impl.cpp
+++ b/rmw_fastrtps_cpp/src/init_rmw_context_impl.cpp
@@ -189,7 +189,7 @@ init_context_impl(
       rmw_fastrtps_cpp::BufferEndpointInfo info;
       info.gid = gid;
       info.topic_name = _strip_ros_prefix_if_exists(dds_topic_name);
-      info.backend_aux_info = backends;
+      info.backend_metadata = backends;
 
       RCUTILS_LOG_DEBUG_NAMED(
         "rmw_fastrtps_cpp",

--- a/rmw_fastrtps_cpp/src/init_rmw_context_impl.cpp
+++ b/rmw_fastrtps_cpp/src/init_rmw_context_impl.cpp
@@ -29,6 +29,7 @@
 #include "rmw_fastrtps_cpp/subscription.hpp"
 
 #include "rmw_fastrtps_shared_cpp/custom_participant_info.hpp"
+#include "rmw_fastrtps_shared_cpp/namespace_prefix.hpp"
 #include "rmw_fastrtps_shared_cpp/participant.hpp"
 #include "rmw_fastrtps_shared_cpp/publisher.hpp"
 #include "rmw_fastrtps_shared_cpp/subscription.hpp"
@@ -37,6 +38,8 @@
 #include "rosidl_typesupport_cpp/message_type_support.hpp"
 
 #include "rmw_fastrtps_shared_cpp/listener_thread.hpp"
+
+#include "buffer_endpoint_registry.hpp"
 
 using rmw_dds_common::msg::ParticipantEntitiesInfo;
 
@@ -176,6 +179,31 @@ init_context_impl(
   if (RMW_RET_OK != ret) {
     return ret;
   }
+
+  // Hook buffer endpoint discovery into the DDS participant listener.
+  participant_info->listener_->set_buffer_discovery_callback(
+    [](const rmw_gid_t & gid, const std::string & dds_topic_name,
+    const std::unordered_map<std::string, std::string> & backends, bool is_reader)
+    {
+      auto & registry = rmw_fastrtps_cpp::BufferEndpointRegistry::get_instance();
+      rmw_fastrtps_cpp::BufferEndpointInfo info;
+      info.gid = gid;
+      info.topic_name = _strip_ros_prefix_if_exists(dds_topic_name);
+      info.backend_aux_info = backends;
+
+      RCUTILS_LOG_DEBUG_NAMED(
+        "rmw_fastrtps_cpp",
+        "DDS discovery: buffer-aware %s on topic '%s' (DDS: '%s'), %zu backend(s)",
+        is_reader ? "subscriber" : "publisher",
+        info.topic_name.c_str(), dds_topic_name.c_str(),
+        backends.size());
+
+      if (is_reader) {
+        registry.notify_subscriber_discovered(info);
+      } else {
+        registry.notify_publisher_discovered(info);
+      }
+    });
 
   common_context->graph_cache.set_on_change_callback(
     [guard_condition = graph_guard_condition.get()]()

--- a/rmw_fastrtps_cpp/src/init_rmw_context_impl.cpp
+++ b/rmw_fastrtps_cpp/src/init_rmw_context_impl.cpp
@@ -174,6 +174,10 @@ init_context_impl(
 
   context->impl->common = common_context.get();
   context->impl->participant_info = participant_info.get();
+  participant_info->buffer_serialization_context_ = context->impl->buffer_serialization_context;
+  auto * buffer_endpoint_registry =
+    static_cast<rmw_fastrtps_cpp::BufferEndpointRegistry *>(
+    context->impl->buffer_endpoint_registry);
 
   rmw_ret_t ret = rmw_fastrtps_shared_cpp::run_listener_thread(context);
   if (RMW_RET_OK != ret) {
@@ -182,10 +186,12 @@ init_context_impl(
 
   // Hook buffer endpoint discovery into the DDS participant listener.
   participant_info->listener_->set_buffer_discovery_callback(
-    [](const rmw_gid_t & gid, const std::string & dds_topic_name,
+    [buffer_endpoint_registry](const rmw_gid_t & gid, const std::string & dds_topic_name,
     const std::unordered_map<std::string, std::string> & backends, bool is_reader)
     {
-      auto & registry = rmw_fastrtps_cpp::BufferEndpointRegistry::get_instance();
+      if (!buffer_endpoint_registry) {
+        return;
+      }
       rmw_fastrtps_cpp::BufferEndpointInfo info;
       info.gid = gid;
       info.topic_name = _strip_ros_prefix_if_exists(dds_topic_name);
@@ -199,9 +205,9 @@ init_context_impl(
         backends.size());
 
       if (is_reader) {
-        registry.notify_subscriber_discovered(info);
+        buffer_endpoint_registry->notify_subscriber_discovered(info);
       } else {
-        registry.notify_publisher_discovered(info);
+        buffer_endpoint_registry->notify_publisher_discovered(info);
       }
     });
 

--- a/rmw_fastrtps_cpp/src/publisher.cpp
+++ b/rmw_fastrtps_cpp/src/publisher.cpp
@@ -258,7 +258,8 @@ rmw_fastrtps_cpp::create_publisher(
   std::unordered_map<std::string, std::string> backend_metadata;
   if (has_buffer_fields) {
     backend_metadata =
-      rosidl_buffer_backend_registry::BufferBackendRegistry::get_instance().get_all_backend_metadata();
+      rosidl_buffer_backend_registry::BufferBackendRegistry::get_instance()
+      .get_all_backend_metadata();
     // CPU serialization is always implicitly supported by buffer-aware publishers.
     // Advertise "cpu" so subscribers can discover this publisher via user_data.
     if (backend_metadata.find("cpu") == backend_metadata.end()) {

--- a/rmw_fastrtps_cpp/src/publisher.cpp
+++ b/rmw_fastrtps_cpp/src/publisher.cpp
@@ -367,6 +367,34 @@ rmw_fastrtps_cpp::create_publisher(
       rosidl_buffer_backend_registry::notify_endpoint_created(
         backend_context->backend_instances, info->local_endpoint_info_);
     }
+
+    // Create CPU-only shared channel DataWriter.
+    // All CPU-only subscribers share this single channel instead of
+    // individual peer-to-peer endpoints.
+    std::string cpu_topic_name = topic_name_mangled + "/_buf_cpu";
+    eprosima::fastdds::dds::TopicQos cpu_topic_qos = dds_participant->get_default_topic_qos();
+    if (!get_topic_qos(*qos_policies, cpu_topic_qos)) {
+      RMW_SET_ERROR_MSG("create_publisher() failed setting CPU channel topic QoS");
+      return nullptr;
+    }
+    info->cpu_topic_ = participant_info->find_or_create_topic(
+      cpu_topic_name, type_name, cpu_topic_qos, nullptr);
+    if (!info->cpu_topic_) {
+      RMW_SET_ERROR_MSG("create_publisher() failed to create CPU channel topic");
+      return nullptr;
+    }
+
+    eprosima::fastdds::dds::DataWriterQos cpu_writer_qos = info->data_writer_->get_qos();
+    info->cpu_data_writer_ = publisher->create_datawriter(
+      info->cpu_topic_, cpu_writer_qos, nullptr);
+    if (!info->cpu_data_writer_) {
+      participant_info->delete_topic(info->cpu_topic_, nullptr);
+      info->cpu_topic_ = nullptr;
+      RMW_SET_ERROR_MSG("create_publisher() failed to create CPU channel DataWriter");
+      return nullptr;
+    }
+    info->cpu_data_writer_->get_statuscondition().set_enabled_statuses(
+      eprosima::fastdds::dds::StatusMask::none());
   }
 
   cleanup_rmw_publisher.cancel();

--- a/rmw_fastrtps_cpp/src/publisher.cpp
+++ b/rmw_fastrtps_cpp/src/publisher.cpp
@@ -47,6 +47,9 @@
 #include "rmw_fastrtps_cpp/identifier.hpp"
 #include "rmw_fastrtps_cpp/publisher.hpp"
 
+#include "rosidl_buffer_backend_registry/buffer_backend_registry.hpp"
+#include "rosidl_typesupport_fastrtps_cpp/message_type_support.h"
+
 #include "tracetools/tracetools.h"
 
 #include "type_support_common.hpp"
@@ -250,10 +253,24 @@ rmw_fastrtps_cpp::create_publisher(
     writer_qos.data_sharing().off();
   }
 
-  // Get QoS from RMW
+  // Detect buffer-aware message type
+  bool has_buffer_fields = callbacks->has_buffer_fields;
+  std::unordered_map<std::string, std::string> backend_aux_info;
+  if (has_buffer_fields) {
+    backend_aux_info =
+      rosidl_buffer_backend_registry::BufferBackendRegistry::get_instance().get_all_aux_info();
+    // CPU serialization is always implicitly supported by buffer-aware publishers.
+    // Advertise "cpu" so subscribers can discover this publisher via user_data.
+    if (backend_aux_info.find("cpu") == backend_aux_info.end()) {
+      backend_aux_info["cpu"] = "";
+    }
+  }
+
+  // Get QoS from RMW, optionally encoding buffer backend info in user_data
   if (!get_datawriter_qos(
       *qos_policies, *type_supports->get_type_hash_func(type_supports),
-      writer_qos))
+      writer_qos, nullptr,
+      has_buffer_fields ? &backend_aux_info : nullptr))
   {
     RMW_SET_ERROR_MSG("create_publisher() failed setting data writer QoS");
     return nullptr;
@@ -322,6 +339,23 @@ rmw_fastrtps_cpp::create_publisher(
   memcpy(const_cast<char *>(rmw_publisher->topic_name), topic_name, strlen(topic_name) + 1);
 
   rmw_publisher->options = *publisher_options;
+
+  // Buffer-aware publisher setup
+  info->is_buffer_aware_ = has_buffer_fields;
+  if (has_buffer_fields) {
+    info->backend_aux_info_ = backend_aux_info;
+    info->participant_ = dds_participant;
+    info->dds_publisher_ = publisher;
+
+    info->local_endpoint_info_ = rmw_get_zero_initialized_topic_endpoint_info();
+    info->local_endpoint_info_.endpoint_type = RMW_ENDPOINT_PUBLISHER;
+    std::memcpy(
+      info->local_endpoint_info_.endpoint_gid,
+      info->publisher_gid.data, RMW_GID_STORAGE_SIZE);
+
+    rosidl_buffer_backend_registry::BufferBackendRegistry::get_instance().notify_endpoint_created(
+      info->local_endpoint_info_);
+  }
 
   cleanup_rmw_publisher.cancel();
   cleanup_datawriter.cancel();

--- a/rmw_fastrtps_cpp/src/publisher.cpp
+++ b/rmw_fastrtps_cpp/src/publisher.cpp
@@ -26,6 +26,7 @@
 #include "fastdds/rtps/attributes/ResourceManagement.hpp"
 
 #include "rcutils/error_handling.h"
+#include "rcutils/logging_macros.h"
 #include "rcutils/macros.h"
 
 #include "rmw/allocators.h"
@@ -395,6 +396,10 @@ rmw_fastrtps_cpp::create_publisher(
     }
     info->cpu_data_writer_->get_statuscondition().set_enabled_statuses(
       eprosima::fastdds::dds::StatusMask::none());
+
+    RCUTILS_LOG_DEBUG_NAMED(
+      "rmw_fastrtps_cpp",
+      "Created buffer-aware publisher on '%s'", topic_name);
   }
 
   cleanup_rmw_publisher.cancel();

--- a/rmw_fastrtps_cpp/src/publisher.cpp
+++ b/rmw_fastrtps_cpp/src/publisher.cpp
@@ -47,7 +47,8 @@
 #include "rmw_fastrtps_cpp/identifier.hpp"
 #include "rmw_fastrtps_cpp/publisher.hpp"
 
-#include "rosidl_buffer_backend_registry/buffer_backend_registry.hpp"
+#include "buffer_backend_context.hpp"
+#include "rosidl_buffer_backend_registry/backend_utils.hpp"
 #include "rosidl_typesupport_fastrtps_cpp/message_type_support.h"
 
 #include "tracetools/tracetools.h"
@@ -257,9 +258,13 @@ rmw_fastrtps_cpp::create_publisher(
   bool has_buffer_fields = callbacks->has_buffer_fields;
   std::unordered_map<std::string, std::string> backend_metadata;
   if (has_buffer_fields) {
-    backend_metadata =
-      rosidl_buffer_backend_registry::BufferBackendRegistry::get_instance()
-      .get_all_backend_metadata();
+    auto * backend_context =
+      static_cast<rmw_fastrtps_cpp::BufferBackendContext *>(
+      participant_info->buffer_serialization_context_);
+    if (backend_context) {
+      backend_metadata = rosidl_buffer_backend_registry::get_all_backend_metadata(
+        backend_context->backend_instances);
+    }
     // CPU serialization is always implicitly supported by buffer-aware publishers.
     // Advertise "cpu" so subscribers can discover this publisher via user_data.
     if (backend_metadata.find("cpu") == backend_metadata.end()) {
@@ -344,6 +349,7 @@ rmw_fastrtps_cpp::create_publisher(
   // Buffer-aware publisher setup
   info->is_buffer_aware_ = has_buffer_fields;
   if (has_buffer_fields) {
+    info->serialization_context_ = participant_info->buffer_serialization_context_;
     info->backend_metadata_ = backend_metadata;
     info->participant_ = dds_participant;
     info->dds_publisher_ = publisher;
@@ -354,8 +360,13 @@ rmw_fastrtps_cpp::create_publisher(
       info->local_endpoint_info_.endpoint_gid,
       info->publisher_gid.data, RMW_GID_STORAGE_SIZE);
 
-    rosidl_buffer_backend_registry::BufferBackendRegistry::get_instance().notify_endpoint_created(
-      info->local_endpoint_info_);
+    auto * backend_context =
+      static_cast<const rmw_fastrtps_cpp::BufferBackendContext *>(
+      info->serialization_context_);
+    if (backend_context) {
+      rosidl_buffer_backend_registry::notify_endpoint_created(
+        backend_context->backend_instances, info->local_endpoint_info_);
+    }
   }
 
   cleanup_rmw_publisher.cancel();

--- a/rmw_fastrtps_cpp/src/publisher.cpp
+++ b/rmw_fastrtps_cpp/src/publisher.cpp
@@ -255,14 +255,14 @@ rmw_fastrtps_cpp::create_publisher(
 
   // Detect buffer-aware message type
   bool has_buffer_fields = callbacks->has_buffer_fields;
-  std::unordered_map<std::string, std::string> backend_aux_info;
+  std::unordered_map<std::string, std::string> backend_metadata;
   if (has_buffer_fields) {
-    backend_aux_info =
-      rosidl_buffer_backend_registry::BufferBackendRegistry::get_instance().get_all_aux_info();
+    backend_metadata =
+      rosidl_buffer_backend_registry::BufferBackendRegistry::get_instance().get_all_backend_metadata();
     // CPU serialization is always implicitly supported by buffer-aware publishers.
     // Advertise "cpu" so subscribers can discover this publisher via user_data.
-    if (backend_aux_info.find("cpu") == backend_aux_info.end()) {
-      backend_aux_info["cpu"] = "";
+    if (backend_metadata.find("cpu") == backend_metadata.end()) {
+      backend_metadata["cpu"] = "";
     }
   }
 
@@ -270,7 +270,7 @@ rmw_fastrtps_cpp::create_publisher(
   if (!get_datawriter_qos(
       *qos_policies, *type_supports->get_type_hash_func(type_supports),
       writer_qos, nullptr,
-      has_buffer_fields ? &backend_aux_info : nullptr))
+      has_buffer_fields ? &backend_metadata : nullptr))
   {
     RMW_SET_ERROR_MSG("create_publisher() failed setting data writer QoS");
     return nullptr;
@@ -343,7 +343,7 @@ rmw_fastrtps_cpp::create_publisher(
   // Buffer-aware publisher setup
   info->is_buffer_aware_ = has_buffer_fields;
   if (has_buffer_fields) {
-    info->backend_aux_info_ = backend_aux_info;
+    info->backend_metadata_ = backend_metadata;
     info->participant_ = dds_participant;
     info->dds_publisher_ = publisher;
 

--- a/rmw_fastrtps_cpp/src/rmw_init.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_init.cpp
@@ -45,7 +45,7 @@
 #include "rmw_fastrtps_cpp/publisher.hpp"
 #include "rmw_fastrtps_cpp/subscription.hpp"
 
-#include "rosidl_buffer_backend_registry/buffer_backend_loader.hpp"
+#include "buffer_backend_loader.hpp"
 
 extern "C"
 {
@@ -119,7 +119,7 @@ rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
   }
 
   try {
-    rosidl_buffer_backend_registry::initialize_buffer_backends();
+    rmw_fastrtps_cpp::initialize_buffer_backends();
   } catch (const std::exception &) {
     // Non-fatal: buffer backends are optional.
   }
@@ -144,7 +144,7 @@ rmw_shutdown(rmw_context_t * context)
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
   context->impl->is_shutdown = true;
 
-  rosidl_buffer_backend_registry::shutdown_buffer_backends();
+  rmw_fastrtps_cpp::shutdown_buffer_backends();
 
   return RMW_RET_OK;
 }

--- a/rmw_fastrtps_cpp/src/rmw_init.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_init.cpp
@@ -17,6 +17,7 @@
 #include <cstring>
 #include <memory>
 
+#include "rcutils/logging_macros.h"
 #include "rcutils/strdup.h"
 #include "rcutils/types.h"
 
@@ -140,8 +141,11 @@ rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
 
   try {
     rmw_fastrtps_cpp::initialize_buffer_backends(*buffer_context);
-  } catch (const std::exception &) {
+  } catch (const std::exception & e) {
     // Non-fatal: buffer backends are optional.
+    RCUTILS_LOG_INFO_NAMED(
+      "rmw_fastrtps_cpp",
+      "Buffer backends not available: %s", e.what());
   }
 
   cleanup_impl.cancel();

--- a/rmw_fastrtps_cpp/src/rmw_init.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_init.cpp
@@ -45,6 +45,8 @@
 #include "rmw_fastrtps_cpp/publisher.hpp"
 #include "rmw_fastrtps_cpp/subscription.hpp"
 
+#include "rosidl_buffer_backend_registry/buffer_backend_loader.hpp"
+
 extern "C"
 {
 rmw_ret_t
@@ -116,6 +118,12 @@ rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
     return ret;
   }
 
+  try {
+    rosidl_buffer_backend_registry::initialize_buffer_backends();
+  } catch (const std::exception &) {
+    // Non-fatal: buffer backends are optional.
+  }
+
   cleanup_impl.cancel();
   restore_context.cancel();
   return RMW_RET_OK;
@@ -135,6 +143,9 @@ rmw_shutdown(rmw_context_t * context)
     eprosima_fastrtps_identifier,
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
   context->impl->is_shutdown = true;
+
+  rosidl_buffer_backend_registry::shutdown_buffer_backends();
+
   return RMW_RET_OK;
 }
 

--- a/rmw_fastrtps_cpp/src/rmw_init.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_init.cpp
@@ -45,7 +45,9 @@
 #include "rmw_fastrtps_cpp/publisher.hpp"
 #include "rmw_fastrtps_cpp/subscription.hpp"
 
+#include "buffer_backend_context.hpp"
 #include "buffer_backend_loader.hpp"
+#include "buffer_endpoint_registry.hpp"
 
 extern "C"
 {
@@ -112,14 +114,32 @@ rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
     [context]() {delete context->impl;});
 
   context->impl->is_shutdown = false;
+  context->impl->buffer_serialization_context = nullptr;
+  context->impl->buffer_endpoint_registry = nullptr;
   context->options = rmw_get_zero_initialized_init_options();
   rmw_ret_t ret = rmw_init_options_copy(options, &context->options);
   if (RMW_RET_OK != ret) {
     return ret;
   }
 
+  auto buffer_context = new (std::nothrow) rmw_fastrtps_cpp::BufferBackendContext();
+  if (nullptr == buffer_context) {
+    RMW_SET_ERROR_MSG("failed to allocate buffer backend context");
+    return RMW_RET_BAD_ALLOC;
+  }
+  context->impl->buffer_serialization_context = buffer_context;
+
+  auto buffer_endpoint_registry = new (std::nothrow) rmw_fastrtps_cpp::BufferEndpointRegistry();
+  if (nullptr == buffer_endpoint_registry) {
+    delete buffer_context;
+    context->impl->buffer_serialization_context = nullptr;
+    RMW_SET_ERROR_MSG("failed to allocate buffer endpoint registry");
+    return RMW_RET_BAD_ALLOC;
+  }
+  context->impl->buffer_endpoint_registry = buffer_endpoint_registry;
+
   try {
-    rmw_fastrtps_cpp::initialize_buffer_backends();
+    rmw_fastrtps_cpp::initialize_buffer_backends(*buffer_context);
   } catch (const std::exception &) {
     // Non-fatal: buffer backends are optional.
   }
@@ -142,9 +162,14 @@ rmw_shutdown(rmw_context_t * context)
     context->implementation_identifier,
     eprosima_fastrtps_identifier,
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+
   context->impl->is_shutdown = true;
 
-  rmw_fastrtps_cpp::shutdown_buffer_backends();
+  auto * buffer_context = static_cast<rmw_fastrtps_cpp::BufferBackendContext *>(
+    context->impl->buffer_serialization_context);
+  if (buffer_context) {
+    rmw_fastrtps_cpp::shutdown_buffer_backends(*buffer_context);
+  }
 
   return RMW_RET_OK;
 }
@@ -170,6 +195,21 @@ rmw_context_fini(rmw_context_t * context)
     RMW_SET_ERROR_MSG("Finalizing a context with active nodes");
     return RMW_RET_ERROR;
   }
+
+  auto * buffer_context = static_cast<rmw_fastrtps_cpp::BufferBackendContext *>(
+    context->impl->buffer_serialization_context);
+  if (buffer_context) {
+    delete buffer_context;
+    context->impl->buffer_serialization_context = nullptr;
+  }
+
+  auto * buffer_endpoint_registry = static_cast<rmw_fastrtps_cpp::BufferEndpointRegistry *>(
+    context->impl->buffer_endpoint_registry);
+  if (buffer_endpoint_registry) {
+    delete buffer_endpoint_registry;
+    context->impl->buffer_endpoint_registry = nullptr;
+  }
+
   rmw_ret_t ret = rmw_init_options_fini(&context->options);
   delete context->impl;
   *context = rmw_get_zero_initialized_context();

--- a/rmw_fastrtps_cpp/src/rmw_publish.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publish.cpp
@@ -39,6 +39,74 @@
 namespace
 {
 
+void
+create_pending_buffer_writers(CustomPublisherInfo * info)
+{
+  auto & state = *info->buffer_state_;
+  std::vector<PendingBufferPublisher> pending;
+  {
+    std::lock_guard<std::mutex> lock(state.mutex);
+    if (state.pending.empty()) {
+      return;
+    }
+    pending = std::move(state.pending);
+    state.pending.clear();
+  }
+
+  std::vector<std::shared_ptr<BufferPublisherEndpoint>> new_endpoints;
+  for (auto & p : pending) {
+    auto endpoint = std::make_shared<BufferPublisherEndpoint>();
+    endpoint->key = p.unique_topic;
+    endpoint->target_subscriber_gid = p.target_subscriber_gid;
+    endpoint->subscriber_endpoint_info = p.subscriber_endpoint_info;
+    endpoint->backend_metadata = std::move(p.backend_metadata);
+
+    eprosima::fastdds::dds::TopicQos topic_qos =
+      info->participant_->get_default_topic_qos();
+    auto * topic = info->participant_->create_topic(
+      p.unique_topic, info->type_support_.get_type_name(), topic_qos);
+    if (!topic) {
+      RCUTILS_LOG_ERROR_NAMED(
+        "rmw_fastrtps_cpp",
+        "Failed to create per-subscriber topic '%s'", p.unique_topic.c_str());
+      continue;
+    }
+    endpoint->topic = topic;
+
+    eprosima::fastdds::dds::DataWriterQos writer_qos =
+      info->dds_publisher_->get_default_datawriter_qos();
+    writer_qos.publish_mode().kind = eprosima::fastdds::dds::SYNCHRONOUS_PUBLISH_MODE;
+    writer_qos.endpoint().history_memory_policy =
+      eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+    writer_qos.data_sharing().off();
+    writer_qos.reliability().kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
+    writer_qos.history() = info->data_writer_->get_qos().history();
+
+    auto * data_writer = info->dds_publisher_->create_datawriter(
+      topic, writer_qos, nullptr);
+    if (!data_writer) {
+      info->participant_->delete_topic(topic);
+      RCUTILS_LOG_ERROR_NAMED(
+        "rmw_fastrtps_cpp",
+        "Failed to create per-subscriber DataWriter for '%s'", p.unique_topic.c_str());
+      continue;
+    }
+    endpoint->data_writer = data_writer;
+
+    RCUTILS_LOG_INFO_NAMED(
+      "rmw_fastrtps_cpp",
+      "Buffer publisher: created per-sub endpoint '%s'", p.unique_topic.c_str());
+    new_endpoints.push_back(std::move(endpoint));
+  }
+
+  if (!new_endpoints.empty()) {
+    std::lock_guard<std::mutex> lock(state.mutex);
+    for (auto & ep : new_endpoints) {
+      state.endpoints.push_back(std::move(ep));
+    }
+  }
+}
+
 /// Publish to per-subscriber buffer endpoints. Returns true if there are
 /// non-buffer-aware subscribers on the main topic that still need to be
 /// served via the normal DataWriter.
@@ -48,15 +116,18 @@ publish_to_buffer_endpoints(
   const void * ros_message,
   const rmw_publisher_t * publisher)
 {
-  auto callbacks = static_cast<const message_type_support_callbacks_t *>(info->type_support_impl_);
+  create_pending_buffer_writers(info);
 
-  std::lock_guard<std::mutex> lock(info->buffer_mutex_);
+  auto callbacks = static_cast<const message_type_support_callbacks_t *>(info->type_support_impl_);
+  auto & state = *info->buffer_state_;
+
+  std::lock_guard<std::mutex> lock(state.mutex);
 
   size_t total_matched = info->publisher_event_->subscription_count();
-  size_t buffer_count = info->buffer_endpoints_.size() + info->pending_buffer_endpoints_.size();
+  size_t buffer_count = state.endpoints.size() + state.pending.size();
   bool has_non_buffer_subscribers = (total_matched > buffer_count);
 
-  if (info->buffer_endpoints_.empty()) {
+  if (state.endpoints.empty()) {
     return has_non_buffer_subscribers;
   }
 
@@ -64,7 +135,7 @@ publish_to_buffer_endpoints(
   eprosima::fastdds::dds::Time_t::now(stamp);
   TRACETOOLS_TRACEPOINT(rmw_publish, publisher, ros_message, stamp.to_ns());
 
-  for (const auto & endpoint : info->buffer_endpoints_) {
+  for (const auto & endpoint : state.endpoints) {
     uint32_t serialized_size = callbacks->get_serialized_size(ros_message);
     size_t buffer_size = serialized_size + 4096;
     std::vector<uint8_t> buffer_data(buffer_size);
@@ -86,7 +157,6 @@ publish_to_buffer_endpoints(
       continue;
     }
 
-    // Write the CDR buffer to this endpoint's DataWriter
     rmw_fastrtps_shared_cpp::SerializedData data;
     data.type = rmw_fastrtps_shared_cpp::FASTDDS_SERIALIZED_DATA_TYPE_CDR_BUFFER;
     data.data = &ser;

--- a/rmw_fastrtps_cpp/src/rmw_publish.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publish.cpp
@@ -74,14 +74,11 @@ create_pending_buffer_writers(CustomPublisherInfo * info)
     }
     endpoint->topic = topic;
 
-    eprosima::fastdds::dds::DataWriterQos writer_qos =
-      info->dds_publisher_->get_default_datawriter_qos();
+    eprosima::fastdds::dds::DataWriterQos writer_qos = info->data_writer_->get_qos();
     writer_qos.publish_mode().kind = eprosima::fastdds::dds::SYNCHRONOUS_PUBLISH_MODE;
     writer_qos.endpoint().history_memory_policy =
       eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
     writer_qos.data_sharing().off();
-    writer_qos.reliability().kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
-    writer_qos.history() = info->data_writer_->get_qos().history();
 
     auto * data_writer = info->dds_publisher_->create_datawriter(
       topic, writer_qos, nullptr);

--- a/rmw_fastrtps_cpp/src/rmw_publish.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publish.cpp
@@ -62,8 +62,7 @@ create_pending_buffer_writers(CustomPublisherInfo * info)
     endpoint->subscriber_endpoint_info = p.subscriber_endpoint_info;
     endpoint->backend_metadata = std::move(p.backend_metadata);
 
-    eprosima::fastdds::dds::TopicQos topic_qos =
-      info->participant_->get_default_topic_qos();
+    eprosima::fastdds::dds::TopicQos topic_qos = info->topic_->get_qos();
     auto * topic = info->participant_->create_topic(
       p.unique_topic, info->type_support_.get_type_name(), topic_qos);
     if (!topic) {
@@ -94,6 +93,14 @@ create_pending_buffer_writers(CustomPublisherInfo * info)
     RCUTILS_LOG_INFO_NAMED(
       "rmw_fastrtps_cpp",
       "Buffer publisher: created per-sub endpoint '%s'", p.unique_topic.c_str());
+    RCUTILS_LOG_DEBUG_NAMED(
+      "rmw_fastrtps_cpp",
+      "Buffer publisher endpoint '%s': reliability=%d, durability=%d, history=%d depth=%d",
+      p.unique_topic.c_str(),
+      writer_qos.reliability().kind,
+      writer_qos.durability().kind,
+      writer_qos.history().kind,
+      writer_qos.history().depth);
     new_endpoints.push_back(std::move(endpoint));
   }
 

--- a/rmw_fastrtps_cpp/src/rmw_publish.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publish.cpp
@@ -108,10 +108,12 @@ create_pending_buffer_writers(CustomPublisherInfo * info)
   }
 }
 
-/// Publish to per-subscriber buffer endpoints. Returns true if there are
-/// non-buffer-aware subscribers on the main topic that still need to be
-/// served via the normal DataWriter.
-bool
+/// Publish to buffer-aware channels.  Only called when all matched
+/// subscribers are backend-aware (no legacy endpoints).
+///
+/// - Write once to the shared CPU channel for all CPU-only subscribers.
+/// - Write per-endpoint to peer-to-peer channels for non-CPU subscribers.
+void
 publish_to_buffer_endpoints(
   CustomPublisherInfo * info,
   const void * ros_message,
@@ -124,18 +126,28 @@ publish_to_buffer_endpoints(
 
   std::lock_guard<std::mutex> lock(state.mutex);
 
-  size_t total_matched = info->publisher_event_->subscription_count();
-  size_t buffer_count = state.endpoints.size() + state.pending.size();
-  bool has_non_buffer_subscribers = (total_matched > buffer_count);
-
-  if (state.endpoints.empty()) {
-    return has_non_buffer_subscribers;
-  }
-
   eprosima::fastdds::dds::Time_t stamp;
   eprosima::fastdds::dds::Time_t::now(stamp);
   TRACETOOLS_TRACEPOINT(rmw_publish, publisher, ros_message, stamp.to_ns());
 
+  // Publish to the shared CPU channel for all CPU-only subscribers.
+  if (!state.cpu_only_subscribers.empty() && info->cpu_data_writer_) {
+    rmw_fastrtps_shared_cpp::SerializedData cpu_data;
+    cpu_data.type = rmw_fastrtps_shared_cpp::FASTDDS_SERIALIZED_DATA_TYPE_ROS_MESSAGE;
+    cpu_data.data = const_cast<void *>(ros_message);
+    cpu_data.impl = info->type_support_impl_;
+
+    if (eprosima::fastdds::dds::RETCODE_OK !=
+      info->cpu_data_writer_->write_w_timestamp(
+        &cpu_data, eprosima::fastdds::dds::HANDLE_NIL, stamp))
+    {
+      RCUTILS_LOG_ERROR_NAMED(
+        "rmw_fastrtps_cpp",
+        "Failed to write to CPU channel DataWriter");
+    }
+  }
+
+  // Publish to per-subscriber peer-to-peer endpoints for non-CPU subscribers.
   for (const auto & endpoint : state.endpoints) {
     uint32_t serialized_size = callbacks->get_serialized_size(ros_message);
     size_t buffer_size = serialized_size + 4;  // +4 for CDR encapsulation header
@@ -190,8 +202,6 @@ publish_to_buffer_endpoints(
         "Buffer-aware write failed for endpoint '%s'", endpoint->key.c_str());
     }
   }
-
-  return has_non_buffer_subscribers;
 }
 
 }  // namespace
@@ -217,12 +227,26 @@ rmw_publish(
 
   auto info = static_cast<CustomPublisherInfo *>(publisher->data);
   if (info->is_buffer_aware_) {
-    bool needs_main_publish = publish_to_buffer_endpoints(info, ros_message, publisher);
-    if (needs_main_publish) {
-      return rmw_fastrtps_shared_cpp::__rmw_publish(
-        eprosima_fastrtps_identifier, publisher, ros_message, allocation);
+    // Check whether any non-backend-aware (legacy) subscribers exist.
+    // If so, skip buffer channels entirely and fall through to the main
+    // DataWriter so old RMW endpoints receive the message.  Buffer-aware
+    // endpoints will also receive it via their main DataReader fallback.
+    size_t total_matched = info->publisher_event_->subscription_count();
+    size_t buffer_aware_count;
+    {
+      std::lock_guard<std::mutex> lock(info->buffer_state_->mutex);
+      auto & st = *info->buffer_state_;
+      buffer_aware_count =
+        st.endpoints.size() + st.pending.size() + st.cpu_only_subscribers.size();
     }
-    return RMW_RET_OK;
+
+    if (total_matched <= buffer_aware_count) {
+      publish_to_buffer_endpoints(info, ros_message, publisher);
+      return RMW_RET_OK;
+    }
+    // Legacy subscribers present — publish via main (legacy) DataWriter.
+    return rmw_fastrtps_shared_cpp::__rmw_publish(
+      eprosima_fastrtps_identifier, publisher, ros_message, allocation);
   }
 
   return rmw_fastrtps_shared_cpp::__rmw_publish(

--- a/rmw_fastrtps_cpp/src/rmw_publish.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publish.cpp
@@ -138,7 +138,7 @@ publish_to_buffer_endpoints(
 
   for (const auto & endpoint : state.endpoints) {
     uint32_t serialized_size = callbacks->get_serialized_size(ros_message);
-    size_t buffer_size = serialized_size + 4096;
+    size_t buffer_size = serialized_size + 4;  // +4 for CDR encapsulation header
     std::vector<uint8_t> buffer_data(buffer_size);
 
     eprosima::fastcdr::FastBuffer fast_buffer(
@@ -166,6 +166,7 @@ publish_to_buffer_endpoints(
         "rmw_fastrtps_cpp",
         "Buffer-aware serialize threw for endpoint '%s': %s",
         endpoint->key.c_str(), e.what());
+      continue;
     }
 
     if (!ok) {

--- a/rmw_fastrtps_cpp/src/rmw_publish.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publish.cpp
@@ -12,16 +12,100 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <vector>
+
 #include "fastcdr/Cdr.h"
 #include "fastcdr/FastBuffer.h"
 
+#include "fastdds/rtps/common/Time_t.hpp"
+
 #include "rmw/allocators.h"
 #include "rmw/error_handling.h"
+#include "rmw/impl/cpp/macros.hpp"
 #include "rmw/rmw.h"
 
+#include "rcutils/logging_macros.h"
+
+#include "rmw_fastrtps_shared_cpp/custom_publisher_info.hpp"
 #include "rmw_fastrtps_shared_cpp/rmw_common.hpp"
+#include "rmw_fastrtps_shared_cpp/TypeSupport.hpp"
 
 #include "rmw_fastrtps_cpp/identifier.hpp"
+
+#include "rosidl_typesupport_fastrtps_cpp/message_type_support.h"
+
+#include "tracetools/tracetools.h"
+
+namespace
+{
+
+/// Publish to per-subscriber buffer endpoints. Returns true if there are
+/// non-buffer-aware subscribers on the main topic that still need to be
+/// served via the normal DataWriter.
+bool
+publish_to_buffer_endpoints(
+  CustomPublisherInfo * info,
+  const void * ros_message,
+  const rmw_publisher_t * publisher)
+{
+  auto callbacks = static_cast<const message_type_support_callbacks_t *>(info->type_support_impl_);
+
+  std::lock_guard<std::mutex> lock(info->buffer_mutex_);
+
+  size_t total_matched = info->publisher_event_->subscription_count();
+  size_t buffer_count = info->buffer_endpoints_.size() + info->pending_buffer_endpoints_.size();
+  bool has_non_buffer_subscribers = (total_matched > buffer_count);
+
+  if (info->buffer_endpoints_.empty()) {
+    return has_non_buffer_subscribers;
+  }
+
+  eprosima::fastdds::dds::Time_t stamp;
+  eprosima::fastdds::dds::Time_t::now(stamp);
+  TRACETOOLS_TRACEPOINT(rmw_publish, publisher, ros_message, stamp.to_ns());
+
+  for (const auto & endpoint : info->buffer_endpoints_) {
+    uint32_t serialized_size = callbacks->get_serialized_size(ros_message);
+    size_t buffer_size = serialized_size + 4096;
+    std::vector<uint8_t> buffer_data(buffer_size);
+
+    eprosima::fastcdr::FastBuffer fast_buffer(
+      reinterpret_cast<char *>(buffer_data.data()), buffer_size);
+    eprosima::fastcdr::Cdr ser(
+      fast_buffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+      eprosima::fastcdr::CdrVersion::XCDRv1);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    bool ok = callbacks->cdr_serialize_with_endpoint(
+      ros_message, ser, endpoint->subscriber_endpoint_info);
+
+    if (!ok) {
+      RCUTILS_LOG_ERROR_NAMED(
+        "rmw_fastrtps_cpp",
+        "Buffer-aware serialize failed for endpoint '%s'", endpoint->key.c_str());
+      continue;
+    }
+
+    // Write the CDR buffer to this endpoint's DataWriter
+    rmw_fastrtps_shared_cpp::SerializedData data;
+    data.type = rmw_fastrtps_shared_cpp::FASTDDS_SERIALIZED_DATA_TYPE_CDR_BUFFER;
+    data.data = &ser;
+    data.impl = nullptr;
+
+    if (eprosima::fastdds::dds::RETCODE_OK !=
+      endpoint->data_writer->write_w_timestamp(
+        &data, eprosima::fastdds::dds::HANDLE_NIL, stamp))
+    {
+      RCUTILS_LOG_ERROR_NAMED(
+        "rmw_fastrtps_cpp",
+        "Buffer-aware write failed for endpoint '%s'", endpoint->key.c_str());
+    }
+  }
+
+  return has_non_buffer_subscribers;
+}
+
+}  // namespace
 
 extern "C"
 {
@@ -31,6 +115,27 @@ rmw_publish(
   const void * ros_message,
   rmw_publisher_allocation_t * allocation)
 {
+  (void) allocation;
+  RMW_CHECK_FOR_NULL_WITH_MSG(
+    publisher, "publisher handle is null",
+    return RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    publisher, publisher->implementation_identifier, eprosima_fastrtps_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RMW_CHECK_FOR_NULL_WITH_MSG(
+    ros_message, "ros message handle is null",
+    return RMW_RET_INVALID_ARGUMENT);
+
+  auto info = static_cast<CustomPublisherInfo *>(publisher->data);
+  if (info->is_buffer_aware_) {
+    bool needs_main_publish = publish_to_buffer_endpoints(info, ros_message, publisher);
+    if (needs_main_publish) {
+      return rmw_fastrtps_shared_cpp::__rmw_publish(
+        eprosima_fastrtps_identifier, publisher, ros_message, allocation);
+    }
+    return RMW_RET_OK;
+  }
+
   return rmw_fastrtps_shared_cpp::__rmw_publish(
     eprosima_fastrtps_identifier, publisher, ros_message, allocation);
 }

--- a/rmw_fastrtps_cpp/src/rmw_publish.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publish.cpp
@@ -62,9 +62,19 @@ create_pending_buffer_writers(CustomPublisherInfo * info)
     endpoint->subscriber_endpoint_info = p.subscriber_endpoint_info;
     endpoint->backend_metadata = std::move(p.backend_metadata);
 
-    eprosima::fastdds::dds::TopicQos topic_qos = info->topic_->get_qos();
-    auto * topic = info->participant_->create_topic(
-      p.unique_topic, info->type_support_.get_type_name(), topic_qos);
+    eprosima::fastdds::dds::Topic * topic = nullptr;
+    auto * existing_desc = info->participant_->lookup_topicdescription(p.unique_topic);
+    if (existing_desc) {
+      topic = dynamic_cast<eprosima::fastdds::dds::Topic *>(existing_desc);
+      if (topic) {
+        endpoint->owns_topic = false;
+      }
+    }
+    if (!topic) {
+      eprosima::fastdds::dds::TopicQos topic_qos = info->topic_->get_qos();
+      topic = info->participant_->create_topic(
+        p.unique_topic, info->type_support_.get_type_name(), topic_qos);
+    }
     if (!topic) {
       RCUTILS_LOG_ERROR_NAMED(
         "rmw_fastrtps_cpp",
@@ -82,7 +92,9 @@ create_pending_buffer_writers(CustomPublisherInfo * info)
     auto * data_writer = info->dds_publisher_->create_datawriter(
       topic, writer_qos, nullptr);
     if (!data_writer) {
-      info->participant_->delete_topic(topic);
+      if (endpoint->owns_topic) {
+        info->participant_->delete_topic(topic);
+      }
       RCUTILS_LOG_ERROR_NAMED(
         "rmw_fastrtps_cpp",
         "Failed to create per-subscriber DataWriter for '%s'", p.unique_topic.c_str());

--- a/rmw_fastrtps_cpp/src/rmw_publish.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publish.cpp
@@ -31,6 +31,7 @@
 #include "rmw_fastrtps_shared_cpp/TypeSupport.hpp"
 
 #include "rmw_fastrtps_cpp/identifier.hpp"
+#include "buffer_backend_context.hpp"
 
 #include "rosidl_typesupport_fastrtps_cpp/message_type_support.h"
 
@@ -147,8 +148,25 @@ publish_to_buffer_endpoints(
       eprosima::fastcdr::CdrVersion::XCDRv1);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
 
-    bool ok = callbacks->cdr_serialize_with_endpoint(
-      ros_message, ser, endpoint->subscriber_endpoint_info);
+    auto * backend_context =
+      static_cast<const rmw_fastrtps_cpp::BufferBackendContext *>(info->serialization_context_);
+    if (!backend_context) {
+      RCUTILS_LOG_ERROR_NAMED(
+        "rmw_fastrtps_cpp",
+        "Buffer-aware serialize missing buffer backend context");
+      continue;
+    }
+    bool ok = false;
+    try {
+      ok = callbacks->cdr_serialize_with_endpoint(
+        ros_message, ser, endpoint->subscriber_endpoint_info,
+        backend_context->serialization_context);
+    } catch (const std::exception & e) {
+      RCUTILS_LOG_ERROR_NAMED(
+        "rmw_fastrtps_cpp",
+        "Buffer-aware serialize threw for endpoint '%s': %s",
+        endpoint->key.c_str(), e.what());
+    }
 
     if (!ok) {
       RCUTILS_LOG_ERROR_NAMED(

--- a/rmw_fastrtps_cpp/src/rmw_publish.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publish.cpp
@@ -27,6 +27,7 @@
 #include "rcutils/logging_macros.h"
 
 #include "rmw_fastrtps_shared_cpp/custom_publisher_info.hpp"
+#include "rmw_fastrtps_shared_cpp/qos.hpp"
 #include "rmw_fastrtps_shared_cpp/rmw_common.hpp"
 #include "rmw_fastrtps_shared_cpp/TypeSupport.hpp"
 
@@ -88,6 +89,14 @@ create_pending_buffer_writers(CustomPublisherInfo * info)
     writer_qos.endpoint().history_memory_policy =
       eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
     writer_qos.data_sharing().off();
+
+    {
+      std::string main_gid_str =
+        encode_endpoint_gid_for_user_data(info->publisher_gid, "PGID:");
+      auto ud_vec = writer_qos.user_data().data_vec();
+      ud_vec.insert(ud_vec.end(), main_gid_str.begin(), main_gid_str.end());
+      writer_qos.user_data().setValue(ud_vec);
+    }
 
     auto * data_writer = info->dds_publisher_->create_datawriter(
       topic, writer_qos, nullptr);

--- a/rmw_fastrtps_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publisher.cpp
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdio>
 #include <string>
 
 #include "rmw/allocators.h"
@@ -21,6 +22,7 @@
 #include "rmw/rmw.h"
 
 #include "rcpputils/scope_exit.hpp"
+#include "rcutils/logging_macros.h"
 
 #include "rmw/impl/cpp/macros.hpp"
 
@@ -29,14 +31,18 @@
 #include "rmw_fastrtps_shared_cpp/custom_participant_info.hpp"
 #include "rmw_fastrtps_shared_cpp/custom_publisher_info.hpp"
 #include "rmw_fastrtps_shared_cpp/publisher.hpp"
+#include "rmw_fastrtps_shared_cpp/qos.hpp"
 #include "rmw_fastrtps_shared_cpp/rmw_common.hpp"
 #include "rmw_fastrtps_shared_cpp/rmw_context_impl.hpp"
+#include "rmw_fastrtps_shared_cpp/create_rmw_gid.hpp"
 
 #include "rmw_fastrtps_cpp/identifier.hpp"
 #include "rmw_fastrtps_cpp/publisher.hpp"
 
 #include "rmw_dds_common/context.hpp"
 #include "rmw_dds_common/msg/participant_entities_info.hpp"
+
+#include "buffer_endpoint_registry.hpp"
 
 extern "C"
 {
@@ -116,7 +122,7 @@ rmw_create_publisher(
     });
 
   auto common_context = static_cast<rmw_dds_common::Context *>(node->context->impl->common);
-  auto info = static_cast<const CustomPublisherInfo *>(publisher->data);
+  auto info = static_cast<CustomPublisherInfo *>(publisher->data);
 
   // Update graph
   if (RMW_RET_OK != common_context->add_publisher_graph(
@@ -124,6 +130,120 @@ rmw_create_publisher(
       node->name, node->namespace_))
   {
     return nullptr;
+  }
+
+  // Register buffer-aware subscriber discovery callback
+  if (info->is_buffer_aware_) {
+    auto alive = info->buffer_alive_flag_;
+    auto & buf_registry = rmw_fastrtps_cpp::BufferEndpointRegistry::get_instance();
+    buf_registry.register_subscriber_discovery_callback(
+      publisher->topic_name,
+      info->publisher_gid,
+      [info, alive](const rmw_fastrtps_cpp::BufferEndpointInfo & sub_info) {
+        if (!alive->load()) {
+          return;
+        }
+
+        auto gid_to_hex = [](const rmw_gid_t & gid, size_t bytes = 8) -> std::string {
+            static const char hex_chars[] = "0123456789abcdef";
+            std::string result;
+            result.reserve(bytes * 2);
+            for (size_t i = 0; i < bytes && i < RMW_GID_STORAGE_SIZE; ++i) {
+              result += hex_chars[(gid.data[i] >> 4) & 0xF];
+              result += hex_chars[gid.data[i] & 0xF];
+            }
+            return result;
+          };
+
+        std::string pub_hex = gid_to_hex(info->publisher_gid);
+        std::string sub_hex = gid_to_hex(sub_info.gid);
+        std::string unique_topic = info->topic_->get_name() +
+          "/_buf/" + pub_hex + "_" + sub_hex;
+
+        {
+          std::lock_guard<std::mutex> lock(info->buffer_mutex_);
+          for (const auto & ep : info->buffer_endpoints_) {
+            if (std::memcmp(ep->target_subscriber_gid.data, sub_info.gid.data,
+              RMW_GID_STORAGE_SIZE) == 0)
+            {
+              RCUTILS_LOG_DEBUG_NAMED(
+                "rmw_fastrtps_cpp",
+                "Buffer publisher: subscriber already known, skipping");
+              return;
+            }
+          }
+          if (!info->pending_buffer_endpoints_.insert(unique_topic).second) {
+            return;
+          }
+        }
+
+        RCUTILS_LOG_INFO_NAMED(
+          "rmw_fastrtps_cpp",
+          "Buffer publisher: subscriber discovered, computing compatibility for '%s'",
+          unique_topic.c_str());
+
+        auto endpoint = std::make_shared<BufferPublisherEndpoint>();
+        endpoint->key = unique_topic;
+        endpoint->target_subscriber_gid = sub_info.gid;
+        endpoint->backend_aux_info = sub_info.backend_aux_info;
+
+        endpoint->subscriber_endpoint_info = rmw_get_zero_initialized_topic_endpoint_info();
+        endpoint->subscriber_endpoint_info.endpoint_type = RMW_ENDPOINT_SUBSCRIPTION;
+        std::memcpy(
+          endpoint->subscriber_endpoint_info.endpoint_gid,
+          sub_info.gid.data, RMW_GID_STORAGE_SIZE);
+
+        eprosima::fastdds::dds::TopicQos topic_qos =
+          info->participant_->get_default_topic_qos();
+        auto * topic = info->participant_->create_topic(
+          unique_topic,
+          info->type_support_.get_type_name(),
+          topic_qos);
+        if (!topic) {
+          RCUTILS_LOG_ERROR_NAMED(
+            "rmw_fastrtps_cpp",
+            "Failed to create per-subscriber topic '%s'", unique_topic.c_str());
+          std::lock_guard<std::mutex> lock(info->buffer_mutex_);
+          info->pending_buffer_endpoints_.erase(unique_topic);
+          return;
+        }
+        endpoint->topic = topic;
+
+        RCUTILS_LOG_INFO_NAMED(
+          "rmw_fastrtps_cpp",
+          "Buffer publisher: creating DataWriter for '%s'", unique_topic.c_str());
+
+        eprosima::fastdds::dds::DataWriterQos writer_qos =
+          info->dds_publisher_->get_default_datawriter_qos();
+        writer_qos.publish_mode().kind = eprosima::fastdds::dds::SYNCHRONOUS_PUBLISH_MODE;
+        writer_qos.endpoint().history_memory_policy =
+          eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+        writer_qos.data_sharing().off();
+        writer_qos.reliability().kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
+        writer_qos.history() = info->data_writer_->get_qos().history();
+
+        auto * data_writer = info->dds_publisher_->create_datawriter(
+          topic, writer_qos, nullptr);
+        if (!data_writer) {
+          info->participant_->delete_topic(topic);
+          RCUTILS_LOG_ERROR_NAMED(
+            "rmw_fastrtps_cpp",
+            "Failed to create per-subscriber DataWriter for '%s'", unique_topic.c_str());
+          std::lock_guard<std::mutex> lock(info->buffer_mutex_);
+          info->pending_buffer_endpoints_.erase(unique_topic);
+          return;
+        }
+        endpoint->data_writer = data_writer;
+
+        {
+          std::lock_guard<std::mutex> lock(info->buffer_mutex_);
+          info->buffer_endpoints_.push_back(endpoint);
+          info->pending_buffer_endpoints_.erase(unique_topic);
+        }
+        RCUTILS_LOG_INFO_NAMED(
+          "rmw_fastrtps_cpp",
+          "Buffer publisher: created per-sub endpoint '%s'", unique_topic.c_str());
+      });
   }
 
   cleanup_publisher.cancel();
@@ -212,6 +332,29 @@ rmw_destroy_publisher(rmw_node_t * node, rmw_publisher_t * publisher)
     publisher->implementation_identifier,
     eprosima_fastrtps_identifier,
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+
+  auto info = static_cast<CustomPublisherInfo *>(publisher->data);
+  if (info && info->is_buffer_aware_) {
+    info->buffer_alive_flag_->store(false);
+
+    rmw_fastrtps_cpp::BufferEndpointRegistry::get_instance().unregister_callbacks(
+      info->publisher_gid);
+
+    std::vector<std::shared_ptr<BufferPublisherEndpoint>> endpoints_to_destroy;
+    {
+      std::lock_guard<std::mutex> lock(info->buffer_mutex_);
+      endpoints_to_destroy = std::move(info->buffer_endpoints_);
+      info->buffer_endpoints_.clear();
+    }
+    for (auto & endpoint : endpoints_to_destroy) {
+      if (endpoint->data_writer) {
+        info->dds_publisher_->delete_datawriter(endpoint->data_writer);
+      }
+      if (endpoint->topic) {
+        info->participant_->delete_topic(endpoint->topic);
+      }
+    }
+  }
 
   return rmw_fastrtps_shared_cpp::__rmw_destroy_publisher(
     eprosima_fastrtps_identifier, node, publisher);

--- a/rmw_fastrtps_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publisher.cpp
@@ -14,7 +14,10 @@
 // limitations under the License.
 
 #include <cstdio>
+#include <set>
 #include <string>
+#include <unordered_map>
+#include <vector>
 
 #include "rmw/allocators.h"
 #include "rmw/error_handling.h"
@@ -42,7 +45,9 @@
 #include "rmw_dds_common/context.hpp"
 #include "rmw_dds_common/msg/participant_entities_info.hpp"
 
+#include "buffer_backend_context.hpp"
 #include "buffer_endpoint_registry.hpp"
+#include "rosidl_buffer_backend_registry/backend_utils.hpp"
 
 extern "C"
 {
@@ -137,66 +142,95 @@ rmw_create_publisher(
     auto state = info->buffer_state_;
     auto pub_gid = info->publisher_gid;
     std::string base_topic = info->topic_->get_name();
-    auto & buf_registry = rmw_fastrtps_cpp::BufferEndpointRegistry::get_instance();
-    buf_registry.register_subscriber_discovery_callback(
-      publisher->topic_name,
-      info->publisher_gid,
-      [state, pub_gid, base_topic](const rmw_fastrtps_cpp::BufferEndpointInfo & sub_info) {
-        if (!state->alive.load()) {
-          return;
-        }
-
-        auto gid_to_hex = [](const rmw_gid_t & gid, size_t bytes = 8) -> std::string {
-          static const char hex_chars[] = "0123456789abcdef";
-          std::string result;
-          result.reserve(bytes * 2);
-          for (size_t i = 0; i < bytes && i < RMW_GID_STORAGE_SIZE; ++i) {
-            result += hex_chars[(gid.data[i] >> 4) & 0xF];
-            result += hex_chars[gid.data[i] & 0xF];
-          }
-          return result;
-        };
-
-        std::string pub_hex = gid_to_hex(pub_gid);
-        std::string sub_hex = gid_to_hex(sub_info.gid);
-        std::string unique_topic = base_topic +
-        "/_buf/" + pub_hex + "_" + sub_hex;
-
-        {
-          std::lock_guard<std::mutex> lock(state->mutex);
+    auto * backend_context =
+      static_cast<const rmw_fastrtps_cpp::BufferBackendContext *>(info->serialization_context_);
+    auto * buf_registry = static_cast<rmw_fastrtps_cpp::BufferEndpointRegistry *>(
+      node->context->impl->buffer_endpoint_registry);
+    if (buf_registry) {
+      buf_registry->register_subscriber_discovery_callback(
+        publisher->topic_name,
+        info->publisher_gid,
+        [state, pub_gid, base_topic, backend_context](
+          const rmw_fastrtps_cpp::BufferEndpointInfo & sub_info) {
           if (!state->alive.load()) {
             return;
           }
-          for (const auto & ep : state->endpoints) {
-            if (std::memcmp(ep->target_subscriber_gid.data, sub_info.gid.data,
+
+          auto gid_to_hex = [](const rmw_gid_t & gid, size_t bytes = 8) -> std::string {
+            static const char hex_chars[] = "0123456789abcdef";
+            std::string result;
+            result.reserve(bytes * 2);
+            for (size_t i = 0; i < bytes && i < RMW_GID_STORAGE_SIZE; ++i) {
+              result += hex_chars[(gid.data[i] >> 4) & 0xF];
+              result += hex_chars[gid.data[i] & 0xF];
+            }
+            return result;
+          };
+
+          std::string pub_hex = gid_to_hex(pub_gid);
+          std::string sub_hex = gid_to_hex(sub_info.gid);
+          std::string unique_topic = base_topic +
+          "/_buf/" + pub_hex + "_" + sub_hex;
+
+          {
+            std::lock_guard<std::mutex> lock(state->mutex);
+            if (!state->alive.load()) {
+              return;
+            }
+            for (const auto & ep : state->endpoints) {
+              if (std::memcmp(ep->target_subscriber_gid.data, sub_info.gid.data,
               RMW_GID_STORAGE_SIZE) == 0)
-            {
-              return;
+              {
+                return;
+              }
             }
-          }
-          for (const auto & p : state->pending) {
-            if (p.unique_topic == unique_topic) {
-              return;
+            for (const auto & p : state->pending) {
+              if (p.unique_topic == unique_topic) {
+                return;
+              }
             }
-          }
 
-          PendingBufferPublisher pending;
-          pending.unique_topic = unique_topic;
-          pending.target_subscriber_gid = sub_info.gid;
-          pending.subscriber_endpoint_info = rmw_get_zero_initialized_topic_endpoint_info();
-          pending.subscriber_endpoint_info.endpoint_type = RMW_ENDPOINT_SUBSCRIPTION;
-          std::memcpy(
-            pending.subscriber_endpoint_info.endpoint_gid,
+            rmw_topic_endpoint_info_t discovered_endpoint_info =
+            rmw_get_zero_initialized_topic_endpoint_info();
+            discovered_endpoint_info.endpoint_type = RMW_ENDPOINT_SUBSCRIPTION;
+            std::memcpy(
+            discovered_endpoint_info.endpoint_gid,
             sub_info.gid.data, RMW_GID_STORAGE_SIZE);
-          pending.backend_metadata = sub_info.backend_metadata;
-          state->pending.push_back(std::move(pending));
-        }
 
-        RCUTILS_LOG_INFO_NAMED(
+            if (backend_context) {
+              std::vector<rmw_topic_endpoint_info_t> existing_endpoints;
+              existing_endpoints.reserve(state->endpoints.size() + state->pending.size());
+              for (const auto & ep : state->endpoints) {
+                existing_endpoints.push_back(ep->subscriber_endpoint_info);
+              }
+              for (const auto & p : state->pending) {
+                existing_endpoints.push_back(p.subscriber_endpoint_info);
+              }
+
+              std::unordered_map<std::string,
+              std::vector<std::set<uint32_t>>> backend_endpoint_groups;
+              (void)rosidl_buffer_backend_registry::notify_endpoint_discovered(
+              backend_context->backend_instances,
+              discovered_endpoint_info,
+              existing_endpoints,
+              backend_endpoint_groups,
+              sub_info.backend_metadata);
+            }
+
+            PendingBufferPublisher pending;
+            pending.unique_topic = unique_topic;
+            pending.target_subscriber_gid = sub_info.gid;
+            pending.subscriber_endpoint_info = discovered_endpoint_info;
+            pending.backend_metadata = sub_info.backend_metadata;
+            state->pending.push_back(std::move(pending));
+          }
+
+          RCUTILS_LOG_INFO_NAMED(
           "rmw_fastrtps_cpp",
           "Buffer publisher: subscriber discovered, queued '%s'",
           unique_topic.c_str());
-      });
+        });
+    }
   }
 
   cleanup_publisher.cancel();
@@ -298,8 +332,11 @@ rmw_destroy_publisher(rmw_node_t * node, rmw_publisher_t * publisher)
       state.pending.clear();
     }
 
-    rmw_fastrtps_cpp::BufferEndpointRegistry::get_instance().unregister_callbacks(
-      info->publisher_gid);
+    auto * buf_registry = static_cast<rmw_fastrtps_cpp::BufferEndpointRegistry *>(
+      node->context->impl->buffer_endpoint_registry);
+    if (buf_registry) {
+      buf_registry->unregister_callbacks(info->publisher_gid);
+    }
 
     for (auto & endpoint : endpoints_to_destroy) {
       if (endpoint->data_writer) {

--- a/rmw_fastrtps_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publisher.cpp
@@ -156,27 +156,19 @@ rmw_create_publisher(
             return;
           }
 
-          auto gid_to_hex = [](const rmw_gid_t & gid, size_t bytes = 8) -> std::string {
-            static const char hex_chars[] = "0123456789abcdef";
-            std::string result;
-            result.reserve(bytes * 2);
-            for (size_t i = 0; i < bytes && i < RMW_GID_STORAGE_SIZE; ++i) {
-              result += hex_chars[(gid.data[i] >> 4) & 0xF];
-              result += hex_chars[gid.data[i] & 0xF];
-            }
-            return result;
-          };
-
-          std::string pub_hex = gid_to_hex(pub_gid);
-          std::string sub_hex = gid_to_hex(sub_info.gid);
-          std::string unique_topic = base_topic +
-          "/_buf/" + pub_hex + "_" + sub_hex;
+          // Detect whether the discovered subscriber is CPU-only.
+          // CPU-only subscribers advertise only {"cpu": ""} in their backend_metadata.
+          bool sub_is_cpu_only = (sub_info.backend_metadata.size() == 1 &&
+          sub_info.backend_metadata.count("cpu") == 1) ||
+          sub_info.backend_metadata.empty();
 
           {
             std::lock_guard<std::mutex> lock(state->mutex);
             if (!state->alive.load()) {
               return;
             }
+
+            // Check for duplicate in existing p2p endpoints or CPU-only list.
             for (const auto & ep : state->endpoints) {
               if (std::memcmp(ep->target_subscriber_gid.data, sub_info.gid.data,
               RMW_GID_STORAGE_SIZE) == 0)
@@ -184,11 +176,48 @@ rmw_create_publisher(
                 return;
               }
             }
-            for (const auto & p : state->pending) {
-              if (p.unique_topic == unique_topic) {
+            for (const auto & g : state->cpu_only_subscribers) {
+              if (std::memcmp(g.data, sub_info.gid.data, RMW_GID_STORAGE_SIZE) == 0) {
                 return;
               }
             }
+
+            if (sub_is_cpu_only) {
+              // CPU-only subscriber: track its GID; the shared CPU channel
+              // DataWriter will serve it -- no per-subscriber endpoint needed.
+              state->cpu_only_subscribers.push_back(sub_info.gid);
+              RCUTILS_LOG_INFO_NAMED(
+                "rmw_fastrtps_cpp",
+                "Buffer publisher: CPU-only subscriber discovered on '%s', "
+                "served by shared CPU channel",
+                base_topic.c_str());
+              return;
+            }
+
+            // Non-CPU subscriber: create a peer-to-peer endpoint.
+            for (const auto & p : state->pending) {
+              if (std::memcmp(p.target_subscriber_gid.data, sub_info.gid.data,
+              RMW_GID_STORAGE_SIZE) == 0)
+              {
+                return;
+              }
+            }
+
+            auto gid_to_hex = [](const rmw_gid_t & gid, size_t bytes = 8) -> std::string {
+              static const char hex_chars[] = "0123456789abcdef";
+              std::string result;
+              result.reserve(bytes * 2);
+              for (size_t i = 0; i < bytes && i < RMW_GID_STORAGE_SIZE; ++i) {
+                result += hex_chars[(gid.data[i] >> 4) & 0xF];
+                result += hex_chars[gid.data[i] & 0xF];
+              }
+              return result;
+            };
+
+            std::string pub_hex = gid_to_hex(pub_gid);
+            std::string sub_hex = gid_to_hex(sub_info.gid);
+            std::string unique_topic = base_topic +
+            "/_buf/" + pub_hex + "_" + sub_hex;
 
             rmw_topic_endpoint_info_t discovered_endpoint_info =
             rmw_get_zero_initialized_topic_endpoint_info();
@@ -223,12 +252,12 @@ rmw_create_publisher(
             pending.subscriber_endpoint_info = discovered_endpoint_info;
             pending.backend_metadata = sub_info.backend_metadata;
             state->pending.push_back(std::move(pending));
-          }
 
-          RCUTILS_LOG_INFO_NAMED(
-          "rmw_fastrtps_cpp",
-          "Buffer publisher: subscriber discovered, queued '%s'",
-          unique_topic.c_str());
+            RCUTILS_LOG_INFO_NAMED(
+              "rmw_fastrtps_cpp",
+              "Buffer publisher: non-CPU subscriber discovered, queued '%s'",
+              unique_topic.c_str());
+          }
         });
     }
   }
@@ -330,6 +359,7 @@ rmw_destroy_publisher(rmw_node_t * node, rmw_publisher_t * publisher)
       endpoints_to_destroy = std::move(state.endpoints);
       state.endpoints.clear();
       state.pending.clear();
+      state.cpu_only_subscribers.clear();
     }
 
     auto * buf_registry = static_cast<rmw_fastrtps_cpp::BufferEndpointRegistry *>(
@@ -345,6 +375,18 @@ rmw_destroy_publisher(rmw_node_t * node, rmw_publisher_t * publisher)
       if (endpoint->topic) {
         info->participant_->delete_topic(endpoint->topic);
       }
+    }
+
+    // Clean up the shared CPU channel DataWriter and Topic.
+    if (info->cpu_data_writer_) {
+      info->dds_publisher_->delete_datawriter(info->cpu_data_writer_);
+      info->cpu_data_writer_ = nullptr;
+    }
+    if (info->cpu_topic_) {
+      auto * participant_info =
+        static_cast<CustomParticipantInfo *>(node->context->impl->participant_info);
+      participant_info->delete_topic(info->cpu_topic_, nullptr);
+      info->cpu_topic_ = nullptr;
     }
   }
 

--- a/rmw_fastrtps_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publisher.cpp
@@ -226,17 +226,15 @@ rmw_create_publisher(
               }
             }
 
-            std::string pub_hex = rmw_fastrtps_shared_cpp::gid_to_hex(pub_gid);
             std::string sub_hex = rmw_fastrtps_shared_cpp::gid_to_hex(sub_info.gid);
-            std::string unique_topic = base_topic +
-            "/_buf/" + pub_hex + "_" + sub_hex;
+            std::string unique_topic = base_topic + "/_buf/" + sub_hex;
 
             rmw_topic_endpoint_info_t discovered_endpoint_info =
             rmw_get_zero_initialized_topic_endpoint_info();
             discovered_endpoint_info.endpoint_type = RMW_ENDPOINT_SUBSCRIPTION;
             std::memcpy(
-            discovered_endpoint_info.endpoint_gid,
-            sub_info.gid.data, RMW_GID_STORAGE_SIZE);
+              discovered_endpoint_info.endpoint_gid,
+              sub_info.gid.data, RMW_GID_STORAGE_SIZE);
 
             if (backend_context) {
               std::vector<rmw_topic_endpoint_info_t> existing_endpoints;
@@ -384,7 +382,7 @@ rmw_destroy_publisher(rmw_node_t * node, rmw_publisher_t * publisher)
       if (endpoint->data_writer) {
         info->dds_publisher_->delete_datawriter(endpoint->data_writer);
       }
-      if (endpoint->topic) {
+      if (endpoint->topic && endpoint->owns_topic) {
         info->participant_->delete_topic(endpoint->topic);
       }
     }

--- a/rmw_fastrtps_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publisher.cpp
@@ -145,20 +145,20 @@ rmw_create_publisher(
         }
 
         auto gid_to_hex = [](const rmw_gid_t & gid, size_t bytes = 8) -> std::string {
-            static const char hex_chars[] = "0123456789abcdef";
-            std::string result;
-            result.reserve(bytes * 2);
-            for (size_t i = 0; i < bytes && i < RMW_GID_STORAGE_SIZE; ++i) {
-              result += hex_chars[(gid.data[i] >> 4) & 0xF];
-              result += hex_chars[gid.data[i] & 0xF];
-            }
-            return result;
-          };
+          static const char hex_chars[] = "0123456789abcdef";
+          std::string result;
+          result.reserve(bytes * 2);
+          for (size_t i = 0; i < bytes && i < RMW_GID_STORAGE_SIZE; ++i) {
+            result += hex_chars[(gid.data[i] >> 4) & 0xF];
+            result += hex_chars[gid.data[i] & 0xF];
+          }
+          return result;
+        };
 
         std::string pub_hex = gid_to_hex(info->publisher_gid);
         std::string sub_hex = gid_to_hex(sub_info.gid);
         std::string unique_topic = info->topic_->get_name() +
-          "/_buf/" + pub_hex + "_" + sub_hex;
+        "/_buf/" + pub_hex + "_" + sub_hex;
 
         {
           std::lock_guard<std::mutex> lock(info->buffer_mutex_);
@@ -194,7 +194,7 @@ rmw_create_publisher(
           sub_info.gid.data, RMW_GID_STORAGE_SIZE);
 
         eprosima::fastdds::dds::TopicQos topic_qos =
-          info->participant_->get_default_topic_qos();
+        info->participant_->get_default_topic_qos();
         auto * topic = info->participant_->create_topic(
           unique_topic,
           info->type_support_.get_type_name(),
@@ -214,10 +214,10 @@ rmw_create_publisher(
           "Buffer publisher: creating DataWriter for '%s'", unique_topic.c_str());
 
         eprosima::fastdds::dds::DataWriterQos writer_qos =
-          info->dds_publisher_->get_default_datawriter_qos();
+        info->dds_publisher_->get_default_datawriter_qos();
         writer_qos.publish_mode().kind = eprosima::fastdds::dds::SYNCHRONOUS_PUBLISH_MODE;
         writer_qos.endpoint().history_memory_policy =
-          eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+        eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
         writer_qos.data_sharing().off();
         writer_qos.reliability().kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
         writer_qos.history() = info->data_writer_->get_qos().history();

--- a/rmw_fastrtps_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publisher.cpp
@@ -134,13 +134,15 @@ rmw_create_publisher(
 
   // Register buffer-aware subscriber discovery callback
   if (info->is_buffer_aware_) {
-    auto alive = info->buffer_alive_flag_;
+    auto state = info->buffer_state_;
+    auto pub_gid = info->publisher_gid;
+    std::string base_topic = info->topic_->get_name();
     auto & buf_registry = rmw_fastrtps_cpp::BufferEndpointRegistry::get_instance();
     buf_registry.register_subscriber_discovery_callback(
       publisher->topic_name,
       info->publisher_gid,
-      [info, alive](const rmw_fastrtps_cpp::BufferEndpointInfo & sub_info) {
-        if (!alive->load()) {
+      [state, pub_gid, base_topic](const rmw_fastrtps_cpp::BufferEndpointInfo & sub_info) {
+        if (!state->alive.load()) {
           return;
         }
 
@@ -155,94 +157,45 @@ rmw_create_publisher(
           return result;
         };
 
-        std::string pub_hex = gid_to_hex(info->publisher_gid);
+        std::string pub_hex = gid_to_hex(pub_gid);
         std::string sub_hex = gid_to_hex(sub_info.gid);
-        std::string unique_topic = info->topic_->get_name() +
+        std::string unique_topic = base_topic +
         "/_buf/" + pub_hex + "_" + sub_hex;
 
         {
-          std::lock_guard<std::mutex> lock(info->buffer_mutex_);
-          for (const auto & ep : info->buffer_endpoints_) {
+          std::lock_guard<std::mutex> lock(state->mutex);
+          if (!state->alive.load()) {
+            return;
+          }
+          for (const auto & ep : state->endpoints) {
             if (std::memcmp(ep->target_subscriber_gid.data, sub_info.gid.data,
               RMW_GID_STORAGE_SIZE) == 0)
             {
-              RCUTILS_LOG_DEBUG_NAMED(
-                "rmw_fastrtps_cpp",
-                "Buffer publisher: subscriber already known, skipping");
               return;
             }
           }
-          if (!info->pending_buffer_endpoints_.insert(unique_topic).second) {
-            return;
+          for (const auto & p : state->pending) {
+            if (p.unique_topic == unique_topic) {
+              return;
+            }
           }
+
+          PendingBufferPublisher pending;
+          pending.unique_topic = unique_topic;
+          pending.target_subscriber_gid = sub_info.gid;
+          pending.subscriber_endpoint_info = rmw_get_zero_initialized_topic_endpoint_info();
+          pending.subscriber_endpoint_info.endpoint_type = RMW_ENDPOINT_SUBSCRIPTION;
+          std::memcpy(
+            pending.subscriber_endpoint_info.endpoint_gid,
+            sub_info.gid.data, RMW_GID_STORAGE_SIZE);
+          pending.backend_metadata = sub_info.backend_metadata;
+          state->pending.push_back(std::move(pending));
         }
 
         RCUTILS_LOG_INFO_NAMED(
           "rmw_fastrtps_cpp",
-          "Buffer publisher: subscriber discovered, computing compatibility for '%s'",
+          "Buffer publisher: subscriber discovered, queued '%s'",
           unique_topic.c_str());
-
-        auto endpoint = std::make_shared<BufferPublisherEndpoint>();
-        endpoint->key = unique_topic;
-        endpoint->target_subscriber_gid = sub_info.gid;
-        endpoint->backend_metadata = sub_info.backend_metadata;
-
-        endpoint->subscriber_endpoint_info = rmw_get_zero_initialized_topic_endpoint_info();
-        endpoint->subscriber_endpoint_info.endpoint_type = RMW_ENDPOINT_SUBSCRIPTION;
-        std::memcpy(
-          endpoint->subscriber_endpoint_info.endpoint_gid,
-          sub_info.gid.data, RMW_GID_STORAGE_SIZE);
-
-        eprosima::fastdds::dds::TopicQos topic_qos =
-        info->participant_->get_default_topic_qos();
-        auto * topic = info->participant_->create_topic(
-          unique_topic,
-          info->type_support_.get_type_name(),
-          topic_qos);
-        if (!topic) {
-          RCUTILS_LOG_ERROR_NAMED(
-            "rmw_fastrtps_cpp",
-            "Failed to create per-subscriber topic '%s'", unique_topic.c_str());
-          std::lock_guard<std::mutex> lock(info->buffer_mutex_);
-          info->pending_buffer_endpoints_.erase(unique_topic);
-          return;
-        }
-        endpoint->topic = topic;
-
-        RCUTILS_LOG_INFO_NAMED(
-          "rmw_fastrtps_cpp",
-          "Buffer publisher: creating DataWriter for '%s'", unique_topic.c_str());
-
-        eprosima::fastdds::dds::DataWriterQos writer_qos =
-        info->dds_publisher_->get_default_datawriter_qos();
-        writer_qos.publish_mode().kind = eprosima::fastdds::dds::SYNCHRONOUS_PUBLISH_MODE;
-        writer_qos.endpoint().history_memory_policy =
-        eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
-        writer_qos.data_sharing().off();
-        writer_qos.reliability().kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
-        writer_qos.history() = info->data_writer_->get_qos().history();
-
-        auto * data_writer = info->dds_publisher_->create_datawriter(
-          topic, writer_qos, nullptr);
-        if (!data_writer) {
-          info->participant_->delete_topic(topic);
-          RCUTILS_LOG_ERROR_NAMED(
-            "rmw_fastrtps_cpp",
-            "Failed to create per-subscriber DataWriter for '%s'", unique_topic.c_str());
-          std::lock_guard<std::mutex> lock(info->buffer_mutex_);
-          info->pending_buffer_endpoints_.erase(unique_topic);
-          return;
-        }
-        endpoint->data_writer = data_writer;
-
-        {
-          std::lock_guard<std::mutex> lock(info->buffer_mutex_);
-          info->buffer_endpoints_.push_back(endpoint);
-          info->pending_buffer_endpoints_.erase(unique_topic);
-        }
-        RCUTILS_LOG_INFO_NAMED(
-          "rmw_fastrtps_cpp",
-          "Buffer publisher: created per-sub endpoint '%s'", unique_topic.c_str());
       });
   }
 
@@ -335,17 +288,19 @@ rmw_destroy_publisher(rmw_node_t * node, rmw_publisher_t * publisher)
 
   auto info = static_cast<CustomPublisherInfo *>(publisher->data);
   if (info && info->is_buffer_aware_) {
-    info->buffer_alive_flag_->store(false);
+    auto & state = *info->buffer_state_;
+    std::vector<std::shared_ptr<BufferPublisherEndpoint>> endpoints_to_destroy;
+    {
+      std::lock_guard<std::mutex> lock(state.mutex);
+      state.alive.store(false);
+      endpoints_to_destroy = std::move(state.endpoints);
+      state.endpoints.clear();
+      state.pending.clear();
+    }
 
     rmw_fastrtps_cpp::BufferEndpointRegistry::get_instance().unregister_callbacks(
       info->publisher_gid);
 
-    std::vector<std::shared_ptr<BufferPublisherEndpoint>> endpoints_to_destroy;
-    {
-      std::lock_guard<std::mutex> lock(info->buffer_mutex_);
-      endpoints_to_destroy = std::move(info->buffer_endpoints_);
-      info->buffer_endpoints_.clear();
-    }
     for (auto & endpoint : endpoints_to_destroy) {
       if (endpoint->data_writer) {
         info->dds_publisher_->delete_datawriter(endpoint->data_writer);

--- a/rmw_fastrtps_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publisher.cpp
@@ -170,14 +170,29 @@ rmw_create_publisher(
 
             // Check for duplicate in existing p2p endpoints or CPU-only list.
             for (const auto & ep : state->endpoints) {
-              if (std::memcmp(ep->target_subscriber_gid.data, sub_info.gid.data,
-              RMW_GID_STORAGE_SIZE) == 0)
-              {
+              bool equal = false;
+              rmw_ret_t ret = rmw_compare_gids_equal(
+                &ep->target_subscriber_gid, &sub_info.gid, &equal);
+              if (RMW_RET_OK != ret) {
+                RCUTILS_LOG_ERROR_NAMED(
+                  "rmw_fastrtps_cpp",
+                  "Buffer publisher: rmw_compare_gids_equal failed during duplicate check");
+                continue;
+              }
+              if (equal) {
                 return;
               }
             }
             for (const auto & g : state->cpu_only_subscribers) {
-              if (std::memcmp(g.data, sub_info.gid.data, RMW_GID_STORAGE_SIZE) == 0) {
+              bool equal = false;
+              rmw_ret_t ret = rmw_compare_gids_equal(&g, &sub_info.gid, &equal);
+              if (RMW_RET_OK != ret) {
+                RCUTILS_LOG_ERROR_NAMED(
+                  "rmw_fastrtps_cpp",
+                  "Buffer publisher: rmw_compare_gids_equal failed during duplicate check");
+                continue;
+              }
+              if (equal) {
                 return;
               }
             }
@@ -196,9 +211,16 @@ rmw_create_publisher(
 
             // Non-CPU subscriber: create a peer-to-peer endpoint.
             for (const auto & p : state->pending) {
-              if (std::memcmp(p.target_subscriber_gid.data, sub_info.gid.data,
-              RMW_GID_STORAGE_SIZE) == 0)
-              {
+              bool equal = false;
+              rmw_ret_t ret = rmw_compare_gids_equal(
+                &p.target_subscriber_gid, &sub_info.gid, &equal);
+              if (RMW_RET_OK != ret) {
+                RCUTILS_LOG_ERROR_NAMED(
+                  "rmw_fastrtps_cpp",
+                  "Buffer publisher: rmw_compare_gids_equal failed during pending check");
+                continue;
+              }
+              if (equal) {
                 return;
               }
             }
@@ -239,11 +261,11 @@ rmw_create_publisher(
               std::unordered_map<std::string,
               std::vector<std::set<uint32_t>>> backend_endpoint_groups;
               (void)rosidl_buffer_backend_registry::notify_endpoint_discovered(
-              backend_context->backend_instances,
-              discovered_endpoint_info,
-              existing_endpoints,
-              backend_endpoint_groups,
-              sub_info.backend_metadata);
+                backend_context->backend_instances,
+                discovered_endpoint_info,
+                existing_endpoints,
+                backend_endpoint_groups,
+                sub_info.backend_metadata);
             }
 
             PendingBufferPublisher pending;

--- a/rmw_fastrtps_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publisher.cpp
@@ -185,7 +185,7 @@ rmw_create_publisher(
         auto endpoint = std::make_shared<BufferPublisherEndpoint>();
         endpoint->key = unique_topic;
         endpoint->target_subscriber_gid = sub_info.gid;
-        endpoint->backend_aux_info = sub_info.backend_aux_info;
+        endpoint->backend_metadata = sub_info.backend_metadata;
 
         endpoint->subscriber_endpoint_info = rmw_get_zero_initialized_topic_endpoint_info();
         endpoint->subscriber_endpoint_info.endpoint_type = RMW_ENDPOINT_SUBSCRIPTION;

--- a/rmw_fastrtps_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publisher.cpp
@@ -32,6 +32,7 @@
 #include "rmw_dds_common/qos.hpp"
 
 #include "rmw_fastrtps_shared_cpp/custom_participant_info.hpp"
+#include "rmw_fastrtps_shared_cpp/guid_utils.hpp"
 #include "rmw_fastrtps_shared_cpp/custom_publisher_info.hpp"
 #include "rmw_fastrtps_shared_cpp/publisher.hpp"
 #include "rmw_fastrtps_shared_cpp/qos.hpp"
@@ -225,19 +226,8 @@ rmw_create_publisher(
               }
             }
 
-            auto gid_to_hex = [](const rmw_gid_t & gid, size_t bytes = 8) -> std::string {
-              static const char hex_chars[] = "0123456789abcdef";
-              std::string result;
-              result.reserve(bytes * 2);
-              for (size_t i = 0; i < bytes && i < RMW_GID_STORAGE_SIZE; ++i) {
-                result += hex_chars[(gid.data[i] >> 4) & 0xF];
-                result += hex_chars[gid.data[i] & 0xF];
-              }
-              return result;
-            };
-
-            std::string pub_hex = gid_to_hex(pub_gid);
-            std::string sub_hex = gid_to_hex(sub_info.gid);
+            std::string pub_hex = rmw_fastrtps_shared_cpp::gid_to_hex(pub_gid);
+            std::string sub_hex = rmw_fastrtps_shared_cpp::gid_to_hex(sub_info.gid);
             std::string unique_topic = base_topic +
             "/_buf/" + pub_hex + "_" + sub_hex;
 

--- a/rmw_fastrtps_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_subscription.cpp
@@ -173,20 +173,20 @@ rmw_create_subscription(
         }
 
         auto gid_to_hex = [](const rmw_gid_t & gid, size_t bytes = 8) -> std::string {
-            static const char hex_chars[] = "0123456789abcdef";
-            std::string result;
-            result.reserve(bytes * 2);
-            for (size_t i = 0; i < bytes && i < RMW_GID_STORAGE_SIZE; ++i) {
-              result += hex_chars[(gid.data[i] >> 4) & 0xF];
-              result += hex_chars[gid.data[i] & 0xF];
-            }
-            return result;
-          };
+          static const char hex_chars[] = "0123456789abcdef";
+          std::string result;
+          result.reserve(bytes * 2);
+          for (size_t i = 0; i < bytes && i < RMW_GID_STORAGE_SIZE; ++i) {
+            result += hex_chars[(gid.data[i] >> 4) & 0xF];
+            result += hex_chars[gid.data[i] & 0xF];
+          }
+          return result;
+        };
 
         std::string pub_hex = gid_to_hex(pub_info.gid);
         std::string sub_hex = gid_to_hex(info->subscription_gid_);
         std::string unique_topic = info->topic_name_mangled_ +
-          "/_buf/" + pub_hex + "_" + sub_hex;
+        "/_buf/" + pub_hex + "_" + sub_hex;
 
         {
           std::lock_guard<std::mutex> lock(info->buffer_mutex_);
@@ -225,7 +225,7 @@ rmw_create_subscription(
         // this topic on the same DDS participant. Reuse it if it exists.
         eprosima::fastdds::dds::Topic * topic = nullptr;
         auto * existing_desc =
-          info->dds_participant_->lookup_topicdescription(unique_topic);
+        info->dds_participant_->lookup_topicdescription(unique_topic);
         if (existing_desc) {
           topic = dynamic_cast<eprosima::fastdds::dds::Topic *>(existing_desc);
           if (topic) {
@@ -234,7 +234,7 @@ rmw_create_subscription(
         }
         if (!topic) {
           eprosima::fastdds::dds::TopicQos topic_qos =
-            info->dds_participant_->get_default_topic_qos();
+          info->dds_participant_->get_default_topic_qos();
           topic = info->dds_participant_->create_topic(
             unique_topic,
             info->type_support_.get_type_name(),
@@ -255,9 +255,9 @@ rmw_create_subscription(
           "Buffer subscription: creating DataReader for '%s'", unique_topic.c_str());
 
         eprosima::fastdds::dds::DataReaderQos reader_qos =
-          info->subscriber_->get_default_datareader_qos();
+        info->subscriber_->get_default_datareader_qos();
         reader_qos.endpoint().history_memory_policy =
-          eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+        eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
         reader_qos.data_sharing().off();
         reader_qos.reliability().kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
         reader_qos.history() = info->datareader_qos_.history();

--- a/rmw_fastrtps_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_subscription.cpp
@@ -136,72 +136,75 @@ rmw_create_subscription(
     auto sub_gid = info->subscription_gid_;
     std::string base_topic = info->topic_name_mangled_;
     auto * guard = info->buffer_data_guard_.get();
-    auto & buf_registry = rmw_fastrtps_cpp::BufferEndpointRegistry::get_instance();
-    buf_registry.register_publisher_discovery_callback(
-      subscription->topic_name,
-      info->subscription_gid_,
-      [state, sub_gid, base_topic, guard](
-        const rmw_fastrtps_cpp::BufferEndpointInfo & pub_info)
-      {
-        if (!state->alive.load()) {
-          return;
-        }
-
-        auto gid_to_hex = [](const rmw_gid_t & gid, size_t bytes = 8) -> std::string {
-          static const char hex_chars[] = "0123456789abcdef";
-          std::string result;
-          result.reserve(bytes * 2);
-          for (size_t i = 0; i < bytes && i < RMW_GID_STORAGE_SIZE; ++i) {
-            result += hex_chars[(gid.data[i] >> 4) & 0xF];
-            result += hex_chars[gid.data[i] & 0xF];
-          }
-          return result;
-        };
-
-        std::string pub_hex = gid_to_hex(pub_info.gid);
-        std::string sub_hex = gid_to_hex(sub_gid);
-        std::string unique_topic = base_topic +
-        "/_buf/" + pub_hex + "_" + sub_hex;
-
+    auto * buf_registry = static_cast<rmw_fastrtps_cpp::BufferEndpointRegistry *>(
+      node->context->impl->buffer_endpoint_registry);
+    if (buf_registry) {
+      buf_registry->register_publisher_discovery_callback(
+        subscription->topic_name,
+        info->subscription_gid_,
+        [state, sub_gid, base_topic, guard](
+          const rmw_fastrtps_cpp::BufferEndpointInfo & pub_info)
         {
-          std::lock_guard<std::mutex> lock(state->mutex);
           if (!state->alive.load()) {
             return;
           }
-          for (const auto & ep : state->endpoints) {
-            if (std::memcmp(ep->publisher_gid.data, pub_info.gid.data,
-              RMW_GID_STORAGE_SIZE) == 0)
-            {
-              return;
-            }
-          }
-          for (const auto & p : state->pending) {
-            if (p.unique_topic == unique_topic) {
-              return;
-            }
-          }
 
-          PendingBufferSubscription pending;
-          pending.unique_topic = unique_topic;
-          pending.publisher_gid = pub_info.gid;
-          pending.publisher_endpoint_info = rmw_get_zero_initialized_topic_endpoint_info();
-          pending.publisher_endpoint_info.endpoint_type = RMW_ENDPOINT_PUBLISHER;
-          std::memcpy(
+          auto gid_to_hex = [](const rmw_gid_t & gid, size_t bytes = 8) -> std::string {
+            static const char hex_chars[] = "0123456789abcdef";
+            std::string result;
+            result.reserve(bytes * 2);
+            for (size_t i = 0; i < bytes && i < RMW_GID_STORAGE_SIZE; ++i) {
+              result += hex_chars[(gid.data[i] >> 4) & 0xF];
+              result += hex_chars[gid.data[i] & 0xF];
+            }
+            return result;
+          };
+
+          std::string pub_hex = gid_to_hex(pub_info.gid);
+          std::string sub_hex = gid_to_hex(sub_gid);
+          std::string unique_topic = base_topic +
+          "/_buf/" + pub_hex + "_" + sub_hex;
+
+          {
+            std::lock_guard<std::mutex> lock(state->mutex);
+            if (!state->alive.load()) {
+              return;
+            }
+            for (const auto & ep : state->endpoints) {
+              if (std::memcmp(ep->publisher_gid.data, pub_info.gid.data,
+              RMW_GID_STORAGE_SIZE) == 0)
+              {
+                return;
+              }
+            }
+            for (const auto & p : state->pending) {
+              if (p.unique_topic == unique_topic) {
+                return;
+              }
+            }
+
+            PendingBufferSubscription pending;
+            pending.unique_topic = unique_topic;
+            pending.publisher_gid = pub_info.gid;
+            pending.publisher_endpoint_info = rmw_get_zero_initialized_topic_endpoint_info();
+            pending.publisher_endpoint_info.endpoint_type = RMW_ENDPOINT_PUBLISHER;
+            std::memcpy(
             pending.publisher_endpoint_info.endpoint_gid,
             pub_info.gid.data, RMW_GID_STORAGE_SIZE);
-          pending.backend_metadata = pub_info.backend_metadata;
-          state->pending.push_back(std::move(pending));
+            pending.backend_metadata = pub_info.backend_metadata;
+            state->pending.push_back(std::move(pending));
 
-          if (guard) {
-            guard->set_trigger_value(true);
+            if (guard) {
+              guard->set_trigger_value(true);
+            }
           }
-        }
 
-        RCUTILS_LOG_INFO_NAMED(
+          RCUTILS_LOG_INFO_NAMED(
           "rmw_fastrtps_cpp",
           "Buffer subscription: publisher discovered, queued '%s'",
           unique_topic.c_str());
-      });
+        });
+    }
   }
 
   cleanup_subscription.cancel();
@@ -306,8 +309,11 @@ rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription)
       state.pending.clear();
     }
 
-    rmw_fastrtps_cpp::BufferEndpointRegistry::get_instance().unregister_callbacks(
-      info->subscription_gid_);
+    auto * buf_registry = static_cast<rmw_fastrtps_cpp::BufferEndpointRegistry *>(
+      node->context->impl->buffer_endpoint_registry);
+    if (buf_registry) {
+      buf_registry->unregister_callbacks(info->subscription_gid_);
+    }
 
     for (auto & endpoint : endpoints_to_destroy) {
       if (endpoint->data_reader) {

--- a/rmw_fastrtps_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_subscription.cpp
@@ -29,6 +29,7 @@
 #include "rmw_dds_common/qos.hpp"
 
 #include "rmw_fastrtps_shared_cpp/custom_participant_info.hpp"
+#include "rmw_fastrtps_shared_cpp/guid_utils.hpp"
 #include "rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp"
 #include "rmw_fastrtps_shared_cpp/qos.hpp"
 #include "rmw_fastrtps_shared_cpp/rmw_common.hpp"
@@ -151,19 +152,8 @@ rmw_create_subscription(
             return;
           }
 
-          auto gid_to_hex = [](const rmw_gid_t & gid, size_t bytes = 8) -> std::string {
-            static const char hex_chars[] = "0123456789abcdef";
-            std::string result;
-            result.reserve(bytes * 2);
-            for (size_t i = 0; i < bytes && i < RMW_GID_STORAGE_SIZE; ++i) {
-              result += hex_chars[(gid.data[i] >> 4) & 0xF];
-              result += hex_chars[gid.data[i] & 0xF];
-            }
-            return result;
-          };
-
-          std::string pub_hex = gid_to_hex(pub_info.gid);
-          std::string sub_hex = gid_to_hex(sub_gid);
+          std::string pub_hex = rmw_fastrtps_shared_cpp::gid_to_hex(pub_info.gid);
+          std::string sub_hex = rmw_fastrtps_shared_cpp::gid_to_hex(sub_gid);
           std::string unique_topic = base_topic +
           "/_buf/" + pub_hex + "_" + sub_hex;
 

--- a/rmw_fastrtps_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_subscription.cpp
@@ -213,7 +213,7 @@ rmw_create_subscription(
         auto endpoint = std::make_shared<BufferSubscriptionEndpoint>();
         endpoint->key = unique_topic;
         endpoint->publisher_gid = pub_info.gid;
-        endpoint->backend_aux_info = pub_info.backend_aux_info;
+        endpoint->backend_metadata = pub_info.backend_metadata;
 
         endpoint->publisher_endpoint_info = rmw_get_zero_initialized_topic_endpoint_info();
         endpoint->publisher_endpoint_info.endpoint_type = RMW_ENDPOINT_PUBLISHER;

--- a/rmw_fastrtps_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_subscription.cpp
@@ -40,7 +40,9 @@
 #include "rmw_fastrtps_cpp/identifier.hpp"
 #include "rmw_fastrtps_cpp/subscription.hpp"
 
+#include "buffer_backend_context.hpp"
 #include "buffer_endpoint_registry.hpp"
+#include "rosidl_buffer_backend_registry/backend_utils.hpp"
 
 extern "C"
 {
@@ -133,17 +135,20 @@ rmw_create_subscription(
 
   // Register buffer-aware publisher discovery callback.
   // CPU-only subscriptions use the shared CPU channel and don't need
-  // per-publisher peer-to-peer endpoints, so skip the callback for them.
+  // per-publisher metadata tracking, so skip the callback for them.
   if (info->is_buffer_aware_ && !info->is_cpu_only_) {
     auto state = info->buffer_state_;
     auto * guard = info->buffer_data_guard_.get();
+    auto * backend_context =
+      static_cast<const rmw_fastrtps_cpp::BufferBackendContext *>(
+      info->serialization_context_);
     auto * buf_registry = static_cast<rmw_fastrtps_cpp::BufferEndpointRegistry *>(
       node->context->impl->buffer_endpoint_registry);
     if (buf_registry) {
       buf_registry->register_publisher_discovery_callback(
         subscription->topic_name,
         info->subscription_gid_,
-        [state, guard](
+        [state, guard, backend_context](
           const rmw_fastrtps_cpp::BufferEndpointInfo & pub_info)
         {
           if (!state->alive.load()) {
@@ -169,6 +174,24 @@ rmw_create_subscription(
               meta.publisher_endpoint_info.endpoint_gid,
               pub_info.gid.data, RMW_GID_STORAGE_SIZE);
             meta.backend_metadata = pub_info.backend_metadata;
+
+            if (backend_context) {
+              std::vector<rmw_topic_endpoint_info_t> existing_endpoints;
+              existing_endpoints.reserve(state->publisher_metadata.size());
+              for (const auto & [hex, m] : state->publisher_metadata) {
+                existing_endpoints.push_back(m.publisher_endpoint_info);
+              }
+
+              std::unordered_map<std::string,
+              std::vector<std::set<uint32_t>>> backend_endpoint_groups;
+              (void)rosidl_buffer_backend_registry::notify_endpoint_discovered(
+                backend_context->backend_instances,
+                meta.publisher_endpoint_info,
+                existing_endpoints,
+                backend_endpoint_groups,
+                pub_info.backend_metadata);
+            }
+
             state->publisher_metadata[pub_hex] = std::move(meta);
 
             if (guard) {

--- a/rmw_fastrtps_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_subscription.cpp
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdio>
+#include <cstring>
 #include <string>
 #include <utility>
 
@@ -22,17 +24,52 @@
 #include "rmw/rmw.h"
 
 #include "rcpputils/scope_exit.hpp"
+#include "rcutils/logging_macros.h"
 
 #include "rmw_dds_common/qos.hpp"
 
 #include "rmw_fastrtps_shared_cpp/custom_participant_info.hpp"
 #include "rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp"
+#include "rmw_fastrtps_shared_cpp/qos.hpp"
 #include "rmw_fastrtps_shared_cpp/rmw_common.hpp"
 #include "rmw_fastrtps_shared_cpp/rmw_context_impl.hpp"
 #include "rmw_fastrtps_shared_cpp/subscription.hpp"
+#include "rmw_fastrtps_shared_cpp/create_rmw_gid.hpp"
 
 #include "rmw_fastrtps_cpp/identifier.hpp"
 #include "rmw_fastrtps_cpp/subscription.hpp"
+
+#include "buffer_endpoint_registry.hpp"
+
+namespace
+{
+/// Lightweight listener for per-publisher DataReaders in buffer-aware subscriptions.
+/// Triggers the subscription's buffer guard condition so rmw_wait detects the data,
+/// and also notifies via the callback path for callback-based executors.
+class BufferDataReaderListener final : public eprosima::fastdds::dds::DataReaderListener
+{
+public:
+  BufferDataReaderListener(
+    eprosima::fastdds::dds::GuardCondition * guard,
+    RMWSubscriptionEvent * event)
+  : guard_(guard), event_(event) {}
+
+  void on_data_available(eprosima::fastdds::dds::DataReader * reader) override
+  {
+    if (guard_) {
+      guard_->set_trigger_value(true);
+    }
+    auto unread = reader->get_unread_count();
+    if (event_) {
+      event_->notify_buffer_data_available(unread > 0 ? static_cast<size_t>(unread) : 1);
+    }
+  }
+
+private:
+  eprosima::fastdds::dds::GuardCondition * guard_;
+  RMWSubscriptionEvent * event_;
+};
+}  // namespace
 
 extern "C"
 {
@@ -123,6 +160,141 @@ rmw_create_subscription(
   info->node_ = node;
   info->common_context_ = common_context;
 
+  // Register buffer-aware publisher discovery callback
+  if (info->is_buffer_aware_) {
+    auto alive = info->buffer_alive_flag_;
+    auto & buf_registry = rmw_fastrtps_cpp::BufferEndpointRegistry::get_instance();
+    buf_registry.register_publisher_discovery_callback(
+      subscription->topic_name,
+      info->subscription_gid_,
+      [info, alive](const rmw_fastrtps_cpp::BufferEndpointInfo & pub_info) {
+        if (!alive->load()) {
+          return;
+        }
+
+        auto gid_to_hex = [](const rmw_gid_t & gid, size_t bytes = 8) -> std::string {
+            static const char hex_chars[] = "0123456789abcdef";
+            std::string result;
+            result.reserve(bytes * 2);
+            for (size_t i = 0; i < bytes && i < RMW_GID_STORAGE_SIZE; ++i) {
+              result += hex_chars[(gid.data[i] >> 4) & 0xF];
+              result += hex_chars[gid.data[i] & 0xF];
+            }
+            return result;
+          };
+
+        std::string pub_hex = gid_to_hex(pub_info.gid);
+        std::string sub_hex = gid_to_hex(info->subscription_gid_);
+        std::string unique_topic = info->topic_name_mangled_ +
+          "/_buf/" + pub_hex + "_" + sub_hex;
+
+        {
+          std::lock_guard<std::mutex> lock(info->buffer_mutex_);
+          for (const auto & ep : info->buffer_endpoints_) {
+            if (std::memcmp(ep->publisher_gid.data, pub_info.gid.data,
+              RMW_GID_STORAGE_SIZE) == 0)
+            {
+              RCUTILS_LOG_DEBUG_NAMED(
+                "rmw_fastrtps_cpp",
+                "Buffer subscription: publisher already known, skipping");
+              return;
+            }
+          }
+          if (!info->pending_buffer_endpoints_.insert(unique_topic).second) {
+            return;
+          }
+        }
+
+        RCUTILS_LOG_INFO_NAMED(
+          "rmw_fastrtps_cpp",
+          "Buffer subscription: publisher discovered, computing compatibility for '%s'",
+          unique_topic.c_str());
+
+        auto endpoint = std::make_shared<BufferSubscriptionEndpoint>();
+        endpoint->key = unique_topic;
+        endpoint->publisher_gid = pub_info.gid;
+        endpoint->backend_aux_info = pub_info.backend_aux_info;
+
+        endpoint->publisher_endpoint_info = rmw_get_zero_initialized_topic_endpoint_info();
+        endpoint->publisher_endpoint_info.endpoint_type = RMW_ENDPOINT_PUBLISHER;
+        std::memcpy(
+          endpoint->publisher_endpoint_info.endpoint_gid,
+          pub_info.gid.data, RMW_GID_STORAGE_SIZE);
+
+        // In single-process scenarios, the publisher may have already created
+        // this topic on the same DDS participant. Reuse it if it exists.
+        eprosima::fastdds::dds::Topic * topic = nullptr;
+        auto * existing_desc =
+          info->dds_participant_->lookup_topicdescription(unique_topic);
+        if (existing_desc) {
+          topic = dynamic_cast<eprosima::fastdds::dds::Topic *>(existing_desc);
+          if (topic) {
+            endpoint->owns_topic = false;
+          }
+        }
+        if (!topic) {
+          eprosima::fastdds::dds::TopicQos topic_qos =
+            info->dds_participant_->get_default_topic_qos();
+          topic = info->dds_participant_->create_topic(
+            unique_topic,
+            info->type_support_.get_type_name(),
+            topic_qos);
+        }
+        if (!topic) {
+          RCUTILS_LOG_ERROR_NAMED(
+            "rmw_fastrtps_cpp",
+            "Failed to create per-publisher topic '%s'", unique_topic.c_str());
+          std::lock_guard<std::mutex> lock(info->buffer_mutex_);
+          info->pending_buffer_endpoints_.erase(unique_topic);
+          return;
+        }
+        endpoint->topic = topic;
+
+        RCUTILS_LOG_INFO_NAMED(
+          "rmw_fastrtps_cpp",
+          "Buffer subscription: creating DataReader for '%s'", unique_topic.c_str());
+
+        eprosima::fastdds::dds::DataReaderQos reader_qos =
+          info->subscriber_->get_default_datareader_qos();
+        reader_qos.endpoint().history_memory_policy =
+          eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+        reader_qos.data_sharing().off();
+        reader_qos.reliability().kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
+        reader_qos.history() = info->datareader_qos_.history();
+        constexpr auto rep = eprosima::fastdds::dds::XCDR_DATA_REPRESENTATION;
+        reader_qos.representation().clear();
+        reader_qos.representation().m_value.push_back(rep);
+
+        auto buffer_listener = std::make_shared<BufferDataReaderListener>(
+          info->buffer_data_guard_.get(), info->subscription_event_);
+        auto * data_reader = info->subscriber_->create_datareader(
+          topic, reader_qos, buffer_listener.get(),
+          eprosima::fastdds::dds::StatusMask::data_available());
+        if (!data_reader) {
+          if (endpoint->owns_topic) {
+            info->dds_participant_->delete_topic(topic);
+          }
+          RCUTILS_LOG_ERROR_NAMED(
+            "rmw_fastrtps_cpp",
+            "Failed to create per-publisher DataReader for '%s'", unique_topic.c_str());
+          std::lock_guard<std::mutex> lock(info->buffer_mutex_);
+          info->pending_buffer_endpoints_.erase(unique_topic);
+          return;
+        }
+        endpoint->data_reader = data_reader;
+        endpoint->listener = buffer_listener;
+
+        {
+          std::lock_guard<std::mutex> lock(info->buffer_mutex_);
+          info->buffer_endpoints_.push_back(endpoint);
+          info->pending_buffer_endpoints_.erase(unique_topic);
+        }
+        RCUTILS_LOG_INFO_NAMED(
+          "rmw_fastrtps_cpp",
+          "Buffer subscription: created per-pub endpoint '%s'", unique_topic.c_str());
+      });
+  }
+
   cleanup_subscription.cancel();
   return subscription;
 }
@@ -212,6 +384,29 @@ rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription)
     subscription->implementation_identifier,
     eprosima_fastrtps_identifier,
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+
+  auto info = static_cast<CustomSubscriberInfo *>(subscription->data);
+  if (info && info->is_buffer_aware_) {
+    info->buffer_alive_flag_->store(false);
+
+    rmw_fastrtps_cpp::BufferEndpointRegistry::get_instance().unregister_callbacks(
+      info->subscription_gid_);
+
+    std::vector<std::shared_ptr<BufferSubscriptionEndpoint>> endpoints_to_destroy;
+    {
+      std::lock_guard<std::mutex> lock(info->buffer_mutex_);
+      endpoints_to_destroy = std::move(info->buffer_endpoints_);
+      info->buffer_endpoints_.clear();
+    }
+    for (auto & endpoint : endpoints_to_destroy) {
+      if (endpoint->data_reader) {
+        info->subscriber_->delete_datareader(endpoint->data_reader);
+      }
+      if (endpoint->topic && endpoint->owns_topic) {
+        info->dds_participant_->delete_topic(endpoint->topic);
+      }
+    }
+  }
 
   return rmw_fastrtps_shared_cpp::__rmw_destroy_subscription(
     eprosima_fastrtps_identifier, node, subscription);

--- a/rmw_fastrtps_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_subscription.cpp
@@ -40,7 +40,9 @@
 #include "rmw_fastrtps_cpp/identifier.hpp"
 #include "rmw_fastrtps_cpp/subscription.hpp"
 
+#include "buffer_backend_context.hpp"
 #include "buffer_endpoint_registry.hpp"
+#include "rosidl_buffer_backend_registry/backend_utils.hpp"
 
 extern "C"
 {
@@ -133,19 +135,20 @@ rmw_create_subscription(
 
   // Register buffer-aware publisher discovery callback.
   // CPU-only subscriptions use the shared CPU channel and don't need
-  // per-publisher peer-to-peer endpoints, so skip the callback for them.
+  // per-publisher metadata tracking, so skip the callback for them.
   if (info->is_buffer_aware_ && !info->is_cpu_only_) {
     auto state = info->buffer_state_;
-    auto sub_gid = info->subscription_gid_;
-    std::string base_topic = info->topic_name_mangled_;
-    auto * guard = info->buffer_data_guard_.get();
+    auto local_endpoint_info = info->local_endpoint_info_;
+    auto * backend_context =
+      static_cast<const rmw_fastrtps_cpp::BufferBackendContext *>(
+      info->serialization_context_);
     auto * buf_registry = static_cast<rmw_fastrtps_cpp::BufferEndpointRegistry *>(
       node->context->impl->buffer_endpoint_registry);
     if (buf_registry) {
       buf_registry->register_publisher_discovery_callback(
         subscription->topic_name,
         info->subscription_gid_,
-        [state, sub_gid, base_topic, guard](
+        [state, local_endpoint_info, backend_context](
           const rmw_fastrtps_cpp::BufferEndpointInfo & pub_info)
         {
           if (!state->alive.load()) {
@@ -153,55 +156,49 @@ rmw_create_subscription(
           }
 
           std::string pub_hex = rmw_fastrtps_shared_cpp::gid_to_hex(pub_info.gid);
-          std::string sub_hex = rmw_fastrtps_shared_cpp::gid_to_hex(sub_gid);
-          std::string unique_topic = base_topic +
-          "/_buf/" + pub_hex + "_" + sub_hex;
 
           {
             std::lock_guard<std::mutex> lock(state->mutex);
             if (!state->alive.load()) {
               return;
             }
-            for (const auto & ep : state->endpoints) {
-              bool equal = false;
-              rmw_ret_t ret = rmw_compare_gids_equal(
-                &ep->publisher_gid, &pub_info.gid, &equal);
-              if (RMW_RET_OK != ret) {
-                RCUTILS_LOG_ERROR_NAMED(
-                  "rmw_fastrtps_cpp",
-                  "Buffer subscription: rmw_compare_gids_equal failed during duplicate check");
-                continue;
-              }
-              if (equal) {
-                return;
-              }
-            }
-            for (const auto & p : state->pending) {
-              if (p.unique_topic == unique_topic) {
-                return;
-              }
+            if (state->publisher_metadata.count(pub_hex) > 0) {
+              return;
             }
 
-            PendingBufferSubscription pending;
-            pending.unique_topic = unique_topic;
-            pending.publisher_gid = pub_info.gid;
-            pending.publisher_endpoint_info = rmw_get_zero_initialized_topic_endpoint_info();
-            pending.publisher_endpoint_info.endpoint_type = RMW_ENDPOINT_PUBLISHER;
+            PublisherBufferMetadata meta;
+            meta.publisher_gid = pub_info.gid;
+            meta.publisher_endpoint_info = rmw_get_zero_initialized_topic_endpoint_info();
+            meta.publisher_endpoint_info.endpoint_type = RMW_ENDPOINT_PUBLISHER;
             std::memcpy(
-            pending.publisher_endpoint_info.endpoint_gid,
-            pub_info.gid.data, RMW_GID_STORAGE_SIZE);
-            pending.backend_metadata = pub_info.backend_metadata;
-            state->pending.push_back(std::move(pending));
+              meta.publisher_endpoint_info.endpoint_gid,
+              pub_info.gid.data, RMW_GID_STORAGE_SIZE);
+            meta.backend_metadata = pub_info.backend_metadata;
 
-            if (guard) {
-              guard->set_trigger_value(true);
+            if (backend_context) {
+              std::vector<rmw_topic_endpoint_info_t> existing_endpoints;
+              existing_endpoints.reserve(state->publisher_metadata.size());
+              for (const auto & [hex, m] : state->publisher_metadata) {
+                existing_endpoints.push_back(m.publisher_endpoint_info);
+              }
+
+              std::unordered_map<std::string,
+              std::vector<std::set<uint32_t>>> backend_endpoint_groups;
+              (void)rosidl_buffer_backend_registry::notify_endpoint_discovered(
+                backend_context->backend_instances,
+                meta.publisher_endpoint_info,
+                existing_endpoints,
+                backend_endpoint_groups,
+                pub_info.backend_metadata);
             }
+
+            state->publisher_metadata[pub_hex] = std::move(meta);
           }
 
           RCUTILS_LOG_INFO_NAMED(
-          "rmw_fastrtps_cpp",
-          "Buffer subscription: publisher discovered, queued '%s'",
-          unique_topic.c_str());
+            "rmw_fastrtps_cpp",
+            "Buffer subscription: publisher discovered (gid: %s)",
+            pub_hex.c_str());
         });
     }
   }
@@ -298,14 +295,10 @@ rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription)
 
   auto info = static_cast<CustomSubscriberInfo *>(subscription->data);
   if (info && info->is_buffer_aware_) {
-    auto & state = *info->buffer_state_;
-    std::vector<std::shared_ptr<BufferSubscriptionEndpoint>> endpoints_to_destroy;
     {
-      std::lock_guard<std::mutex> lock(state.mutex);
-      state.alive.store(false);
-      endpoints_to_destroy = std::move(state.endpoints);
-      state.endpoints.clear();
-      state.pending.clear();
+      std::lock_guard<std::mutex> lock(info->buffer_state_->mutex);
+      info->buffer_state_->alive.store(false);
+      info->buffer_state_->publisher_metadata.clear();
     }
 
     auto * buf_registry = static_cast<rmw_fastrtps_cpp::BufferEndpointRegistry *>(
@@ -314,16 +307,16 @@ rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription)
       buf_registry->unregister_callbacks(info->subscription_gid_);
     }
 
-    for (auto & endpoint : endpoints_to_destroy) {
-      if (endpoint->data_reader) {
-        info->subscriber_->delete_datareader(endpoint->data_reader);
-      }
-      if (endpoint->topic && endpoint->owns_topic) {
-        info->dds_participant_->delete_topic(endpoint->topic);
-      }
+    if (info->accel_data_reader_) {
+      info->subscriber_->delete_datareader(info->accel_data_reader_);
+      info->accel_data_reader_ = nullptr;
+    }
+    info->accel_data_reader_listener_.reset();
+    if (info->accel_topic_) {
+      info->dds_participant_->delete_topic(info->accel_topic_);
+      info->accel_topic_ = nullptr;
     }
 
-    // Clean up the shared CPU channel DataReader and Topic.
     if (info->cpu_data_reader_) {
       info->subscriber_->delete_datareader(info->cpu_data_reader_);
       info->cpu_data_reader_ = nullptr;

--- a/rmw_fastrtps_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_subscription.cpp
@@ -130,8 +130,10 @@ rmw_create_subscription(
   info->node_ = node;
   info->common_context_ = common_context;
 
-  // Register buffer-aware publisher discovery callback
-  if (info->is_buffer_aware_) {
+  // Register buffer-aware publisher discovery callback.
+  // CPU-only subscriptions use the shared CPU channel and don't need
+  // per-publisher peer-to-peer endpoints, so skip the callback for them.
+  if (info->is_buffer_aware_ && !info->is_cpu_only_) {
     auto state = info->buffer_state_;
     auto sub_gid = info->subscription_gid_;
     std::string base_topic = info->topic_name_mangled_;
@@ -322,6 +324,17 @@ rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription)
       if (endpoint->topic && endpoint->owns_topic) {
         info->dds_participant_->delete_topic(endpoint->topic);
       }
+    }
+
+    // Clean up the shared CPU channel DataReader and Topic.
+    if (info->cpu_data_reader_) {
+      info->subscriber_->delete_datareader(info->cpu_data_reader_);
+      info->cpu_data_reader_ = nullptr;
+    }
+    info->cpu_data_reader_listener_.reset();
+    if (info->cpu_topic_) {
+      info->dds_participant_->delete_topic(info->cpu_topic_);
+      info->cpu_topic_ = nullptr;
     }
   }
 

--- a/rmw_fastrtps_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_subscription.cpp
@@ -173,9 +173,16 @@ rmw_create_subscription(
               return;
             }
             for (const auto & ep : state->endpoints) {
-              if (std::memcmp(ep->publisher_gid.data, pub_info.gid.data,
-              RMW_GID_STORAGE_SIZE) == 0)
-              {
+              bool equal = false;
+              rmw_ret_t ret = rmw_compare_gids_equal(
+                &ep->publisher_gid, &pub_info.gid, &equal);
+              if (RMW_RET_OK != ret) {
+                RCUTILS_LOG_ERROR_NAMED(
+                  "rmw_fastrtps_cpp",
+                  "Buffer subscription: rmw_compare_gids_equal failed during duplicate check");
+                continue;
+              }
+              if (equal) {
                 return;
               }
             }

--- a/rmw_fastrtps_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_subscription.cpp
@@ -29,8 +29,8 @@
 #include "rmw_dds_common/qos.hpp"
 
 #include "rmw_fastrtps_shared_cpp/custom_participant_info.hpp"
-#include "rmw_fastrtps_shared_cpp/guid_utils.hpp"
 #include "rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp"
+#include "rmw_fastrtps_shared_cpp/guid_utils.hpp"
 #include "rmw_fastrtps_shared_cpp/qos.hpp"
 #include "rmw_fastrtps_shared_cpp/rmw_common.hpp"
 #include "rmw_fastrtps_shared_cpp/rmw_context_impl.hpp"
@@ -40,9 +40,7 @@
 #include "rmw_fastrtps_cpp/identifier.hpp"
 #include "rmw_fastrtps_cpp/subscription.hpp"
 
-#include "buffer_backend_context.hpp"
 #include "buffer_endpoint_registry.hpp"
-#include "rosidl_buffer_backend_registry/backend_utils.hpp"
 
 extern "C"
 {
@@ -135,20 +133,17 @@ rmw_create_subscription(
 
   // Register buffer-aware publisher discovery callback.
   // CPU-only subscriptions use the shared CPU channel and don't need
-  // per-publisher metadata tracking, so skip the callback for them.
+  // per-publisher peer-to-peer endpoints, so skip the callback for them.
   if (info->is_buffer_aware_ && !info->is_cpu_only_) {
     auto state = info->buffer_state_;
-    auto local_endpoint_info = info->local_endpoint_info_;
-    auto * backend_context =
-      static_cast<const rmw_fastrtps_cpp::BufferBackendContext *>(
-      info->serialization_context_);
+    auto * guard = info->buffer_data_guard_.get();
     auto * buf_registry = static_cast<rmw_fastrtps_cpp::BufferEndpointRegistry *>(
       node->context->impl->buffer_endpoint_registry);
     if (buf_registry) {
       buf_registry->register_publisher_discovery_callback(
         subscription->topic_name,
         info->subscription_gid_,
-        [state, local_endpoint_info, backend_context](
+        [state, guard](
           const rmw_fastrtps_cpp::BufferEndpointInfo & pub_info)
         {
           if (!state->alive.load()) {
@@ -174,30 +169,16 @@ rmw_create_subscription(
               meta.publisher_endpoint_info.endpoint_gid,
               pub_info.gid.data, RMW_GID_STORAGE_SIZE);
             meta.backend_metadata = pub_info.backend_metadata;
-
-            if (backend_context) {
-              std::vector<rmw_topic_endpoint_info_t> existing_endpoints;
-              existing_endpoints.reserve(state->publisher_metadata.size());
-              for (const auto & [hex, m] : state->publisher_metadata) {
-                existing_endpoints.push_back(m.publisher_endpoint_info);
-              }
-
-              std::unordered_map<std::string,
-              std::vector<std::set<uint32_t>>> backend_endpoint_groups;
-              (void)rosidl_buffer_backend_registry::notify_endpoint_discovered(
-                backend_context->backend_instances,
-                meta.publisher_endpoint_info,
-                existing_endpoints,
-                backend_endpoint_groups,
-                pub_info.backend_metadata);
-            }
-
             state->publisher_metadata[pub_hex] = std::move(meta);
+
+            if (guard) {
+              guard->set_trigger_value(true);
+            }
           }
 
           RCUTILS_LOG_INFO_NAMED(
             "rmw_fastrtps_cpp",
-            "Buffer subscription: publisher discovered (gid: %s)",
+            "Buffer subscription: publisher discovered, recorded '%s'",
             pub_hex.c_str());
         });
     }
@@ -296,9 +277,10 @@ rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription)
   auto info = static_cast<CustomSubscriberInfo *>(subscription->data);
   if (info && info->is_buffer_aware_) {
     {
-      std::lock_guard<std::mutex> lock(info->buffer_state_->mutex);
-      info->buffer_state_->alive.store(false);
-      info->buffer_state_->publisher_metadata.clear();
+      auto & state = *info->buffer_state_;
+      std::lock_guard<std::mutex> lock(state.mutex);
+      state.alive.store(false);
+      state.publisher_metadata.clear();
     }
 
     auto * buf_registry = static_cast<rmw_fastrtps_cpp::BufferEndpointRegistry *>(
@@ -307,6 +289,10 @@ rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription)
       buf_registry->unregister_callbacks(info->subscription_gid_);
     }
 
+    auto * participant_info =
+      static_cast<CustomParticipantInfo *>(node->context->impl->participant_info);
+
+    // Clean up the accelerated channel DataReader and Topic.
     if (info->accel_data_reader_) {
       info->subscriber_->delete_datareader(info->accel_data_reader_);
       info->accel_data_reader_ = nullptr;
@@ -317,13 +303,14 @@ rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription)
       info->accel_topic_ = nullptr;
     }
 
+    // Clean up the shared CPU channel DataReader and Topic.
     if (info->cpu_data_reader_) {
       info->subscriber_->delete_datareader(info->cpu_data_reader_);
       info->cpu_data_reader_ = nullptr;
     }
     info->cpu_data_reader_listener_.reset();
     if (info->cpu_topic_) {
-      info->dds_participant_->delete_topic(info->cpu_topic_);
+      participant_info->delete_topic(info->cpu_topic_, nullptr);
       info->cpu_topic_ = nullptr;
     }
   }

--- a/rmw_fastrtps_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_subscription.cpp
@@ -41,36 +41,6 @@
 
 #include "buffer_endpoint_registry.hpp"
 
-namespace
-{
-/// Lightweight listener for per-publisher DataReaders in buffer-aware subscriptions.
-/// Triggers the subscription's buffer guard condition so rmw_wait detects the data,
-/// and also notifies via the callback path for callback-based executors.
-class BufferDataReaderListener final : public eprosima::fastdds::dds::DataReaderListener
-{
-public:
-  BufferDataReaderListener(
-    eprosima::fastdds::dds::GuardCondition * guard,
-    RMWSubscriptionEvent * event)
-  : guard_(guard), event_(event) {}
-
-  void on_data_available(eprosima::fastdds::dds::DataReader * reader) override
-  {
-    if (guard_) {
-      guard_->set_trigger_value(true);
-    }
-    auto unread = reader->get_unread_count();
-    if (event_) {
-      event_->notify_buffer_data_available(unread > 0 ? static_cast<size_t>(unread) : 1);
-    }
-  }
-
-private:
-  eprosima::fastdds::dds::GuardCondition * guard_;
-  RMWSubscriptionEvent * event_;
-};
-}  // namespace
-
 extern "C"
 {
 rmw_ret_t
@@ -162,13 +132,18 @@ rmw_create_subscription(
 
   // Register buffer-aware publisher discovery callback
   if (info->is_buffer_aware_) {
-    auto alive = info->buffer_alive_flag_;
+    auto state = info->buffer_state_;
+    auto sub_gid = info->subscription_gid_;
+    std::string base_topic = info->topic_name_mangled_;
+    auto * guard = info->buffer_data_guard_.get();
     auto & buf_registry = rmw_fastrtps_cpp::BufferEndpointRegistry::get_instance();
     buf_registry.register_publisher_discovery_callback(
       subscription->topic_name,
       info->subscription_gid_,
-      [info, alive](const rmw_fastrtps_cpp::BufferEndpointInfo & pub_info) {
-        if (!alive->load()) {
+      [state, sub_gid, base_topic, guard](
+        const rmw_fastrtps_cpp::BufferEndpointInfo & pub_info)
+      {
+        if (!state->alive.load()) {
           return;
         }
 
@@ -184,114 +159,48 @@ rmw_create_subscription(
         };
 
         std::string pub_hex = gid_to_hex(pub_info.gid);
-        std::string sub_hex = gid_to_hex(info->subscription_gid_);
-        std::string unique_topic = info->topic_name_mangled_ +
+        std::string sub_hex = gid_to_hex(sub_gid);
+        std::string unique_topic = base_topic +
         "/_buf/" + pub_hex + "_" + sub_hex;
 
         {
-          std::lock_guard<std::mutex> lock(info->buffer_mutex_);
-          for (const auto & ep : info->buffer_endpoints_) {
+          std::lock_guard<std::mutex> lock(state->mutex);
+          if (!state->alive.load()) {
+            return;
+          }
+          for (const auto & ep : state->endpoints) {
             if (std::memcmp(ep->publisher_gid.data, pub_info.gid.data,
               RMW_GID_STORAGE_SIZE) == 0)
             {
-              RCUTILS_LOG_DEBUG_NAMED(
-                "rmw_fastrtps_cpp",
-                "Buffer subscription: publisher already known, skipping");
               return;
             }
           }
-          if (!info->pending_buffer_endpoints_.insert(unique_topic).second) {
-            return;
+          for (const auto & p : state->pending) {
+            if (p.unique_topic == unique_topic) {
+              return;
+            }
+          }
+
+          PendingBufferSubscription pending;
+          pending.unique_topic = unique_topic;
+          pending.publisher_gid = pub_info.gid;
+          pending.publisher_endpoint_info = rmw_get_zero_initialized_topic_endpoint_info();
+          pending.publisher_endpoint_info.endpoint_type = RMW_ENDPOINT_PUBLISHER;
+          std::memcpy(
+            pending.publisher_endpoint_info.endpoint_gid,
+            pub_info.gid.data, RMW_GID_STORAGE_SIZE);
+          pending.backend_metadata = pub_info.backend_metadata;
+          state->pending.push_back(std::move(pending));
+
+          if (guard) {
+            guard->set_trigger_value(true);
           }
         }
 
         RCUTILS_LOG_INFO_NAMED(
           "rmw_fastrtps_cpp",
-          "Buffer subscription: publisher discovered, computing compatibility for '%s'",
+          "Buffer subscription: publisher discovered, queued '%s'",
           unique_topic.c_str());
-
-        auto endpoint = std::make_shared<BufferSubscriptionEndpoint>();
-        endpoint->key = unique_topic;
-        endpoint->publisher_gid = pub_info.gid;
-        endpoint->backend_metadata = pub_info.backend_metadata;
-
-        endpoint->publisher_endpoint_info = rmw_get_zero_initialized_topic_endpoint_info();
-        endpoint->publisher_endpoint_info.endpoint_type = RMW_ENDPOINT_PUBLISHER;
-        std::memcpy(
-          endpoint->publisher_endpoint_info.endpoint_gid,
-          pub_info.gid.data, RMW_GID_STORAGE_SIZE);
-
-        // In single-process scenarios, the publisher may have already created
-        // this topic on the same DDS participant. Reuse it if it exists.
-        eprosima::fastdds::dds::Topic * topic = nullptr;
-        auto * existing_desc =
-        info->dds_participant_->lookup_topicdescription(unique_topic);
-        if (existing_desc) {
-          topic = dynamic_cast<eprosima::fastdds::dds::Topic *>(existing_desc);
-          if (topic) {
-            endpoint->owns_topic = false;
-          }
-        }
-        if (!topic) {
-          eprosima::fastdds::dds::TopicQos topic_qos =
-          info->dds_participant_->get_default_topic_qos();
-          topic = info->dds_participant_->create_topic(
-            unique_topic,
-            info->type_support_.get_type_name(),
-            topic_qos);
-        }
-        if (!topic) {
-          RCUTILS_LOG_ERROR_NAMED(
-            "rmw_fastrtps_cpp",
-            "Failed to create per-publisher topic '%s'", unique_topic.c_str());
-          std::lock_guard<std::mutex> lock(info->buffer_mutex_);
-          info->pending_buffer_endpoints_.erase(unique_topic);
-          return;
-        }
-        endpoint->topic = topic;
-
-        RCUTILS_LOG_INFO_NAMED(
-          "rmw_fastrtps_cpp",
-          "Buffer subscription: creating DataReader for '%s'", unique_topic.c_str());
-
-        eprosima::fastdds::dds::DataReaderQos reader_qos =
-        info->subscriber_->get_default_datareader_qos();
-        reader_qos.endpoint().history_memory_policy =
-        eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
-        reader_qos.data_sharing().off();
-        reader_qos.reliability().kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
-        reader_qos.history() = info->datareader_qos_.history();
-        constexpr auto rep = eprosima::fastdds::dds::XCDR_DATA_REPRESENTATION;
-        reader_qos.representation().clear();
-        reader_qos.representation().m_value.push_back(rep);
-
-        auto buffer_listener = std::make_shared<BufferDataReaderListener>(
-          info->buffer_data_guard_.get(), info->subscription_event_);
-        auto * data_reader = info->subscriber_->create_datareader(
-          topic, reader_qos, buffer_listener.get(),
-          eprosima::fastdds::dds::StatusMask::data_available());
-        if (!data_reader) {
-          if (endpoint->owns_topic) {
-            info->dds_participant_->delete_topic(topic);
-          }
-          RCUTILS_LOG_ERROR_NAMED(
-            "rmw_fastrtps_cpp",
-            "Failed to create per-publisher DataReader for '%s'", unique_topic.c_str());
-          std::lock_guard<std::mutex> lock(info->buffer_mutex_);
-          info->pending_buffer_endpoints_.erase(unique_topic);
-          return;
-        }
-        endpoint->data_reader = data_reader;
-        endpoint->listener = buffer_listener;
-
-        {
-          std::lock_guard<std::mutex> lock(info->buffer_mutex_);
-          info->buffer_endpoints_.push_back(endpoint);
-          info->pending_buffer_endpoints_.erase(unique_topic);
-        }
-        RCUTILS_LOG_INFO_NAMED(
-          "rmw_fastrtps_cpp",
-          "Buffer subscription: created per-pub endpoint '%s'", unique_topic.c_str());
       });
   }
 
@@ -387,17 +296,19 @@ rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription)
 
   auto info = static_cast<CustomSubscriberInfo *>(subscription->data);
   if (info && info->is_buffer_aware_) {
-    info->buffer_alive_flag_->store(false);
+    auto & state = *info->buffer_state_;
+    std::vector<std::shared_ptr<BufferSubscriptionEndpoint>> endpoints_to_destroy;
+    {
+      std::lock_guard<std::mutex> lock(state.mutex);
+      state.alive.store(false);
+      endpoints_to_destroy = std::move(state.endpoints);
+      state.endpoints.clear();
+      state.pending.clear();
+    }
 
     rmw_fastrtps_cpp::BufferEndpointRegistry::get_instance().unregister_callbacks(
       info->subscription_gid_);
 
-    std::vector<std::shared_ptr<BufferSubscriptionEndpoint>> endpoints_to_destroy;
-    {
-      std::lock_guard<std::mutex> lock(info->buffer_mutex_);
-      endpoints_to_destroy = std::move(info->buffer_endpoints_);
-      info->buffer_endpoints_.clear();
-    }
     for (auto & endpoint : endpoints_to_destroy) {
       if (endpoint->data_reader) {
         info->subscriber_->delete_datareader(endpoint->data_reader);

--- a/rmw_fastrtps_cpp/src/rmw_take.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_take.cpp
@@ -14,12 +14,111 @@
 
 #include "rmw/allocators.h"
 #include "rmw/error_handling.h"
+#include "rmw/impl/cpp/macros.hpp"
 #include "rmw/serialized_message.h"
 #include "rmw/rmw.h"
 
+#include "fastcdr/Cdr.h"
+#include "fastcdr/FastBuffer.h"
+
+#include "fastdds/dds/subscriber/SampleInfo.hpp"
+#include "fastdds/dds/core/StackAllocatedSequence.hpp"
+
+#include "rcutils/logging_macros.h"
+
+#include "rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp"
 #include "rmw_fastrtps_shared_cpp/rmw_common.hpp"
+#include "rmw_fastrtps_shared_cpp/TypeSupport.hpp"
 
 #include "rmw_fastrtps_cpp/identifier.hpp"
+
+#include "rosidl_typesupport_fastrtps_cpp/message_type_support.h"
+
+#include "rcpputils/scope_exit.hpp"
+
+namespace
+{
+
+rmw_ret_t
+take_buffer_aware(
+  const rmw_subscription_t * subscription,
+  void * ros_message,
+  bool * taken,
+  rmw_message_info_t * message_info)
+{
+  *taken = false;
+  auto info = static_cast<CustomSubscriberInfo *>(subscription->data);
+  auto callbacks = static_cast<const message_type_support_callbacks_t *>(
+    info->type_support_impl_);
+
+  std::lock_guard<std::mutex> lock(info->buffer_mutex_);
+
+  for (const auto & endpoint : info->buffer_endpoints_) {
+    // Receive raw CDR bytes -- the standard deserializeROSmessage cannot handle
+    // the buffer-aware CDR format produced by cdr_serialize_with_endpoint.
+    eprosima::fastcdr::FastBuffer receive_buffer;
+    rmw_fastrtps_shared_cpp::SerializedData data;
+    data.type = rmw_fastrtps_shared_cpp::FASTDDS_SERIALIZED_DATA_TYPE_CDR_BUFFER;
+    data.data = &receive_buffer;
+    data.impl = nullptr;
+
+    eprosima::fastdds::dds::StackAllocatedSequence<void *, 1> data_values;
+    const_cast<void **>(data_values.buffer())[0] = &data;
+    eprosima::fastdds::dds::SampleInfoSeq info_seq{1};
+
+    auto ret_code = endpoint->data_reader->take(data_values, info_seq, 1);
+    if (ret_code != eprosima::fastdds::dds::RETCODE_OK) {
+      continue;
+    }
+
+    auto reset = rcpputils::make_scope_exit(
+      [&]() {
+        data_values.length(0);
+        info_seq.length(0);
+      });
+
+    if (!info_seq[0].valid_data) {
+      continue;
+    }
+
+    eprosima::fastcdr::Cdr deser(
+      receive_buffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+      eprosima::fastcdr::CdrVersion::XCDRv1);
+    deser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+    bool deser_ok = callbacks->cdr_deserialize_with_endpoint(
+      deser, ros_message, endpoint->publisher_endpoint_info);
+
+    if (!deser_ok) {
+      RCUTILS_LOG_ERROR_NAMED(
+        "rmw_fastrtps_cpp",
+        "Buffer-aware deserialize failed for endpoint '%s'", endpoint->key.c_str());
+      continue;
+    }
+
+    *taken = true;
+    if (message_info) {
+      rmw_fastrtps_shared_cpp::_assign_message_info(
+        eprosima_fastrtps_identifier, message_info, &info_seq[0]);
+    }
+
+    // Re-arm the guard condition if any buffer endpoint still has unread
+    // data.  DDS on_data_available only fires on a status *transition*, so
+    // if we took one sample while more remain, the guard would stay false
+    // and rmw_wait would never wake up for the remaining samples.
+    for (const auto & ep : info->buffer_endpoints_) {
+      if (ep->data_reader->get_unread_count() > 0) {
+        info->buffer_data_guard_->set_trigger_value(true);
+        break;
+      }
+    }
+
+    return RMW_RET_OK;
+  }
+
+  return RMW_RET_OK;
+}
+
+}  // namespace
 
 extern "C"
 {
@@ -30,6 +129,31 @@ rmw_take(
   bool * taken,
   rmw_subscription_allocation_t * allocation)
 {
+  RMW_CHECK_FOR_NULL_WITH_MSG(
+    subscription, "subscription handle is null",
+    return RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    subscription, subscription->implementation_identifier, eprosima_fastrtps_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RMW_CHECK_FOR_NULL_WITH_MSG(
+    ros_message, "ros message handle is null",
+    return RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_FOR_NULL_WITH_MSG(
+    taken, "taken handle is null",
+    return RMW_RET_INVALID_ARGUMENT);
+
+  auto info = static_cast<CustomSubscriberInfo *>(subscription->data);
+  if (info->is_buffer_aware_) {
+    rmw_ret_t ret = take_buffer_aware(subscription, ros_message, taken, nullptr);
+    if (ret != RMW_RET_OK || *taken) {
+      return ret;
+    }
+    // No data from buffer endpoints; fall back to the main DataReader for
+    // messages published by non-buffer-aware publishers (e.g. cross-RMW).
+    return rmw_fastrtps_shared_cpp::__rmw_take(
+      eprosima_fastrtps_identifier, subscription, ros_message, taken, allocation);
+  }
+
   return rmw_fastrtps_shared_cpp::__rmw_take(
     eprosima_fastrtps_identifier, subscription, ros_message, taken, allocation);
 }
@@ -42,6 +166,23 @@ rmw_take_with_info(
   rmw_message_info_t * message_info,
   rmw_subscription_allocation_t * allocation)
 {
+  RMW_CHECK_FOR_NULL_WITH_MSG(
+    subscription, "subscription handle is null",
+    return RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    subscription, subscription->implementation_identifier, eprosima_fastrtps_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+
+  auto info = static_cast<CustomSubscriberInfo *>(subscription->data);
+  if (info->is_buffer_aware_) {
+    rmw_ret_t ret = take_buffer_aware(subscription, ros_message, taken, message_info);
+    if (ret != RMW_RET_OK || *taken) {
+      return ret;
+    }
+    return rmw_fastrtps_shared_cpp::__rmw_take_with_info(
+      eprosima_fastrtps_identifier, subscription, ros_message, taken, message_info, allocation);
+  }
+
   return rmw_fastrtps_shared_cpp::__rmw_take_with_info(
     eprosima_fastrtps_identifier, subscription, ros_message, taken, message_info, allocation);
 }

--- a/rmw_fastrtps_cpp/src/rmw_take.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_take.cpp
@@ -29,8 +29,11 @@
 
 #include "rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp"
 #include "rmw_fastrtps_shared_cpp/guid_utils.hpp"
+#include "rmw_fastrtps_shared_cpp/qos.hpp"
 #include "rmw_fastrtps_shared_cpp/rmw_common.hpp"
 #include "rmw_fastrtps_shared_cpp/TypeSupport.hpp"
+
+#include "fastdds/dds/builtin/topic/PublicationBuiltinTopicData.hpp"
 
 #include "rmw_fastrtps_cpp/identifier.hpp"
 #include "buffer_backend_context.hpp"
@@ -163,6 +166,20 @@ take_buffer_aware(
   if (message_info) {
     rmw_fastrtps_shared_cpp::_assign_message_info(
       eprosima_fastrtps_identifier, message_info, &info_seq[0]);
+
+    eprosima::fastdds::rtps::PublicationBuiltinTopicData pub_data;
+    if (eprosima::fastdds::dds::RETCODE_OK ==
+      info->accel_data_reader_->get_matched_publication_data(
+        pub_data, info_seq[0].publication_handle))
+    {
+      rmw_gid_t main_gid{};
+      auto & ud = pub_data.user_data.data_vec();
+      if (parse_endpoint_gid_from_user_data(
+            ud.data(), ud.size(), "PGID:", main_gid)) {
+        std::memcpy(
+          message_info->publisher_gid.data, main_gid.data, RMW_GID_STORAGE_SIZE);
+      }
+    }
   }
 
   if (info->accel_data_reader_->get_unread_count() > 0 && info->buffer_data_guard_) {

--- a/rmw_fastrtps_cpp/src/rmw_take.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_take.cpp
@@ -22,16 +22,13 @@
 #include "fastcdr/FastBuffer.h"
 
 #include "fastdds/dds/subscriber/SampleInfo.hpp"
-#include "fastdds/dds/subscriber/Subscriber.hpp"
 #include "fastdds/dds/core/StackAllocatedSequence.hpp"
 #include "fastdds/dds/core/condition/GuardCondition.hpp"
-#include "fastdds/dds/core/status/StatusMask.hpp"
-#include "fastdds/dds/domain/DomainParticipant.hpp"
-#include "fastdds/dds/topic/Topic.hpp"
 
 #include "rcutils/logging_macros.h"
 
 #include "rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp"
+#include "rmw_fastrtps_shared_cpp/guid_utils.hpp"
 #include "rmw_fastrtps_shared_cpp/rmw_common.hpp"
 #include "rmw_fastrtps_shared_cpp/TypeSupport.hpp"
 
@@ -45,121 +42,6 @@
 namespace
 {
 
-class BufferDataReaderListener final : public eprosima::fastdds::dds::DataReaderListener
-{
-public:
-  BufferDataReaderListener(
-    eprosima::fastdds::dds::GuardCondition * guard,
-    RMWSubscriptionEvent * event)
-  : guard_(guard), event_(event) {}
-
-  void on_data_available(eprosima::fastdds::dds::DataReader * reader) override
-  {
-    if (guard_) {
-      guard_->set_trigger_value(true);
-    }
-    auto unread = reader->get_unread_count();
-    if (event_) {
-      event_->notify_buffer_data_available(unread > 0 ? static_cast<size_t>(unread) : 1);
-    }
-  }
-
-private:
-  eprosima::fastdds::dds::GuardCondition * guard_;
-  RMWSubscriptionEvent * event_;
-};
-
-void
-create_pending_buffer_readers(CustomSubscriberInfo * info)
-{
-  auto & state = *info->buffer_state_;
-  std::vector<PendingBufferSubscription> pending;
-  {
-    std::lock_guard<std::mutex> lock(state.mutex);
-    if (state.pending.empty()) {
-      return;
-    }
-    pending = std::move(state.pending);
-    state.pending.clear();
-  }
-
-  std::vector<std::shared_ptr<BufferSubscriptionEndpoint>> new_endpoints;
-  for (auto & p : pending) {
-    auto endpoint = std::make_shared<BufferSubscriptionEndpoint>();
-    endpoint->key = p.unique_topic;
-    endpoint->publisher_gid = p.publisher_gid;
-    endpoint->publisher_endpoint_info = p.publisher_endpoint_info;
-    endpoint->backend_metadata = std::move(p.backend_metadata);
-
-    eprosima::fastdds::dds::Topic * topic = nullptr;
-    auto * existing_desc =
-      info->dds_participant_->lookup_topicdescription(p.unique_topic);
-    if (existing_desc) {
-      topic = dynamic_cast<eprosima::fastdds::dds::Topic *>(existing_desc);
-      if (topic) {
-        endpoint->owns_topic = false;
-      }
-    }
-    if (!topic) {
-      eprosima::fastdds::dds::TopicQos topic_qos = info->topic_->get_qos();
-      topic = info->dds_participant_->create_topic(
-        p.unique_topic, info->type_support_.get_type_name(), topic_qos);
-    }
-    if (!topic) {
-      RCUTILS_LOG_ERROR_NAMED(
-        "rmw_fastrtps_cpp",
-        "Failed to create per-publisher topic '%s'", p.unique_topic.c_str());
-      continue;
-    }
-    endpoint->topic = topic;
-
-    eprosima::fastdds::dds::DataReaderQos reader_qos = info->data_reader_->get_qos();
-    reader_qos.endpoint().history_memory_policy =
-      eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
-    reader_qos.data_sharing().off();
-    constexpr auto rep = eprosima::fastdds::dds::XCDR_DATA_REPRESENTATION;
-    reader_qos.representation().clear();
-    reader_qos.representation().m_value.push_back(rep);
-
-    auto buffer_listener = std::make_shared<BufferDataReaderListener>(
-      info->buffer_data_guard_.get(), info->subscription_event_);
-    auto * data_reader = info->subscriber_->create_datareader(
-      topic, reader_qos, buffer_listener.get(),
-      eprosima::fastdds::dds::StatusMask::data_available());
-    if (!data_reader) {
-      if (endpoint->owns_topic) {
-        info->dds_participant_->delete_topic(topic);
-      }
-      RCUTILS_LOG_ERROR_NAMED(
-        "rmw_fastrtps_cpp",
-        "Failed to create per-publisher DataReader for '%s'", p.unique_topic.c_str());
-      continue;
-    }
-    endpoint->data_reader = data_reader;
-    endpoint->listener = buffer_listener;
-
-    RCUTILS_LOG_INFO_NAMED(
-      "rmw_fastrtps_cpp",
-      "Buffer subscription: created per-pub endpoint '%s'", p.unique_topic.c_str());
-    RCUTILS_LOG_DEBUG_NAMED(
-      "rmw_fastrtps_cpp",
-      "Buffer subscription endpoint '%s': reliability=%d, durability=%d, history=%d depth=%d",
-      p.unique_topic.c_str(),
-      reader_qos.reliability().kind,
-      reader_qos.durability().kind,
-      reader_qos.history().kind,
-      reader_qos.history().depth);
-    new_endpoints.push_back(std::move(endpoint));
-  }
-
-  if (!new_endpoints.empty()) {
-    std::lock_guard<std::mutex> lock(state.mutex);
-    for (auto & ep : new_endpoints) {
-      state.endpoints.push_back(std::move(ep));
-    }
-  }
-}
-
 rmw_ret_t
 take_buffer_aware(
   const rmw_subscription_t * subscription,
@@ -172,9 +54,7 @@ take_buffer_aware(
   auto callbacks = static_cast<const message_type_support_callbacks_t *>(
     info->type_support_impl_);
 
-  // For CPU-only subscriptions, try the shared CPU channel DataReader first.
-  // The message was serialized with standard type-support serialization (ROS_MESSAGE),
-  // so we use the normal take path via the standard FastDDS deserialization.
+  // CPU-only path: take from the shared CPU channel DataReader.
   if (info->cpu_data_reader_) {
     rmw_fastrtps_shared_cpp::SerializedData cpu_recv_data;
     cpu_recv_data.type = rmw_fastrtps_shared_cpp::FASTDDS_SERIALIZED_DATA_TYPE_ROS_MESSAGE;
@@ -195,7 +75,6 @@ take_buffer_aware(
       cpu_vals.length(0);
       cpu_info_seq.length(0);
 
-      // Re-arm guard if more data remains on the CPU channel.
       if (info->cpu_data_reader_->get_unread_count() > 0 && info->buffer_data_guard_) {
         info->buffer_data_guard_->set_trigger_value(true);
       }
@@ -205,84 +84,89 @@ take_buffer_aware(
     cpu_info_seq.length(0);
   }
 
-  // For non-CPU-only subscriptions, try per-publisher peer-to-peer endpoints.
-  create_pending_buffer_readers(info);
-
-  auto & state = *info->buffer_state_;
-  std::lock_guard<std::mutex> lock(state.mutex);
-
-  for (const auto & endpoint : state.endpoints) {
-    eprosima::fastcdr::FastBuffer receive_buffer;
-    rmw_fastrtps_shared_cpp::SerializedData data;
-    data.type = rmw_fastrtps_shared_cpp::FASTDDS_SERIALIZED_DATA_TYPE_CDR_BUFFER;
-    data.data = &receive_buffer;
-    data.impl = nullptr;
-
-    eprosima::fastdds::dds::StackAllocatedSequence<void *, 1> data_values;
-    const_cast<void **>(data_values.buffer())[0] = &data;
-    eprosima::fastdds::dds::SampleInfoSeq info_seq{1};
-
-    auto ret_code = endpoint->data_reader->take(data_values, info_seq, 1);
-    if (ret_code != eprosima::fastdds::dds::RETCODE_OK) {
-      continue;
-    }
-
-    auto reset = rcpputils::make_scope_exit(
-      [&]() {
-        data_values.length(0);
-        info_seq.length(0);
-      });
-
-    if (!info_seq[0].valid_data) {
-      continue;
-    }
-
-    eprosima::fastcdr::Cdr deser(
-      receive_buffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
-      eprosima::fastcdr::CdrVersion::XCDRv1);
-    deser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
-    auto * backend_context =
-      static_cast<const rmw_fastrtps_cpp::BufferBackendContext *>(info->serialization_context_);
-    if (!backend_context) {
-      RCUTILS_LOG_ERROR_NAMED(
-        "rmw_fastrtps_cpp",
-        "Buffer-aware deserialize missing buffer backend context");
-      continue;
-    }
-    bool deser_ok = false;
-    try {
-      deser_ok = callbacks->cdr_deserialize_with_endpoint(
-        deser, ros_message, endpoint->publisher_endpoint_info,
-        backend_context->serialization_context);
-    } catch (const std::exception & e) {
-      RCUTILS_LOG_ERROR_NAMED(
-        "rmw_fastrtps_cpp",
-        "Buffer-aware deserialize threw for endpoint '%s': %s",
-        endpoint->key.c_str(), e.what());
-    }
-
-    if (!deser_ok) {
-      RCUTILS_LOG_ERROR_NAMED(
-        "rmw_fastrtps_cpp",
-        "Buffer-aware deserialize failed for endpoint '%s'", endpoint->key.c_str());
-      continue;
-    }
-
-    *taken = true;
-    if (message_info) {
-      rmw_fastrtps_shared_cpp::_assign_message_info(
-        eprosima_fastrtps_identifier, message_info, &info_seq[0]);
-    }
-
-    // Re-arm guard if more data remains on any buffer endpoint.
-    for (const auto & ep : state.endpoints) {
-      if (ep->data_reader->get_unread_count() > 0) {
-        info->buffer_data_guard_->set_trigger_value(true);
-        break;
-      }
-    }
-
+  // Accelerated path: single shared DataReader for all buffer-aware publishers.
+  if (!info->accel_data_reader_) {
     return RMW_RET_OK;
+  }
+
+  eprosima::fastcdr::FastBuffer receive_buffer;
+  rmw_fastrtps_shared_cpp::SerializedData data;
+  data.type = rmw_fastrtps_shared_cpp::FASTDDS_SERIALIZED_DATA_TYPE_CDR_BUFFER;
+  data.data = &receive_buffer;
+  data.impl = nullptr;
+
+  eprosima::fastdds::dds::StackAllocatedSequence<void *, 1> data_values;
+  const_cast<void **>(data_values.buffer())[0] = &data;
+  eprosima::fastdds::dds::SampleInfoSeq info_seq{1};
+
+  auto ret_code = info->accel_data_reader_->take(data_values, info_seq, 1);
+  if (ret_code != eprosima::fastdds::dds::RETCODE_OK) {
+    return RMW_RET_OK;
+  }
+
+  auto reset = rcpputils::make_scope_exit(
+    [&]() {
+      data_values.length(0);
+      info_seq.length(0);
+    });
+
+  if (!info_seq[0].valid_data) {
+    return RMW_RET_OK;
+  }
+
+  // Look up publisher metadata by writer GID.
+  rmw_gid_t writer_gid{};
+  rmw_fastrtps_shared_cpp::copy_from_fastdds_guid_to_byte_array(
+    info_seq[0].sample_identity.writer_guid(),
+    writer_gid.data);
+  std::string writer_hex = rmw_fastrtps_shared_cpp::gid_to_hex(writer_gid);
+
+  rmw_topic_endpoint_info_t pub_endpoint_info = rmw_get_zero_initialized_topic_endpoint_info();
+  pub_endpoint_info.endpoint_type = RMW_ENDPOINT_PUBLISHER;
+  std::memcpy(pub_endpoint_info.endpoint_gid, writer_gid.data, RMW_GID_STORAGE_SIZE);
+
+  {
+    std::lock_guard<std::mutex> lock(info->buffer_state_->mutex);
+    auto it = info->buffer_state_->publisher_metadata.find(writer_hex);
+    if (it != info->buffer_state_->publisher_metadata.end()) {
+      pub_endpoint_info = it->second.publisher_endpoint_info;
+    }
+  }
+
+  eprosima::fastcdr::Cdr deser(
+    receive_buffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+    eprosima::fastcdr::CdrVersion::XCDRv1);
+  deser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+  auto * backend_context =
+    static_cast<const rmw_fastrtps_cpp::BufferBackendContext *>(info->serialization_context_);
+  if (!backend_context) {
+    RCUTILS_LOG_ERROR_NAMED(
+      "rmw_fastrtps_cpp",
+      "Buffer-aware deserialize missing buffer backend context");
+    return RMW_RET_OK;
+  }
+
+  bool deser_ok = false;
+  deser_ok = callbacks->cdr_deserialize_with_endpoint(
+    deser, ros_message, pub_endpoint_info,
+    backend_context->serialization_context);
+
+  if (!deser_ok) {
+    RCUTILS_LOG_ERROR_NAMED(
+      "rmw_fastrtps_cpp",
+      "Buffer-aware deserialize failed for publisher '%s'", writer_hex.c_str());
+    return RMW_RET_OK;
+  }
+
+  *taken = true;
+  if (message_info) {
+    rmw_fastrtps_shared_cpp::_assign_message_info(
+      eprosima_fastrtps_identifier, message_info, &info_seq[0]);
+  }
+
+  if (info->accel_data_reader_->get_unread_count() > 0 && info->buffer_data_guard_) {
+    info->buffer_data_guard_->set_trigger_value(true);
   }
 
   return RMW_RET_OK;

--- a/rmw_fastrtps_cpp/src/rmw_take.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_take.cpp
@@ -114,13 +114,10 @@ create_pending_buffer_readers(CustomSubscriberInfo * info)
     }
     endpoint->topic = topic;
 
-    eprosima::fastdds::dds::DataReaderQos reader_qos =
-      info->subscriber_->get_default_datareader_qos();
+    eprosima::fastdds::dds::DataReaderQos reader_qos = info->data_reader_->get_qos();
     reader_qos.endpoint().history_memory_policy =
       eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
     reader_qos.data_sharing().off();
-    reader_qos.reliability().kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
-    reader_qos.history() = info->datareader_qos_.history();
     constexpr auto rep = eprosima::fastdds::dds::XCDR_DATA_REPRESENTATION;
     reader_qos.representation().clear();
     reader_qos.representation().m_value.push_back(rep);

--- a/rmw_fastrtps_cpp/src/rmw_take.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_take.cpp
@@ -36,6 +36,7 @@
 #include "rmw_fastrtps_shared_cpp/TypeSupport.hpp"
 
 #include "rmw_fastrtps_cpp/identifier.hpp"
+#include "buffer_backend_context.hpp"
 
 #include "rosidl_typesupport_fastrtps_cpp/message_type_support.h"
 
@@ -202,8 +203,25 @@ take_buffer_aware(
       receive_buffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
       eprosima::fastcdr::CdrVersion::XCDRv1);
     deser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
-    bool deser_ok = callbacks->cdr_deserialize_with_endpoint(
-      deser, ros_message, endpoint->publisher_endpoint_info);
+    auto * backend_context =
+      static_cast<const rmw_fastrtps_cpp::BufferBackendContext *>(info->serialization_context_);
+    if (!backend_context) {
+      RCUTILS_LOG_ERROR_NAMED(
+        "rmw_fastrtps_cpp",
+        "Buffer-aware deserialize missing buffer backend context");
+      continue;
+    }
+    bool deser_ok = false;
+    try {
+      deser_ok = callbacks->cdr_deserialize_with_endpoint(
+        deser, ros_message, endpoint->publisher_endpoint_info,
+        backend_context->serialization_context);
+    } catch (const std::exception & e) {
+      RCUTILS_LOG_ERROR_NAMED(
+        "rmw_fastrtps_cpp",
+        "Buffer-aware deserialize threw for endpoint '%s': %s",
+        endpoint->key.c_str(), e.what());
+    }
 
     if (!deser_ok) {
       RCUTILS_LOG_ERROR_NAMED(

--- a/rmw_fastrtps_cpp/src/rmw_take.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_take.cpp
@@ -168,6 +168,40 @@ take_buffer_aware(
   auto callbacks = static_cast<const message_type_support_callbacks_t *>(
     info->type_support_impl_);
 
+  // For CPU-only subscriptions, try the shared CPU channel DataReader first.
+  // The message was serialized with standard type-support serialization (ROS_MESSAGE),
+  // so we use the normal take path via the standard FastDDS deserialization.
+  if (info->cpu_data_reader_) {
+    rmw_fastrtps_shared_cpp::SerializedData cpu_recv_data;
+    cpu_recv_data.type = rmw_fastrtps_shared_cpp::FASTDDS_SERIALIZED_DATA_TYPE_ROS_MESSAGE;
+    cpu_recv_data.data = ros_message;
+    cpu_recv_data.impl = info->type_support_impl_;
+
+    eprosima::fastdds::dds::StackAllocatedSequence<void *, 1> cpu_vals;
+    const_cast<void **>(cpu_vals.buffer())[0] = &cpu_recv_data;
+    eprosima::fastdds::dds::SampleInfoSeq cpu_info_seq{1};
+
+    auto cpu_ret = info->cpu_data_reader_->take(cpu_vals, cpu_info_seq, 1);
+    if (cpu_ret == eprosima::fastdds::dds::RETCODE_OK && cpu_info_seq[0].valid_data) {
+      *taken = true;
+      if (message_info) {
+        rmw_fastrtps_shared_cpp::_assign_message_info(
+          eprosima_fastrtps_identifier, message_info, &cpu_info_seq[0]);
+      }
+      cpu_vals.length(0);
+      cpu_info_seq.length(0);
+
+      // Re-arm guard if more data remains on the CPU channel.
+      if (info->cpu_data_reader_->get_unread_count() > 0 && info->buffer_data_guard_) {
+        info->buffer_data_guard_->set_trigger_value(true);
+      }
+      return RMW_RET_OK;
+    }
+    cpu_vals.length(0);
+    cpu_info_seq.length(0);
+  }
+
+  // For non-CPU-only subscriptions, try per-publisher peer-to-peer endpoints.
   create_pending_buffer_readers(info);
 
   auto & state = *info->buffer_state_;
@@ -236,6 +270,7 @@ take_buffer_aware(
         eprosima_fastrtps_identifier, message_info, &info_seq[0]);
     }
 
+    // Re-arm guard if more data remains on any buffer endpoint.
     for (const auto & ep : state.endpoints) {
       if (ep->data_reader->get_unread_count() > 0) {
         info->buffer_data_guard_->set_trigger_value(true);

--- a/rmw_fastrtps_cpp/src/rmw_take.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_take.cpp
@@ -101,8 +101,7 @@ create_pending_buffer_readers(CustomSubscriberInfo * info)
       }
     }
     if (!topic) {
-      eprosima::fastdds::dds::TopicQos topic_qos =
-        info->dds_participant_->get_default_topic_qos();
+      eprosima::fastdds::dds::TopicQos topic_qos = info->topic_->get_qos();
       topic = info->dds_participant_->create_topic(
         p.unique_topic, info->type_support_.get_type_name(), topic_qos);
     }
@@ -142,6 +141,14 @@ create_pending_buffer_readers(CustomSubscriberInfo * info)
     RCUTILS_LOG_INFO_NAMED(
       "rmw_fastrtps_cpp",
       "Buffer subscription: created per-pub endpoint '%s'", p.unique_topic.c_str());
+    RCUTILS_LOG_DEBUG_NAMED(
+      "rmw_fastrtps_cpp",
+      "Buffer subscription endpoint '%s': reliability=%d, durability=%d, history=%d depth=%d",
+      p.unique_topic.c_str(),
+      reader_qos.reliability().kind,
+      reader_qos.durability().kind,
+      reader_qos.history().kind,
+      reader_qos.history().depth);
     new_endpoints.push_back(std::move(endpoint));
   }
 

--- a/rmw_fastrtps_cpp/src/rmw_take.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_take.cpp
@@ -175,7 +175,8 @@ take_buffer_aware(
       rmw_gid_t main_gid{};
       auto & ud = pub_data.user_data.data_vec();
       if (parse_endpoint_gid_from_user_data(
-            ud.data(), ud.size(), "PGID:", main_gid)) {
+            ud.data(), ud.size(), "PGID:", main_gid))
+      {
         std::memcpy(
           message_info->publisher_gid.data, main_gid.data, RMW_GID_STORAGE_SIZE);
       }

--- a/rmw_fastrtps_cpp/src/rmw_take.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_take.cpp
@@ -22,7 +22,12 @@
 #include "fastcdr/FastBuffer.h"
 
 #include "fastdds/dds/subscriber/SampleInfo.hpp"
+#include "fastdds/dds/subscriber/Subscriber.hpp"
 #include "fastdds/dds/core/StackAllocatedSequence.hpp"
+#include "fastdds/dds/core/condition/GuardCondition.hpp"
+#include "fastdds/dds/core/status/StatusMask.hpp"
+#include "fastdds/dds/domain/DomainParticipant.hpp"
+#include "fastdds/dds/topic/Topic.hpp"
 
 #include "rcutils/logging_macros.h"
 
@@ -39,6 +44,117 @@
 namespace
 {
 
+class BufferDataReaderListener final : public eprosima::fastdds::dds::DataReaderListener
+{
+public:
+  BufferDataReaderListener(
+    eprosima::fastdds::dds::GuardCondition * guard,
+    RMWSubscriptionEvent * event)
+  : guard_(guard), event_(event) {}
+
+  void on_data_available(eprosima::fastdds::dds::DataReader * reader) override
+  {
+    if (guard_) {
+      guard_->set_trigger_value(true);
+    }
+    auto unread = reader->get_unread_count();
+    if (event_) {
+      event_->notify_buffer_data_available(unread > 0 ? static_cast<size_t>(unread) : 1);
+    }
+  }
+
+private:
+  eprosima::fastdds::dds::GuardCondition * guard_;
+  RMWSubscriptionEvent * event_;
+};
+
+void
+create_pending_buffer_readers(CustomSubscriberInfo * info)
+{
+  auto & state = *info->buffer_state_;
+  std::vector<PendingBufferSubscription> pending;
+  {
+    std::lock_guard<std::mutex> lock(state.mutex);
+    if (state.pending.empty()) {
+      return;
+    }
+    pending = std::move(state.pending);
+    state.pending.clear();
+  }
+
+  std::vector<std::shared_ptr<BufferSubscriptionEndpoint>> new_endpoints;
+  for (auto & p : pending) {
+    auto endpoint = std::make_shared<BufferSubscriptionEndpoint>();
+    endpoint->key = p.unique_topic;
+    endpoint->publisher_gid = p.publisher_gid;
+    endpoint->publisher_endpoint_info = p.publisher_endpoint_info;
+    endpoint->backend_metadata = std::move(p.backend_metadata);
+
+    eprosima::fastdds::dds::Topic * topic = nullptr;
+    auto * existing_desc =
+      info->dds_participant_->lookup_topicdescription(p.unique_topic);
+    if (existing_desc) {
+      topic = dynamic_cast<eprosima::fastdds::dds::Topic *>(existing_desc);
+      if (topic) {
+        endpoint->owns_topic = false;
+      }
+    }
+    if (!topic) {
+      eprosima::fastdds::dds::TopicQos topic_qos =
+        info->dds_participant_->get_default_topic_qos();
+      topic = info->dds_participant_->create_topic(
+        p.unique_topic, info->type_support_.get_type_name(), topic_qos);
+    }
+    if (!topic) {
+      RCUTILS_LOG_ERROR_NAMED(
+        "rmw_fastrtps_cpp",
+        "Failed to create per-publisher topic '%s'", p.unique_topic.c_str());
+      continue;
+    }
+    endpoint->topic = topic;
+
+    eprosima::fastdds::dds::DataReaderQos reader_qos =
+      info->subscriber_->get_default_datareader_qos();
+    reader_qos.endpoint().history_memory_policy =
+      eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+    reader_qos.data_sharing().off();
+    reader_qos.reliability().kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
+    reader_qos.history() = info->datareader_qos_.history();
+    constexpr auto rep = eprosima::fastdds::dds::XCDR_DATA_REPRESENTATION;
+    reader_qos.representation().clear();
+    reader_qos.representation().m_value.push_back(rep);
+
+    auto buffer_listener = std::make_shared<BufferDataReaderListener>(
+      info->buffer_data_guard_.get(), info->subscription_event_);
+    auto * data_reader = info->subscriber_->create_datareader(
+      topic, reader_qos, buffer_listener.get(),
+      eprosima::fastdds::dds::StatusMask::data_available());
+    if (!data_reader) {
+      if (endpoint->owns_topic) {
+        info->dds_participant_->delete_topic(topic);
+      }
+      RCUTILS_LOG_ERROR_NAMED(
+        "rmw_fastrtps_cpp",
+        "Failed to create per-publisher DataReader for '%s'", p.unique_topic.c_str());
+      continue;
+    }
+    endpoint->data_reader = data_reader;
+    endpoint->listener = buffer_listener;
+
+    RCUTILS_LOG_INFO_NAMED(
+      "rmw_fastrtps_cpp",
+      "Buffer subscription: created per-pub endpoint '%s'", p.unique_topic.c_str());
+    new_endpoints.push_back(std::move(endpoint));
+  }
+
+  if (!new_endpoints.empty()) {
+    std::lock_guard<std::mutex> lock(state.mutex);
+    for (auto & ep : new_endpoints) {
+      state.endpoints.push_back(std::move(ep));
+    }
+  }
+}
+
 rmw_ret_t
 take_buffer_aware(
   const rmw_subscription_t * subscription,
@@ -51,11 +167,12 @@ take_buffer_aware(
   auto callbacks = static_cast<const message_type_support_callbacks_t *>(
     info->type_support_impl_);
 
-  std::lock_guard<std::mutex> lock(info->buffer_mutex_);
+  create_pending_buffer_readers(info);
 
-  for (const auto & endpoint : info->buffer_endpoints_) {
-    // Receive raw CDR bytes -- the standard deserializeROSmessage cannot handle
-    // the buffer-aware CDR format produced by cdr_serialize_with_endpoint.
+  auto & state = *info->buffer_state_;
+  std::lock_guard<std::mutex> lock(state.mutex);
+
+  for (const auto & endpoint : state.endpoints) {
     eprosima::fastcdr::FastBuffer receive_buffer;
     rmw_fastrtps_shared_cpp::SerializedData data;
     data.type = rmw_fastrtps_shared_cpp::FASTDDS_SERIALIZED_DATA_TYPE_CDR_BUFFER;
@@ -101,11 +218,7 @@ take_buffer_aware(
         eprosima_fastrtps_identifier, message_info, &info_seq[0]);
     }
 
-    // Re-arm the guard condition if any buffer endpoint still has unread
-    // data.  DDS on_data_available only fires on a status *transition*, so
-    // if we took one sample while more remain, the guard would stay false
-    // and rmw_wait would never wake up for the remaining samples.
-    for (const auto & ep : info->buffer_endpoints_) {
+    for (const auto & ep : state.endpoints) {
       if (ep->data_reader->get_unread_count() > 0) {
         info->buffer_data_guard_->set_trigger_value(true);
         break;

--- a/rmw_fastrtps_cpp/src/subscription.cpp
+++ b/rmw_fastrtps_cpp/src/subscription.cpp
@@ -34,6 +34,7 @@
 
 #include "rcutils/allocator.h"
 #include "rcutils/error_handling.h"
+#include "rcutils/logging_macros.h"
 #include "rcutils/macros.h"
 #include "rcutils/strdup.h"
 #include "rosidl_dynamic_typesupport/dynamic_message_type_support_struct.h"
@@ -901,6 +902,11 @@ __create_subscription(
       rosidl_buffer_backend_registry::notify_endpoint_created(
         backend_context->backend_instances, info->local_endpoint_info_);
     }
+
+    RCUTILS_LOG_DEBUG_NAMED(
+      "rmw_fastrtps_cpp",
+      "Created buffer-aware subscription on '%s' (mode: %s)",
+      topic_name, cpu_only ? "cpu-only" : "accelerated");
   }
 
   cleanup_rmw_subscription.cancel();

--- a/rmw_fastrtps_cpp/src/subscription.cpp
+++ b/rmw_fastrtps_cpp/src/subscription.cpp
@@ -19,6 +19,7 @@
 #include <utility>
 #include <vector>
 
+#include "fastdds/dds/core/condition/GuardCondition.hpp"
 #include "fastdds/dds/domain/DomainParticipant.hpp"
 #include "fastdds/dds/subscriber/Subscriber.hpp"
 #include "fastdds/dds/subscriber/qos/DataReaderQos.hpp"
@@ -66,6 +67,35 @@
 #include "type_support_common.hpp"
 
 using PropertyPolicyHelper = eprosima::fastdds::rtps::PropertyPolicyHelper;
+
+namespace
+{
+
+class CpuChannelDataReaderListener final : public eprosima::fastdds::dds::DataReaderListener
+{
+public:
+  CpuChannelDataReaderListener(
+    eprosima::fastdds::dds::GuardCondition * guard,
+    RMWSubscriptionEvent * event)
+  : guard_(guard), event_(event) {}
+
+  void on_data_available(eprosima::fastdds::dds::DataReader * reader) override
+  {
+    if (guard_) {
+      guard_->set_trigger_value(true);
+    }
+    auto unread = reader->get_unread_count();
+    if (event_) {
+      event_->notify_buffer_data_available(unread > 0 ? static_cast<size_t>(unread) : 1);
+    }
+  }
+
+private:
+  eprosima::fastdds::dds::GuardCondition * guard_;
+  RMWSubscriptionEvent * event_;
+};
+
+}  // namespace
 
 namespace rmw_fastrtps_cpp
 {
@@ -666,6 +696,7 @@ __create_subscription(
   bool has_buffer_fields = callbacks->has_buffer_fields;
   std::unordered_map<std::string, std::string> filtered_backends;
   std::vector<std::string> my_backend_types;
+  bool cpu_only = false;
 
   if (has_buffer_fields) {
     std::unordered_map<std::string, std::string> all_backends;
@@ -711,7 +742,7 @@ __create_subscription(
     }
 
     // NULL, empty, or only "cpu" entries: CPU-only (backward compat default)
-    bool cpu_only = !use_all && (requested_list.empty() ||
+    cpu_only = !use_all && (requested_list.empty() ||
       std::all_of(requested_list.begin(), requested_list.end(),
       [](const std::string & n) {return n == "cpu";}));
 
@@ -819,6 +850,7 @@ __create_subscription(
 
   // Buffer-aware subscription setup
   info->is_buffer_aware_ = has_buffer_fields;
+  info->is_cpu_only_ = has_buffer_fields && cpu_only;
   if (has_buffer_fields) {
     info->serialization_context_ = participant_info->buffer_serialization_context_;
     info->my_backend_types_ = std::move(my_backend_types);
@@ -830,6 +862,44 @@ __create_subscription(
 
     info->buffer_data_guard_ =
       std::make_unique<eprosima::fastdds::dds::GuardCondition>();
+
+    // For CPU-only subscriptions, create a DataReader on the shared CPU channel.
+    // This allows publishers to write once for all CPU-only subscribers.
+    if (cpu_only) {
+      std::string cpu_topic_name = topic_name_mangled + "/_buf_cpu";
+      auto * existing_desc = dds_participant->lookup_topicdescription(cpu_topic_name);
+      if (existing_desc) {
+        info->cpu_topic_ = dynamic_cast<eprosima::fastdds::dds::Topic *>(existing_desc);
+      }
+      if (!info->cpu_topic_) {
+        eprosima::fastdds::dds::TopicQos cpu_tqos = dds_participant->get_default_topic_qos();
+        if (!get_topic_qos(*qos_policies, cpu_tqos)) {
+          RMW_SET_ERROR_MSG("create_subscription() failed setting CPU channel topic QoS");
+          return nullptr;
+        }
+        info->cpu_topic_ = dds_participant->create_topic(
+          cpu_topic_name, type_name, cpu_tqos);
+      }
+      if (!info->cpu_topic_) {
+        RMW_SET_ERROR_MSG("create_subscription() failed to create CPU channel topic");
+        return nullptr;
+      }
+
+      eprosima::fastdds::dds::DataReaderQos cpu_rqos = info->datareader_qos_;
+      info->cpu_data_reader_listener_ =
+        std::make_shared<CpuChannelDataReaderListener>(
+        info->buffer_data_guard_.get(), info->subscription_event_);
+      info->cpu_data_reader_ = subscriber->create_datareader(
+        info->cpu_topic_, cpu_rqos, info->cpu_data_reader_listener_.get(),
+        eprosima::fastdds::dds::StatusMask::data_available());
+      if (!info->cpu_data_reader_) {
+        info->cpu_data_reader_listener_.reset();
+        dds_participant->delete_topic(info->cpu_topic_);
+        info->cpu_topic_ = nullptr;
+        RMW_SET_ERROR_MSG("create_subscription() failed to create CPU channel DataReader");
+        return nullptr;
+      }
+    }
 
     auto * backend_context =
       static_cast<const rmw_fastrtps_cpp::BufferBackendContext *>(

--- a/rmw_fastrtps_cpp/src/subscription.cpp
+++ b/rmw_fastrtps_cpp/src/subscription.cpp
@@ -50,6 +50,7 @@
 
 #include "rmw_fastrtps_shared_cpp/custom_participant_info.hpp"
 #include "rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp"
+#include "rmw_fastrtps_shared_cpp/guid_utils.hpp"
 #include "rmw_fastrtps_shared_cpp/names.hpp"
 #include "rmw_fastrtps_shared_cpp/namespace_prefix.hpp"
 #include "rmw_fastrtps_shared_cpp/qos.hpp"
@@ -857,9 +858,8 @@ __create_subscription(
     info->buffer_data_guard_ =
       std::make_unique<eprosima::fastdds::dds::GuardCondition>();
 
-    // For CPU-only subscriptions, create a DataReader on the shared CPU channel.
-    // This allows publishers to write once for all CPU-only subscribers.
     if (cpu_only) {
+      // CPU-only: create a DataReader on the shared CPU channel.
       std::string cpu_topic_name = topic_name_mangled + "/_buf_cpu";
       auto * existing_desc = dds_participant->lookup_topicdescription(cpu_topic_name);
       if (existing_desc) {
@@ -891,6 +891,40 @@ __create_subscription(
         dds_participant->delete_topic(info->cpu_topic_);
         info->cpu_topic_ = nullptr;
         RMW_SET_ERROR_MSG("create_subscription() failed to create CPU channel DataReader");
+        return nullptr;
+      }
+    } else {
+      // Accelerated: single shared DataReader for all buffer-aware publishers.
+      std::string sub_hex = rmw_fastrtps_shared_cpp::gid_to_hex(info->subscription_gid_);
+      std::string accel_topic_name = topic_name_mangled + "/_buf/" + sub_hex;
+
+      eprosima::fastdds::dds::TopicQos accel_tqos = info->topic_->get_qos();
+      info->accel_topic_ = dds_participant->create_topic(
+        accel_topic_name, type_name, accel_tqos);
+      if (!info->accel_topic_) {
+        RMW_SET_ERROR_MSG("create_subscription() failed to create accelerated channel topic");
+        return nullptr;
+      }
+
+      eprosima::fastdds::dds::DataReaderQos accel_rqos = info->datareader_qos_;
+      accel_rqos.endpoint().history_memory_policy =
+        eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+      accel_rqos.data_sharing().off();
+      constexpr auto rep = eprosima::fastdds::dds::XCDR_DATA_REPRESENTATION;
+      accel_rqos.representation().clear();
+      accel_rqos.representation().m_value.push_back(rep);
+
+      info->accel_data_reader_listener_ =
+        std::make_shared<CpuChannelDataReaderListener>(
+        info->buffer_data_guard_.get(), info->subscription_event_);
+      info->accel_data_reader_ = subscriber->create_datareader(
+        info->accel_topic_, accel_rqos, info->accel_data_reader_listener_.get(),
+        eprosima::fastdds::dds::StatusMask::data_available());
+      if (!info->accel_data_reader_) {
+        info->accel_data_reader_listener_.reset();
+        dds_participant->delete_topic(info->accel_topic_);
+        info->accel_topic_ = nullptr;
+        RMW_SET_ERROR_MSG("create_subscription() failed to create accelerated channel DataReader");
         return nullptr;
       }
     }

--- a/rmw_fastrtps_cpp/src/subscription.cpp
+++ b/rmw_fastrtps_cpp/src/subscription.cpp
@@ -45,6 +45,7 @@
 #include "rmw/validate_full_topic_name.h"
 
 #include "rcpputils/scope_exit.hpp"
+#include "rcpputils/split.hpp"
 
 #include "rmw_fastrtps_shared_cpp/custom_participant_info.hpp"
 #include "rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp"
@@ -713,22 +714,14 @@ __create_subscription(
     if (subscription_options->acceptable_buffer_backends &&
       strlen(subscription_options->acceptable_buffer_backends) > 0)
     {
-      std::string acceptable(subscription_options->acceptable_buffer_backends);
-      size_t start = 0;
-      while (start < acceptable.size()) {
-        size_t end = acceptable.find(',', start);
-        std::string token = acceptable.substr(
-          start, end == std::string::npos ? std::string::npos : end - start);
+      auto tokens = rcpputils::split(
+        subscription_options->acceptable_buffer_backends, ',', true);
+      for (auto & token : tokens) {
         auto begin_it = token.find_first_not_of(" \t");
         auto end_it = token.find_last_not_of(" \t");
         if (begin_it != std::string::npos) {
-          token = token.substr(begin_it, end_it - begin_it + 1);
+          requested_list.push_back(token.substr(begin_it, end_it - begin_it + 1));
         }
-        if (!token.empty()) {
-          requested_list.push_back(token);
-        }
-        if (end == std::string::npos) {break;}
-        start = end + 1;
       }
     }
 

--- a/rmw_fastrtps_cpp/src/subscription.cpp
+++ b/rmw_fastrtps_cpp/src/subscription.cpp
@@ -668,7 +668,8 @@ __create_subscription(
 
   if (has_buffer_fields) {
     auto all_backends =
-      rosidl_buffer_backend_registry::BufferBackendRegistry::get_instance().get_all_backend_metadata();
+      rosidl_buffer_backend_registry::BufferBackendRegistry::get_instance()
+      .get_all_backend_metadata();
 
     // Parse acceptable_buffer_backends option (comma-separated) to filter
     std::vector<std::string> requested_list;

--- a/rmw_fastrtps_cpp/src/subscription.cpp
+++ b/rmw_fastrtps_cpp/src/subscription.cpp
@@ -57,7 +57,8 @@
 #include "rmw_fastrtps_cpp/identifier.hpp"
 #include "rmw_fastrtps_cpp/subscription.hpp"
 
-#include "rosidl_buffer_backend_registry/buffer_backend_registry.hpp"
+#include "buffer_backend_context.hpp"
+#include "rosidl_buffer_backend_registry/backend_utils.hpp"
 #include "rosidl_typesupport_fastrtps_cpp/message_type_support.h"
 
 #include "tracetools/tracetools.h"
@@ -667,9 +668,14 @@ __create_subscription(
   std::vector<std::string> my_backend_types;
 
   if (has_buffer_fields) {
-    auto all_backends =
-      rosidl_buffer_backend_registry::BufferBackendRegistry::get_instance()
-      .get_all_backend_metadata();
+    std::unordered_map<std::string, std::string> all_backends;
+    auto * backend_context =
+      static_cast<rmw_fastrtps_cpp::BufferBackendContext *>(
+      participant_info->buffer_serialization_context_);
+    if (backend_context) {
+      all_backends = rosidl_buffer_backend_registry::get_all_backend_metadata(
+        backend_context->backend_instances);
+    }
 
     // Parse acceptable_buffer_backends option (comma-separated) to filter
     std::vector<std::string> requested_list;
@@ -814,6 +820,7 @@ __create_subscription(
   // Buffer-aware subscription setup
   info->is_buffer_aware_ = has_buffer_fields;
   if (has_buffer_fields) {
+    info->serialization_context_ = participant_info->buffer_serialization_context_;
     info->my_backend_types_ = std::move(my_backend_types);
     info->local_endpoint_info_ = rmw_get_zero_initialized_topic_endpoint_info();
     info->local_endpoint_info_.endpoint_type = RMW_ENDPOINT_SUBSCRIPTION;
@@ -824,8 +831,13 @@ __create_subscription(
     info->buffer_data_guard_ =
       std::make_unique<eprosima::fastdds::dds::GuardCondition>();
 
-    rosidl_buffer_backend_registry::BufferBackendRegistry::get_instance().notify_endpoint_created(
-      info->local_endpoint_info_);
+    auto * backend_context =
+      static_cast<const rmw_fastrtps_cpp::BufferBackendContext *>(
+      info->serialization_context_);
+    if (backend_context) {
+      rosidl_buffer_backend_registry::notify_endpoint_created(
+        backend_context->backend_instances, info->local_endpoint_info_);
+    }
   }
 
   cleanup_rmw_subscription.cancel();

--- a/rmw_fastrtps_cpp/src/subscription.cpp
+++ b/rmw_fastrtps_cpp/src/subscription.cpp
@@ -14,8 +14,10 @@
 
 #include <rosidl_dynamic_typesupport/identifier.h>
 
+#include <algorithm>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "fastdds/dds/domain/DomainParticipant.hpp"
 #include "fastdds/dds/subscriber/Subscriber.hpp"
@@ -54,6 +56,9 @@
 
 #include "rmw_fastrtps_cpp/identifier.hpp"
 #include "rmw_fastrtps_cpp/subscription.hpp"
+
+#include "rosidl_buffer_backend_registry/buffer_backend_registry.hpp"
+#include "rosidl_typesupport_fastrtps_cpp/message_type_support.h"
 
 #include "tracetools/tracetools.h"
 
@@ -656,9 +661,82 @@ __create_subscription(
     reader_qos.data_sharing().off();
   }
 
+  // Detect buffer-aware message type
+  bool has_buffer_fields = callbacks->has_buffer_fields;
+  std::unordered_map<std::string, std::string> filtered_backends;
+  std::vector<std::string> my_backend_types;
+
+  if (has_buffer_fields) {
+    auto all_backends =
+      rosidl_buffer_backend_registry::BufferBackendRegistry::get_instance().get_all_aux_info();
+
+    // Parse acceptable_buffer_backends option (comma-separated) to filter
+    std::vector<std::string> requested_list;
+    if (subscription_options->acceptable_buffer_backends &&
+      strlen(subscription_options->acceptable_buffer_backends) > 0)
+    {
+      std::string acceptable(subscription_options->acceptable_buffer_backends);
+      size_t start = 0;
+      while (start < acceptable.size()) {
+        size_t end = acceptable.find(',', start);
+        std::string token = acceptable.substr(
+          start, end == std::string::npos ? std::string::npos : end - start);
+        auto begin_it = token.find_first_not_of(" \t");
+        auto end_it = token.find_last_not_of(" \t");
+        if (begin_it != std::string::npos) {
+          token = token.substr(begin_it, end_it - begin_it + 1);
+        }
+        if (!token.empty()) {
+          requested_list.push_back(token);
+        }
+        if (end == std::string::npos) {break;}
+        start = end + 1;
+      }
+    }
+
+    // "any": accept all installed backends
+    bool use_all = false;
+    for (const auto & name : requested_list) {
+      if (name == "any") {
+        use_all = true;
+        break;
+      }
+    }
+
+    // NULL, empty, or only "cpu" entries: CPU-only (backward compat default)
+    bool cpu_only = !use_all && (requested_list.empty() ||
+      std::all_of(requested_list.begin(), requested_list.end(),
+      [](const std::string & n) {return n == "cpu";}));
+
+    if (cpu_only) {
+      // CPU-only: advertise "cpu" as the only supported backend so the
+      // subscription stays on the buffer-aware per-endpoint route and
+      // passes the backends_compatible check with CPU-only publishers.
+      my_backend_types.push_back("cpu");
+      filtered_backends["cpu"] = "";
+    } else if (use_all) {
+      filtered_backends = all_backends;
+      for (const auto & [k, v] : all_backends) {
+        my_backend_types.push_back(k);
+      }
+    } else {
+      for (const auto & name : requested_list) {
+        if (name == "cpu") {
+          continue;
+        }
+        auto it = all_backends.find(name);
+        if (it != all_backends.end()) {
+          filtered_backends[it->first] = it->second;
+          my_backend_types.push_back(it->first);
+        }
+      }
+    }
+  }
+
   if (!get_datareader_qos(
       *qos_policies, *type_supports->get_type_hash_func(type_supports),
-      reader_qos))
+      reader_qos, nullptr,
+      has_buffer_fields ? &filtered_backends : nullptr))
   {
     RMW_SET_ERROR_MSG("create_subscription() failed setting data reader QoS");
     return nullptr;
@@ -675,7 +753,7 @@ __create_subscription(
 
   info->datareader_qos_ = reader_qos;
 
-  // create_datareader
+  // Always create the base DataReader (serves as discovery placeholder even for buffer-aware)
   if (!rmw_fastrtps_shared_cpp::create_datareader(
       info->datareader_qos_,
       subscription_options,
@@ -731,6 +809,23 @@ __create_subscription(
   rmw_fastrtps_shared_cpp::__init_subscription_for_loans(rmw_subscription);
   rmw_subscription->is_cft_enabled = info->filtered_topic_ != nullptr;
   rmw_subscription->is_cft_supported = true;
+
+  // Buffer-aware subscription setup
+  info->is_buffer_aware_ = has_buffer_fields;
+  if (has_buffer_fields) {
+    info->my_backend_types_ = std::move(my_backend_types);
+    info->local_endpoint_info_ = rmw_get_zero_initialized_topic_endpoint_info();
+    info->local_endpoint_info_.endpoint_type = RMW_ENDPOINT_SUBSCRIPTION;
+    std::memcpy(
+      info->local_endpoint_info_.endpoint_gid,
+      info->subscription_gid_.data, RMW_GID_STORAGE_SIZE);
+
+    info->buffer_data_guard_ =
+      std::make_unique<eprosima::fastdds::dds::GuardCondition>();
+
+    rosidl_buffer_backend_registry::BufferBackendRegistry::get_instance().notify_endpoint_created(
+      info->local_endpoint_info_);
+  }
 
   cleanup_rmw_subscription.cancel();
   cleanup_datareader.cancel();

--- a/rmw_fastrtps_cpp/src/subscription.cpp
+++ b/rmw_fastrtps_cpp/src/subscription.cpp
@@ -861,19 +861,13 @@ __create_subscription(
     if (cpu_only) {
       // CPU-only: create a DataReader on the shared CPU channel.
       std::string cpu_topic_name = topic_name_mangled + "/_buf_cpu";
-      auto * existing_desc = dds_participant->lookup_topicdescription(cpu_topic_name);
-      if (existing_desc) {
-        info->cpu_topic_ = dynamic_cast<eprosima::fastdds::dds::Topic *>(existing_desc);
+      eprosima::fastdds::dds::TopicQos cpu_tqos = dds_participant->get_default_topic_qos();
+      if (!get_topic_qos(*qos_policies, cpu_tqos)) {
+        RMW_SET_ERROR_MSG("create_subscription() failed setting CPU channel topic QoS");
+        return nullptr;
       }
-      if (!info->cpu_topic_) {
-        eprosima::fastdds::dds::TopicQos cpu_tqos = dds_participant->get_default_topic_qos();
-        if (!get_topic_qos(*qos_policies, cpu_tqos)) {
-          RMW_SET_ERROR_MSG("create_subscription() failed setting CPU channel topic QoS");
-          return nullptr;
-        }
-        info->cpu_topic_ = dds_participant->create_topic(
-          cpu_topic_name, type_name, cpu_tqos);
-      }
+      info->cpu_topic_ = participant_info->find_or_create_topic(
+        cpu_topic_name, type_name, cpu_tqos, nullptr);
       if (!info->cpu_topic_) {
         RMW_SET_ERROR_MSG("create_subscription() failed to create CPU channel topic");
         return nullptr;
@@ -888,7 +882,7 @@ __create_subscription(
         eprosima::fastdds::dds::StatusMask::data_available());
       if (!info->cpu_data_reader_) {
         info->cpu_data_reader_listener_.reset();
-        dds_participant->delete_topic(info->cpu_topic_);
+        participant_info->delete_topic(info->cpu_topic_, nullptr);
         info->cpu_topic_ = nullptr;
         RMW_SET_ERROR_MSG("create_subscription() failed to create CPU channel DataReader");
         return nullptr;

--- a/rmw_fastrtps_cpp/src/subscription.cpp
+++ b/rmw_fastrtps_cpp/src/subscription.cpp
@@ -668,7 +668,7 @@ __create_subscription(
 
   if (has_buffer_fields) {
     auto all_backends =
-      rosidl_buffer_backend_registry::BufferBackendRegistry::get_instance().get_all_aux_info();
+      rosidl_buffer_backend_registry::BufferBackendRegistry::get_instance().get_all_backend_metadata();
 
     // Parse acceptable_buffer_backends option (comma-separated) to filter
     std::vector<std::string> requested_list;

--- a/rmw_fastrtps_dynamic_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_dynamic_cpp/CMakeLists.txt
@@ -42,6 +42,7 @@ find_package(fastcdr 2 REQUIRED)
 find_package(fastdds 3 REQUIRED)
 
 find_package(rmw REQUIRED)
+find_package(rosidl_buffer REQUIRED)
 find_package(rosidl_runtime_c REQUIRED)
 find_package(rosidl_typesupport_introspection_c REQUIRED)
 find_package(rosidl_typesupport_introspection_cpp REQUIRED)
@@ -103,6 +104,7 @@ target_link_libraries(rmw_fastrtps_dynamic_cpp PUBLIC
   rcutils::rcutils
   rmw::rmw
   rmw_fastrtps_shared_cpp::rmw_fastrtps_shared_cpp
+  rosidl_buffer::rosidl_buffer
   rosidl_runtime_c::rosidl_runtime_c
   rosidl_typesupport_introspection_c::rosidl_typesupport_introspection_c
   rosidl_typesupport_introspection_cpp::rosidl_typesupport_introspection_cpp
@@ -134,6 +136,7 @@ ament_export_dependencies(
   rcutils
   rmw
   rmw_fastrtps_shared_cpp
+  rosidl_buffer
   rosidl_runtime_c
   rosidl_typesupport_introspection_c
   rosidl_typesupport_introspection_cpp

--- a/rmw_fastrtps_dynamic_cpp/package.xml
+++ b/rmw_fastrtps_dynamic_cpp/package.xml
@@ -24,6 +24,7 @@
   <build_depend>rmw</build_depend>
   <build_depend>rmw_dds_common</build_depend>
   <build_depend>rmw_fastrtps_shared_cpp</build_depend>
+  <build_depend>rosidl_buffer</build_depend>
   <build_depend>rosidl_runtime_c</build_depend>
   <build_depend>rosidl_typesupport_introspection_c</build_depend>
   <build_depend>rosidl_typesupport_introspection_cpp</build_depend>
@@ -36,6 +37,7 @@
   <build_export_depend>rmw</build_export_depend>
   <build_export_depend>rmw_dds_common</build_export_depend>
   <build_export_depend>rmw_fastrtps_shared_cpp</build_export_depend>
+  <build_export_depend>rosidl_buffer</build_export_depend>
   <build_export_depend>rosidl_runtime_c</build_export_depend>
   <build_export_depend>rosidl_typesupport_introspection_c</build_export_depend>
   <build_export_depend>rosidl_typesupport_introspection_cpp</build_export_depend>

--- a/rmw_fastrtps_dynamic_cpp/src/TypeSupport_impl.hpp
+++ b/rmw_fastrtps_dynamic_cpp/src/TypeSupport_impl.hpp
@@ -19,6 +19,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include "fastcdr/Cdr.h"
@@ -33,6 +34,8 @@
 
 #include "rosidl_typesupport_introspection_c/message_introspection.h"
 #include "rosidl_typesupport_introspection_c/service_introspection.h"
+
+#include "rosidl_buffer/buffer.hpp"
 
 #include "rosidl_runtime_c/primitives_sequence_functions.h"
 #include "rosidl_runtime_c/u16string_functions.h"
@@ -270,7 +273,26 @@ bool TypeSupport<MembersType>::serializeROSmessage(
         break;
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_BYTE:
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT8:
-        serialize_field<uint8_t>(member, field, ser);
+        if (member->is_rosidl_buffer_ && member->is_array_ &&
+          !(member->array_size_ && !member->is_upper_bound_))
+        {
+          if constexpr (std::is_same_v<MembersType,
+            rosidl_typesupport_introspection_cpp::MessageMembers>)
+          {
+            auto & buffer = *reinterpret_cast<const rosidl::Buffer<uint8_t> *>(field);
+            ser.serialize_sequence(buffer.data(), buffer.size());
+          } else {
+            auto & seq = *reinterpret_cast<rosidl_runtime_c__uint8__Sequence *>(field);
+            if (seq.is_rosidl_buffer && seq.data) {
+              auto * buf = reinterpret_cast<const rosidl::Buffer<uint8_t> *>(seq.data);
+              ser.serialize_sequence(buf->data(), buf->size());
+            } else {
+              ser.serialize_sequence(reinterpret_cast<uint8_t *>(seq.data), seq.size);
+            }
+          }
+        } else {
+          serialize_field<uint8_t>(member, field, ser);
+        }
         break;
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_CHAR:
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT8:
@@ -605,7 +627,37 @@ size_t TypeSupport<MembersType>::getEstimatedSerializedSize(
         break;
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_BYTE:
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT8:
-        current_alignment = next_field_align<uint8_t>(member, field, current_alignment);
+        if (member->is_rosidl_buffer_ && member->is_array_ &&
+          !(member->array_size_ && !member->is_upper_bound_))
+        {
+          const size_t padding = 4;
+          size_t item_size = sizeof(uint8_t);
+          current_alignment += eprosima::fastcdr::Cdr::alignment(current_alignment, padding);
+          current_alignment += padding;
+          size_t buf_size = 0;
+          if constexpr (std::is_same_v<MembersType,
+            rosidl_typesupport_introspection_cpp::MessageMembers>)
+          {
+            buf_size =
+              reinterpret_cast<const rosidl::Buffer<uint8_t> *>(field)->size();
+          } else {
+            auto * seq =
+              reinterpret_cast<const rosidl_runtime_c__uint8__Sequence *>(field);
+            if (seq->is_rosidl_buffer && seq->data) {
+              buf_size =
+                reinterpret_cast<const rosidl::Buffer<uint8_t> *>(seq->data)->size();
+            } else {
+              buf_size = seq->size;
+            }
+          }
+          if (buf_size > 0) {
+            current_alignment += eprosima::fastcdr::Cdr::alignment(
+              current_alignment, item_size);
+            current_alignment += item_size * buf_size;
+          }
+        } else {
+          current_alignment = next_field_align<uint8_t>(member, field, current_alignment);
+        }
         break;
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_CHAR:
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT8:
@@ -854,7 +906,43 @@ bool TypeSupport<MembersType>::deserializeROSmessage(
         break;
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_BYTE:
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT8:
-        deserialize_field<uint8_t>(member, field, deser);
+        if (member->is_rosidl_buffer_ && member->is_array_ &&
+          !(member->array_size_ && !member->is_upper_bound_))
+        {
+          if constexpr (std::is_same_v<MembersType,
+            rosidl_typesupport_introspection_cpp::MessageMembers>)
+          {
+            auto & buffer = *reinterpret_cast<rosidl::Buffer<uint8_t> *>(field);
+            int32_t dsize = 0;
+            deser >> dsize;
+            check_sequence_size(dsize, deser);
+            buffer.resize(dsize);
+            if (dsize > 0) {
+              deser.deserialize_array(buffer.data(), dsize);
+            }
+          } else {
+            auto * seq = reinterpret_cast<rosidl_runtime_c__uint8__Sequence *>(field);
+            int32_t dsize = 0;
+            deser >> dsize;
+            check_sequence_size(dsize, deser);
+            if (seq->is_rosidl_buffer && seq->data) {
+              auto * buf = reinterpret_cast<rosidl::Buffer<uint8_t> *>(seq->data);
+              buf->resize(dsize);
+              if (dsize > 0) {
+                deser.deserialize_array(buf->data(), dsize);
+              }
+            } else {
+              if (!rosidl_runtime_c__uint8__Sequence__init(seq, dsize)) {
+                throw std::runtime_error("unable to initialize uint8 sequence");
+              }
+              if (dsize > 0) {
+                deser.deserialize_array(seq->data, dsize);
+              }
+            }
+          }
+        } else {
+          deserialize_field<uint8_t>(member, field, deser);
+        }
         break;
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_CHAR:
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT8:

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_init.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_init.cpp
@@ -111,6 +111,8 @@ rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
     [context]() {delete context->impl;});
 
   context->impl->is_shutdown = false;
+  context->impl->buffer_serialization_context = nullptr;
+  context->impl->buffer_endpoint_registry = nullptr;
   context->options = rmw_get_zero_initialized_init_options();
   rmw_ret_t ret = rmw_init_options_copy(options, &context->options);
   if (RMW_RET_OK != ret) {

--- a/rmw_fastrtps_shared_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_shared_cpp/CMakeLists.txt
@@ -50,6 +50,7 @@ find_package(fastcdr 2 REQUIRED)
 find_package(fastdds 3 REQUIRED)
 
 find_package(rmw REQUIRED)
+find_package(rosidl_buffer_backend_registry REQUIRED)
 
 add_library(rmw_fastrtps_shared_cpp
   src/custom_participant_info.cpp
@@ -115,6 +116,7 @@ target_link_libraries(rmw_fastrtps_shared_cpp PUBLIC
 )
 
 target_link_libraries(rmw_fastrtps_shared_cpp PRIVATE
+  rosidl_buffer_backend_registry::rosidl_buffer_backend_registry
   rosidl_typesupport_introspection_c::rosidl_typesupport_introspection_c
   rosidl_typesupport_introspection_cpp::rosidl_typesupport_introspection_cpp
   tracetools::tracetools

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
@@ -137,7 +137,7 @@ typedef struct CustomParticipantInfo
 } CustomParticipantInfo;
 
 /// Callback type for when a buffer-aware endpoint is discovered via DDS.
-/// Parameters: gid, topic_name, backend_aux_info, is_reader.
+/// Parameters: gid, topic_name, backend_metadata, is_reader.
 using BufferDiscoveryCallback = std::function<void (
       const rmw_gid_t &, const std::string &,
       const std::unordered_map<std::string, std::string> &, bool)>;

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
@@ -139,8 +139,8 @@ typedef struct CustomParticipantInfo
 /// Callback type for when a buffer-aware endpoint is discovered via DDS.
 /// Parameters: gid, topic_name, backend_aux_info, is_reader.
 using BufferDiscoveryCallback = std::function<void (
-    const rmw_gid_t &, const std::string &,
-    const std::unordered_map<std::string, std::string> &, bool)>;
+      const rmw_gid_t &, const std::string &,
+      const std::unordered_map<std::string, std::string> &, bool)>;
 
 class ParticipantListener : public eprosima::fastdds::dds::DomainParticipantListener
 {

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
@@ -111,6 +111,7 @@ typedef struct CustomParticipantInfo
 
   eprosima::fastdds::dds::Publisher * publisher_{nullptr};
   eprosima::fastdds::dds::Subscriber * subscriber_{nullptr};
+  void * buffer_serialization_context_{nullptr};
 
   // Protects creation and destruction of topics, readers and writers
   mutable std::mutex entity_creation_mutex_;

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
@@ -15,11 +15,13 @@
 #ifndef RMW_FASTRTPS_SHARED_CPP__CUSTOM_PARTICIPANT_INFO_HPP_
 #define RMW_FASTRTPS_SHARED_CPP__CUSTOM_PARTICIPANT_INFO_HPP_
 
+#include <functional>
 #include <map>
 #include <memory>
 #include <mutex>
 #include <set>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -134,6 +136,12 @@ typedef struct CustomParticipantInfo
     EventListenerInterface * event_listener);
 } CustomParticipantInfo;
 
+/// Callback type for when a buffer-aware endpoint is discovered via DDS.
+/// Parameters: gid, topic_name, backend_aux_info, is_reader.
+using BufferDiscoveryCallback = std::function<void (
+    const rmw_gid_t &, const std::string &,
+    const std::unordered_map<std::string, std::string> &, bool)>;
+
 class ParticipantListener : public eprosima::fastdds::dds::DomainParticipantListener
 {
 public:
@@ -143,6 +151,12 @@ public:
   : context(context),
     identifier_(identifier)
   {}
+
+  void set_buffer_discovery_callback(BufferDiscoveryCallback cb)
+  {
+    std::lock_guard<std::mutex> lock(buffer_cb_mutex_);
+    buffer_discovery_cb_ = std::move(cb);
+  }
 
   void on_participant_discovery(
     eprosima::fastdds::dds::DomainParticipant * participant,
@@ -263,6 +277,26 @@ private:
           qos_profile,
           is_reader,
           ser_type_hash_ptr);
+
+        // Parse buffer backend info and invoke callback if present.
+        // Copy the callback outside the lock so buffer_cb_mutex_ is not held
+        // during the callback (which may acquire other mutexes or do DDS work).
+        auto buffer_backends = parse_buffer_backends_from_user_data(
+          userDataValue.data(), userDataValue.size());
+        if (!buffer_backends.empty()) {
+          BufferDiscoveryCallback cb_copy;
+          {
+            std::lock_guard<std::mutex> lock(buffer_cb_mutex_);
+            cb_copy = buffer_discovery_cb_;
+          }
+          if (cb_copy) {
+            cb_copy(
+              rmw_fastrtps_shared_cpp::create_rmw_gid(identifier_, proxyData.guid),
+              proxyData.topic_name.to_string(),
+              buffer_backends,
+              is_reader);
+          }
+        }
       } else {
         context->graph_cache.remove_entity(
           rmw_fastrtps_shared_cpp::create_rmw_gid(
@@ -275,6 +309,9 @@ private:
 
   rmw_dds_common::Context * context;
   const char * const identifier_;
+
+  std::mutex buffer_cb_mutex_;
+  BufferDiscoveryCallback buffer_discovery_cb_;
 };
 
 #endif  // RMW_FASTRTPS_SHARED_CPP__CUSTOM_PARTICIPANT_INFO_HPP_

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_publisher_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_publisher_info.hpp
@@ -87,6 +87,7 @@ struct BufferPublisherEndpoint
   std::string key;
   eprosima::fastdds::dds::DataWriter * data_writer{nullptr};
   eprosima::fastdds::dds::Topic * topic{nullptr};
+  bool owns_topic{true};
   rmw_gid_t target_subscriber_gid{};
   rmw_topic_endpoint_info_t subscriber_endpoint_info{};
   std::unordered_map<std::string, std::string> backend_metadata;

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_publisher_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_publisher_info.hpp
@@ -92,6 +92,26 @@ struct BufferPublisherEndpoint
   std::unordered_map<std::string, std::string> backend_metadata;
 };
 
+/// Metadata queued by the discovery callback for lazy DataWriter creation.
+struct PendingBufferPublisher
+{
+  std::string unique_topic;
+  rmw_gid_t target_subscriber_gid{};
+  rmw_topic_endpoint_info_t subscriber_endpoint_info{};
+  std::unordered_map<std::string, std::string> backend_metadata;
+};
+
+/// Mutable buffer state shared between the discovery callback and the
+/// publish/destroy paths.  Managed via shared_ptr so the callback can
+/// safely outlive the CustomPublisherInfo that created it.
+struct BufferPublisherState
+{
+  std::atomic<bool> alive{true};
+  std::mutex mutex;
+  std::vector<std::shared_ptr<BufferPublisherEndpoint>> endpoints;
+  std::vector<PendingBufferPublisher> pending;
+};
+
 typedef struct CustomPublisherInfo : public CustomEventInfo
 {
   virtual ~CustomPublisherInfo() = default;
@@ -110,13 +130,8 @@ typedef struct CustomPublisherInfo : public CustomEventInfo
   bool is_buffer_aware_{false};
   std::unordered_map<std::string, std::string> backend_metadata_;
   rmw_topic_endpoint_info_t local_endpoint_info_{};
-  std::mutex buffer_mutex_;
-  std::vector<std::shared_ptr<BufferPublisherEndpoint>> buffer_endpoints_;
-  std::set<std::string> pending_buffer_endpoints_;
-  /// Shared flag set to false before destruction so discovery callbacks that
-  /// captured a raw pointer to this object can detect the invalidation.
-  std::shared_ptr<std::atomic<bool>> buffer_alive_flag_{
-    std::make_shared<std::atomic<bool>>(true)};
+  std::shared_ptr<BufferPublisherState> buffer_state_{
+    std::make_shared<BufferPublisherState>()};
 
   // DDS objects needed to create dynamic DataWriters
   eprosima::fastdds::dds::DomainParticipant * participant_{nullptr};

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_publisher_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_publisher_info.hpp
@@ -89,7 +89,7 @@ struct BufferPublisherEndpoint
   eprosima::fastdds::dds::Topic * topic{nullptr};
   rmw_gid_t target_subscriber_gid{};
   rmw_topic_endpoint_info_t subscriber_endpoint_info{};
-  std::unordered_map<std::string, std::string> backend_aux_info;
+  std::unordered_map<std::string, std::string> backend_metadata;
 };
 
 typedef struct CustomPublisherInfo : public CustomEventInfo
@@ -108,7 +108,7 @@ typedef struct CustomPublisherInfo : public CustomEventInfo
 
   // Buffer-aware publisher fields
   bool is_buffer_aware_{false};
-  std::unordered_map<std::string, std::string> backend_aux_info_;
+  std::unordered_map<std::string, std::string> backend_metadata_;
   rmw_topic_endpoint_info_t local_endpoint_info_{};
   std::mutex buffer_mutex_;
   std::vector<std::shared_ptr<BufferPublisherEndpoint>> buffer_endpoints_;

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_publisher_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_publisher_info.hpp
@@ -15,16 +15,24 @@
 #ifndef RMW_FASTRTPS_SHARED_CPP__CUSTOM_PUBLISHER_INFO_HPP_
 #define RMW_FASTRTPS_SHARED_CPP__CUSTOM_PUBLISHER_INFO_HPP_
 
+#include <atomic>
+#include <cstring>
+#include <memory>
 #include <mutex>
 #include <set>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 #include "fastdds/dds/core/policy/QosPolicies.hpp"
 #include "fastdds/dds/core/status/BaseStatus.hpp"
 #include "fastdds/dds/core/status/DeadlineMissedStatus.hpp"
 #include "fastdds/dds/core/status/IncompatibleQosStatus.hpp"
 #include "fastdds/dds/core/status/PublicationMatchedStatus.hpp"
+#include "fastdds/dds/domain/DomainParticipant.hpp"
 #include "fastdds/dds/publisher/DataWriter.hpp"
 #include "fastdds/dds/publisher/DataWriterListener.hpp"
+#include "fastdds/dds/publisher/Publisher.hpp"
 #include "fastdds/dds/topic/Topic.hpp"
 #include "fastdds/dds/topic/TypeSupport.hpp"
 
@@ -33,6 +41,7 @@
 
 #include "rcpputils/thread_safety_annotations.hpp"
 #include "rmw/rmw.h"
+#include "rmw/topic_endpoint_info.h"
 
 #include "rmw_fastrtps_shared_cpp/custom_event_info.hpp"
 
@@ -72,6 +81,17 @@ private:
   RMWPublisherEvent * publisher_event_;
 };
 
+/// Per-subscriber endpoint created for buffer-aware publishing.
+struct BufferPublisherEndpoint
+{
+  std::string key;
+  eprosima::fastdds::dds::DataWriter * data_writer{nullptr};
+  eprosima::fastdds::dds::Topic * topic{nullptr};
+  rmw_gid_t target_subscriber_gid{};
+  rmw_topic_endpoint_info_t subscriber_endpoint_info{};
+  std::unordered_map<std::string, std::string> backend_aux_info;
+};
+
 typedef struct CustomPublisherInfo : public CustomEventInfo
 {
   virtual ~CustomPublisherInfo() = default;
@@ -85,6 +105,22 @@ typedef struct CustomPublisherInfo : public CustomEventInfo
   const char * typesupport_identifier_{nullptr};
 
   eprosima::fastdds::dds::Topic * topic_{nullptr};
+
+  // Buffer-aware publisher fields
+  bool is_buffer_aware_{false};
+  std::unordered_map<std::string, std::string> backend_aux_info_;
+  rmw_topic_endpoint_info_t local_endpoint_info_{};
+  std::mutex buffer_mutex_;
+  std::vector<std::shared_ptr<BufferPublisherEndpoint>> buffer_endpoints_;
+  std::set<std::string> pending_buffer_endpoints_;
+  /// Shared flag set to false before destruction so discovery callbacks that
+  /// captured a raw pointer to this object can detect the invalidation.
+  std::shared_ptr<std::atomic<bool>> buffer_alive_flag_{
+    std::make_shared<std::atomic<bool>>(true)};
+
+  // DDS objects needed to create dynamic DataWriters
+  eprosima::fastdds::dds::DomainParticipant * participant_{nullptr};
+  eprosima::fastdds::dds::Publisher * dds_publisher_{nullptr};
 
   RMW_FASTRTPS_SHARED_CPP_PUBLIC
   EventListenerInterface *

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_publisher_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_publisher_info.hpp
@@ -130,6 +130,7 @@ typedef struct CustomPublisherInfo : public CustomEventInfo
   bool is_buffer_aware_{false};
   std::unordered_map<std::string, std::string> backend_metadata_;
   rmw_topic_endpoint_info_t local_endpoint_info_{};
+  const void * serialization_context_{nullptr};
   std::shared_ptr<BufferPublisherState> buffer_state_{
     std::make_shared<BufferPublisherState>()};
 

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_publisher_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_publisher_info.hpp
@@ -108,8 +108,11 @@ struct BufferPublisherState
 {
   std::atomic<bool> alive{true};
   std::mutex mutex;
+  /// Per-subscriber (peer-to-peer) endpoints for non-CPU-only subscribers.
   std::vector<std::shared_ptr<BufferPublisherEndpoint>> endpoints;
   std::vector<PendingBufferPublisher> pending;
+  /// GIDs of discovered CPU-only subscribers served by the shared CPU channel.
+  std::vector<rmw_gid_t> cpu_only_subscribers;
 };
 
 typedef struct CustomPublisherInfo : public CustomEventInfo
@@ -133,6 +136,10 @@ typedef struct CustomPublisherInfo : public CustomEventInfo
   const void * serialization_context_{nullptr};
   std::shared_ptr<BufferPublisherState> buffer_state_{
     std::make_shared<BufferPublisherState>()};
+
+  // CPU-only shared channel (one writer serves all CPU-only subscribers)
+  eprosima::fastdds::dds::DataWriter * cpu_data_writer_{nullptr};
+  eprosima::fastdds::dds::Topic * cpu_topic_{nullptr};
 
   // DDS objects needed to create dynamic DataWriters
   eprosima::fastdds::dds::DomainParticipant * participant_{nullptr};

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
@@ -156,6 +156,7 @@ struct CustomSubscriberInfo : public CustomEventInfo
   bool is_buffer_aware_{false};
   std::vector<std::string> my_backend_types_;
   rmw_topic_endpoint_info_t local_endpoint_info_{};
+  const void * serialization_context_{nullptr};
   std::shared_ptr<BufferSubscriptionState> buffer_state_{
     std::make_shared<BufferSubscriptionState>()};
   /// Guard condition triggered when per-publisher DataReaders receive data.

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
@@ -106,7 +106,7 @@ struct BufferSubscriptionEndpoint
   std::shared_ptr<eprosima::fastdds::dds::DataReaderListener> listener;
   rmw_gid_t publisher_gid{};
   rmw_topic_endpoint_info_t publisher_endpoint_info{};
-  std::unordered_map<std::string, std::string> backend_aux_info;
+  std::unordered_map<std::string, std::string> backend_metadata;
 };
 
 struct CustomSubscriberInfo : public CustomEventInfo

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
@@ -109,6 +109,26 @@ struct BufferSubscriptionEndpoint
   std::unordered_map<std::string, std::string> backend_metadata;
 };
 
+/// Metadata queued by the discovery callback for lazy DataReader creation.
+struct PendingBufferSubscription
+{
+  std::string unique_topic;
+  rmw_gid_t publisher_gid{};
+  rmw_topic_endpoint_info_t publisher_endpoint_info{};
+  std::unordered_map<std::string, std::string> backend_metadata;
+};
+
+/// Mutable buffer state shared between the discovery callback and the
+/// take/destroy paths.  Managed via shared_ptr so the callback can
+/// safely outlive the CustomSubscriberInfo that created it.
+struct BufferSubscriptionState
+{
+  std::atomic<bool> alive{true};
+  std::mutex mutex;
+  std::vector<std::shared_ptr<BufferSubscriptionEndpoint>> endpoints;
+  std::vector<PendingBufferSubscription> pending;
+};
+
 struct CustomSubscriberInfo : public CustomEventInfo
 {
   virtual ~CustomSubscriberInfo() = default;
@@ -136,13 +156,8 @@ struct CustomSubscriberInfo : public CustomEventInfo
   bool is_buffer_aware_{false};
   std::vector<std::string> my_backend_types_;
   rmw_topic_endpoint_info_t local_endpoint_info_{};
-  std::mutex buffer_mutex_;
-  std::vector<std::shared_ptr<BufferSubscriptionEndpoint>> buffer_endpoints_;
-  std::set<std::string> pending_buffer_endpoints_;
-  /// Shared flag set to false before destruction so discovery callbacks that
-  /// captured a raw pointer to this object can detect the invalidation.
-  std::shared_ptr<std::atomic<bool>> buffer_alive_flag_{
-    std::make_shared<std::atomic<bool>>(true)};
+  std::shared_ptr<BufferSubscriptionState> buffer_state_{
+    std::make_shared<BufferSubscriptionState>()};
   /// Guard condition triggered when per-publisher DataReaders receive data.
   /// Used by rmw_wait to detect data on buffer-aware subscriptions.
   std::unique_ptr<eprosima::fastdds::dds::GuardCondition> buffer_data_guard_;

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
@@ -154,6 +154,7 @@ struct CustomSubscriberInfo : public CustomEventInfo
 
   // Buffer-aware subscription fields
   bool is_buffer_aware_{false};
+  bool is_cpu_only_{false};
   std::vector<std::string> my_backend_types_;
   rmw_topic_endpoint_info_t local_endpoint_info_{};
   const void * serialization_context_{nullptr};
@@ -162,6 +163,11 @@ struct CustomSubscriberInfo : public CustomEventInfo
   /// Guard condition triggered when per-publisher DataReaders receive data.
   /// Used by rmw_wait to detect data on buffer-aware subscriptions.
   std::unique_ptr<eprosima::fastdds::dds::GuardCondition> buffer_data_guard_;
+
+  // CPU-only shared channel reader (when acceptable_buffer_backends is CPU-only)
+  eprosima::fastdds::dds::DataReader * cpu_data_reader_{nullptr};
+  eprosima::fastdds::dds::Topic * cpu_topic_{nullptr};
+  std::shared_ptr<eprosima::fastdds::dds::DataReaderListener> cpu_data_reader_listener_;
 
   RMW_FASTRTPS_SHARED_CPP_PUBLIC
   EventListenerInterface *

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
@@ -96,23 +96,9 @@ namespace rmw_fastrtps_shared_cpp
 struct LoanManager;
 }  // namespace rmw_fastrtps_shared_cpp
 
-/// Per-publisher endpoint created for buffer-aware subscriptions.
-struct BufferSubscriptionEndpoint
+/// Metadata about a discovered buffer-aware publisher, keyed by GID.
+struct PublisherBufferMetadata
 {
-  std::string key;
-  eprosima::fastdds::dds::DataReader * data_reader{nullptr};
-  eprosima::fastdds::dds::Topic * topic{nullptr};
-  bool owns_topic{true};
-  std::shared_ptr<eprosima::fastdds::dds::DataReaderListener> listener;
-  rmw_gid_t publisher_gid{};
-  rmw_topic_endpoint_info_t publisher_endpoint_info{};
-  std::unordered_map<std::string, std::string> backend_metadata;
-};
-
-/// Metadata queued by the discovery callback for lazy DataReader creation.
-struct PendingBufferSubscription
-{
-  std::string unique_topic;
   rmw_gid_t publisher_gid{};
   rmw_topic_endpoint_info_t publisher_endpoint_info{};
   std::unordered_map<std::string, std::string> backend_metadata;
@@ -125,8 +111,8 @@ struct BufferSubscriptionState
 {
   std::atomic<bool> alive{true};
   std::mutex mutex;
-  std::vector<std::shared_ptr<BufferSubscriptionEndpoint>> endpoints;
-  std::vector<PendingBufferSubscription> pending;
+  /// GID hex string -> publisher metadata, populated by discovery callback.
+  std::unordered_map<std::string, PublisherBufferMetadata> publisher_metadata;
 };
 
 struct CustomSubscriberInfo : public CustomEventInfo
@@ -160,7 +146,7 @@ struct CustomSubscriberInfo : public CustomEventInfo
   const void * serialization_context_{nullptr};
   std::shared_ptr<BufferSubscriptionState> buffer_state_{
     std::make_shared<BufferSubscriptionState>()};
-  /// Guard condition triggered when per-publisher DataReaders receive data.
+  /// Guard condition triggered when buffer channel DataReaders receive data.
   /// Used by rmw_wait to detect data on buffer-aware subscriptions.
   std::unique_ptr<eprosima::fastdds::dds::GuardCondition> buffer_data_guard_;
 
@@ -168,6 +154,11 @@ struct CustomSubscriberInfo : public CustomEventInfo
   eprosima::fastdds::dds::DataReader * cpu_data_reader_{nullptr};
   eprosima::fastdds::dds::Topic * cpu_topic_{nullptr};
   std::shared_ptr<eprosima::fastdds::dds::DataReaderListener> cpu_data_reader_listener_;
+
+  // Accelerated shared channel reader (all buffer-aware publishers write here)
+  eprosima::fastdds::dds::DataReader * accel_data_reader_{nullptr};
+  eprosima::fastdds::dds::Topic * accel_topic_{nullptr};
+  std::shared_ptr<eprosima::fastdds::dds::DataReaderListener> accel_data_reader_listener_;
 
   RMW_FASTRTPS_SHARED_CPP_PUBLIC
   EventListenerInterface *

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
@@ -16,15 +16,20 @@
 #define RMW_FASTRTPS_SHARED_CPP__CUSTOM_SUBSCRIBER_INFO_HPP_
 
 #include <algorithm>
+#include <atomic>
+#include <cstring>
 #include <limits>
 #include <memory>
 #include <mutex>
 #include <set>
 #include <string>
+#include <unordered_map>
 #include <utility>
+#include <vector>
 
 #include "fastdds/dds/core/status/DeadlineMissedStatus.hpp"
 #include "fastdds/dds/core/status/LivelinessChangedStatus.hpp"
+#include "fastdds/dds/core/condition/GuardCondition.hpp"
 #include "fastdds/dds/core/status/SubscriptionMatchedStatus.hpp"
 #include "fastdds/dds/subscriber/DataReader.hpp"
 #include "fastdds/dds/subscriber/DataReaderListener.hpp"
@@ -39,6 +44,7 @@
 
 #include "rmw/impl/cpp/macros.hpp"
 #include "rmw/event_callback_type.h"
+#include "rmw/topic_endpoint_info.h"
 
 #include "rmw_dds_common/context.hpp"
 
@@ -90,6 +96,19 @@ namespace rmw_fastrtps_shared_cpp
 struct LoanManager;
 }  // namespace rmw_fastrtps_shared_cpp
 
+/// Per-publisher endpoint created for buffer-aware subscriptions.
+struct BufferSubscriptionEndpoint
+{
+  std::string key;
+  eprosima::fastdds::dds::DataReader * data_reader{nullptr};
+  eprosima::fastdds::dds::Topic * topic{nullptr};
+  bool owns_topic{true};
+  std::shared_ptr<eprosima::fastdds::dds::DataReaderListener> listener;
+  rmw_gid_t publisher_gid{};
+  rmw_topic_endpoint_info_t publisher_endpoint_info{};
+  std::unordered_map<std::string, std::string> backend_aux_info;
+};
+
 struct CustomSubscriberInfo : public CustomEventInfo
 {
   virtual ~CustomSubscriberInfo() = default;
@@ -112,6 +131,21 @@ struct CustomSubscriberInfo : public CustomEventInfo
   eprosima::fastdds::dds::Topic * topic_ {nullptr};
   eprosima::fastdds::dds::ContentFilteredTopic * filtered_topic_ {nullptr};
   eprosima::fastdds::dds::DataReaderQos datareader_qos_;
+
+  // Buffer-aware subscription fields
+  bool is_buffer_aware_{false};
+  std::vector<std::string> my_backend_types_;
+  rmw_topic_endpoint_info_t local_endpoint_info_{};
+  std::mutex buffer_mutex_;
+  std::vector<std::shared_ptr<BufferSubscriptionEndpoint>> buffer_endpoints_;
+  std::set<std::string> pending_buffer_endpoints_;
+  /// Shared flag set to false before destruction so discovery callbacks that
+  /// captured a raw pointer to this object can detect the invalidation.
+  std::shared_ptr<std::atomic<bool>> buffer_alive_flag_{
+    std::make_shared<std::atomic<bool>>(true)};
+  /// Guard condition triggered when per-publisher DataReaders receive data.
+  /// Used by rmw_wait to detect data on buffer-aware subscriptions.
+  std::unique_ptr<eprosima::fastdds::dds::GuardCondition> buffer_data_guard_;
 
   RMW_FASTRTPS_SHARED_CPP_PUBLIC
   EventListenerInterface *
@@ -195,6 +229,10 @@ public:
 
   RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void update_data_available();
+
+  /// Notify that buffer data is available (bypasses main DataReader unread check).
+  RMW_FASTRTPS_SHARED_CPP_PUBLIC
+  void notify_buffer_data_available(size_t count);
 
   RMW_FASTRTPS_SHARED_CPP_PUBLIC
   void update_requested_deadline_missed(uint32_t total_count, uint32_t total_count_change);

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/guid_utils.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/guid_utils.hpp
@@ -90,7 +90,7 @@ struct hash_fastdds_guid
 };
 
 inline std::string
-gid_to_hex(const rmw_gid_t & gid, size_t bytes = 8)
+gid_to_hex(const rmw_gid_t & gid, size_t bytes = RMW_GID_STORAGE_SIZE)
 {
   static const char hex_chars[] = "0123456789abcdef";
   std::string result;

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/guid_utils.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/guid_utils.hpp
@@ -18,9 +18,12 @@
 #include <cassert>
 #include <cstddef>
 #include <cstring>
+#include <string>
 #include <type_traits>
 
 #include "fastdds/rtps/common/Guid.hpp"
+
+#include "rmw/types.h"
 
 namespace rmw_fastrtps_shared_cpp
 {
@@ -85,6 +88,19 @@ struct hash_fastdds_guid
     return ret_val;
   }
 };
+
+inline std::string
+gid_to_hex(const rmw_gid_t & gid, size_t bytes = 8)
+{
+  static const char hex_chars[] = "0123456789abcdef";
+  std::string result;
+  result.reserve(bytes * 2);
+  for (size_t i = 0; i < bytes && i < RMW_GID_STORAGE_SIZE; ++i) {
+    result += hex_chars[(gid.data[i] >> 4) & 0xF];
+    result += hex_chars[gid.data[i] & 0xF];
+  }
+  return result;
+}
 
 }  // namespace rmw_fastrtps_shared_cpp
 

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/qos.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/qos.hpp
@@ -20,6 +20,8 @@
 #include <unordered_map>
 
 #include <fastdds/dds/core/policy/QosPolicies.hpp>
+
+#include "rmw/types.h"
 #include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
 #include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
 #include <fastdds/dds/topic/qos/TopicQos.hpp>
@@ -63,6 +65,17 @@ encode_buffer_backends_for_user_data(
 RMW_FASTRTPS_SHARED_CPP_PUBLIC
 std::unordered_map<std::string, std::string>
 parse_buffer_backends_from_user_data(const uint8_t * data, size_t size);
+
+/// Encode a GID with a sentinel tag for inclusion in DDS user_data.
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
+std::string
+encode_endpoint_gid_for_user_data(const rmw_gid_t & gid, const char * tag);
+
+/// Parse a GID with the given sentinel tag from DDS user_data bytes.
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
+bool
+parse_endpoint_gid_from_user_data(
+  const uint8_t * data, size_t size, const char * tag, rmw_gid_t & gid);
 
 RMW_FASTRTPS_SHARED_CPP_PUBLIC
 bool

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/qos.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/qos.hpp
@@ -16,6 +16,9 @@
 #ifndef RMW_FASTRTPS_SHARED_CPP__QOS_HPP_
 #define RMW_FASTRTPS_SHARED_CPP__QOS_HPP_
 
+#include <string>
+#include <unordered_map>
+
 #include <fastdds/dds/core/policy/QosPolicies.hpp>
 #include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
 #include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
@@ -37,7 +40,8 @@ get_datareader_qos(
   const rmw_qos_profile_t & qos_policies,
   const rosidl_type_hash_t & type_hash,
   eprosima::fastdds::dds::DataReaderQos & reader_qos,
-  const rosidl_type_hash_t * ser_type_hash = nullptr);
+  const rosidl_type_hash_t * ser_type_hash = nullptr,
+  const std::unordered_map<std::string, std::string> * buffer_backends = nullptr);
 
 RMW_FASTRTPS_SHARED_CPP_PUBLIC
 bool
@@ -45,7 +49,20 @@ get_datawriter_qos(
   const rmw_qos_profile_t & qos_policies,
   const rosidl_type_hash_t & type_hash,
   eprosima::fastdds::dds::DataWriterQos & writer_qos,
-  const rosidl_type_hash_t * ser_type_hash = nullptr);
+  const rosidl_type_hash_t * ser_type_hash = nullptr,
+  const std::unordered_map<std::string, std::string> * buffer_backends = nullptr);
+
+/// Encode buffer backend info as a string for inclusion in DDS user_data.
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
+std::string
+encode_buffer_backends_for_user_data(
+  const std::unordered_map<std::string, std::string> & backends);
+
+/// Parse buffer backend info from DDS user_data bytes.
+/// Returns empty map if the sentinel prefix is not found.
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
+std::unordered_map<std::string, std::string>
+parse_buffer_backends_from_user_data(const uint8_t * data, size_t size);
 
 RMW_FASTRTPS_SHARED_CPP_PUBLIC
 bool

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/rmw_common.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/rmw_common.hpp
@@ -17,6 +17,8 @@
 
 #include "./visibility_control.h"
 
+#include "fastdds/dds/subscriber/SampleInfo.hpp"
+
 #include "rcutils/allocator.h"
 #include "rcutils/types/string_array.h"
 
@@ -602,6 +604,13 @@ __rmw_feature_supported(rmw_feature_t feature);
 RMW_FASTRTPS_SHARED_CPP_PUBLIC
 bool
 __rmw_event_type_is_supported(rmw_event_type_t rmw_event_type);
+
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
+void
+_assign_message_info(
+  const char * identifier,
+  rmw_message_info_t * message_info,
+  const eprosima::fastdds::dds::SampleInfo * sinfo);
 
 }  // namespace rmw_fastrtps_shared_cpp
 

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/rmw_context_impl.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/rmw_context_impl.hpp
@@ -24,6 +24,10 @@ struct rmw_context_impl_s
   void * common;
   /// Pointer to `rmw_fastrtps_shared_cpp::CustomParticipantInfo`.
   void * participant_info;
+  /// Pointer to rmw_fastrtps_cpp::BufferBackendContext.
+  void * buffer_serialization_context;
+  /// Pointer to rmw_fastrtps_cpp::BufferEndpointRegistry.
+  void * buffer_endpoint_registry;
   /// Mutex used to protect initialization/destruction.
   std::mutex mutex;
   /// Reference count.

--- a/rmw_fastrtps_shared_cpp/package.xml
+++ b/rmw_fastrtps_shared_cpp/package.xml
@@ -29,6 +29,7 @@
   <build_depend>rosidl_typesupport_introspection_c</build_depend>
   <build_depend>rosidl_typesupport_introspection_cpp</build_depend>
   <build_depend>tracetools</build_depend>
+  <build_depend>rosidl_buffer_backend_registry</build_depend>
 
   <build_export_depend>rosidl_dynamic_typesupport</build_export_depend>
   <build_export_depend>fastcdr</build_export_depend>

--- a/rmw_fastrtps_shared_cpp/src/custom_subscriber_info.cpp
+++ b/rmw_fastrtps_shared_cpp/src/custom_subscriber_info.cpp
@@ -402,6 +402,15 @@ void RMWSubscriptionEvent::update_data_available()
   }
 }
 
+void RMWSubscriptionEvent::notify_buffer_data_available(size_t count)
+{
+  rcpputils::unique_lock<std::mutex> lock_mutex(on_new_message_m_);
+
+  if (on_new_message_cb_ && count > 0) {
+    on_new_message_cb_(new_message_user_data_, count);
+  }
+}
+
 void RMWSubscriptionEvent::update_requested_deadline_missed(
   uint32_t total_count, uint32_t total_count_change)
 {

--- a/rmw_fastrtps_shared_cpp/src/qos.cpp
+++ b/rmw_fastrtps_shared_cpp/src/qos.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <limits>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -161,18 +162,17 @@ encode_buffer_backends_for_user_data(
   if (backends.empty()) {
     return {};
   }
-  std::string result = BUFFER_BACKEND_SENTINEL;
+  std::ostringstream ss;
+  ss << BUFFER_BACKEND_SENTINEL;
   bool first = true;
   for (const auto & [name, aux] : backends) {
     if (!first) {
-      result += ';';
+      ss << ';';
     }
-    result += name;
-    result += '=';
-    result += aux;
+    ss << name << '=' << aux;
     first = false;
   }
-  return result;
+  return ss.str();
 }
 
 std::unordered_map<std::string, std::string>
@@ -191,23 +191,18 @@ parse_buffer_backends_from_user_data(const uint8_t * data, size_t size)
   if (backends_str.empty()) {
     return result;
   }
-  size_t start = 0;
-  while (start < backends_str.size()) {
-    size_t sep = backends_str.find(';', start);
-    std::string entry = backends_str.substr(
-      start, sep == std::string::npos ? std::string::npos : sep - start);
-    if (!entry.empty()) {
-      size_t eq = entry.find('=');
-      std::string name = entry.substr(0, eq);
-      std::string aux = (eq == std::string::npos) ? "" : entry.substr(eq + 1);
-      if (!name.empty()) {
-        result[name] = aux;
-      }
+  std::istringstream ss(backends_str);
+  std::string entry;
+  while (std::getline(ss, entry, ';')) {
+    if (entry.empty()) {
+      continue;
     }
-    if (sep == std::string::npos) {
-      break;
+    size_t eq = entry.find('=');
+    std::string name = entry.substr(0, eq);
+    std::string aux = (eq == std::string::npos) ? "" : entry.substr(eq + 1);
+    if (!name.empty()) {
+      result[name] = aux;
     }
-    start = sep + 1;
   }
   return result;
 }

--- a/rmw_fastrtps_shared_cpp/src/qos.cpp
+++ b/rmw_fastrtps_shared_cpp/src/qos.cpp
@@ -12,11 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <iomanip>
 #include <limits>
 #include <sstream>
 #include <string>
 #include <unordered_map>
 #include <vector>
+
+#include "rmw/types.h"
 
 #include "rcutils/logging_macros.h"
 
@@ -205,6 +208,44 @@ parse_buffer_backends_from_user_data(const uint8_t * data, size_t size)
     }
   }
   return result;
+}
+
+std::string
+encode_endpoint_gid_for_user_data(const rmw_gid_t & gid, const char * tag)
+{
+  std::ostringstream ss;
+  ss << tag;
+  ss << std::hex << std::setfill('0');
+  for (size_t i = 0; i < RMW_GID_STORAGE_SIZE; ++i) {
+    ss << std::setw(2) << static_cast<unsigned>(gid.data[i]);
+  }
+  return ss.str();
+}
+
+bool
+parse_endpoint_gid_from_user_data(
+  const uint8_t * data, size_t size, const char * tag, rmw_gid_t & gid)
+{
+  size_t tag_len = strlen(tag);
+  if (!data || size < tag_len) {
+    return false;
+  }
+  std::string str(reinterpret_cast<const char *>(data), size);
+  auto pos = str.find(tag);
+  if (pos == std::string::npos) {
+    return false;
+  }
+  std::string hex_str = str.substr(pos + tag_len, RMW_GID_STORAGE_SIZE * 2);
+  if (hex_str.size() != RMW_GID_STORAGE_SIZE * 2) {
+    return false;
+  }
+  for (size_t i = 0; i < RMW_GID_STORAGE_SIZE; ++i) {
+    unsigned val = 0;
+    std::istringstream iss(hex_str.substr(i * 2, 2));
+    iss >> std::hex >> val;
+    gid.data[i] = static_cast<uint8_t>(val);
+  }
+  return true;
 }
 
 template<typename DDSEntityQos>

--- a/rmw_fastrtps_shared_cpp/src/qos.cpp
+++ b/rmw_fastrtps_shared_cpp/src/qos.cpp
@@ -14,6 +14,7 @@
 
 #include <limits>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "rcutils/logging_macros.h"
@@ -150,13 +151,75 @@ bool fill_entity_qos_from_profile(
   return true;
 }
 
+static const char * BUFFER_BACKEND_SENTINEL = "BUFBE:";
+static const size_t BUFFER_BACKEND_SENTINEL_LEN = 6;
+
+std::string
+encode_buffer_backends_for_user_data(
+  const std::unordered_map<std::string, std::string> & backends)
+{
+  if (backends.empty()) {
+    return {};
+  }
+  std::string result = BUFFER_BACKEND_SENTINEL;
+  bool first = true;
+  for (const auto & [name, aux] : backends) {
+    if (!first) {
+      result += ';';
+    }
+    result += name;
+    result += '=';
+    result += aux;
+    first = false;
+  }
+  return result;
+}
+
+std::unordered_map<std::string, std::string>
+parse_buffer_backends_from_user_data(const uint8_t * data, size_t size)
+{
+  std::unordered_map<std::string, std::string> result;
+  if (!data || size < BUFFER_BACKEND_SENTINEL_LEN) {
+    return result;
+  }
+  std::string str(reinterpret_cast<const char *>(data), size);
+  auto pos = str.find(BUFFER_BACKEND_SENTINEL);
+  if (pos == std::string::npos) {
+    return result;
+  }
+  std::string backends_str = str.substr(pos + BUFFER_BACKEND_SENTINEL_LEN);
+  if (backends_str.empty()) {
+    return result;
+  }
+  size_t start = 0;
+  while (start < backends_str.size()) {
+    size_t sep = backends_str.find(';', start);
+    std::string entry = backends_str.substr(
+      start, sep == std::string::npos ? std::string::npos : sep - start);
+    if (!entry.empty()) {
+      size_t eq = entry.find('=');
+      std::string name = entry.substr(0, eq);
+      std::string aux = (eq == std::string::npos) ? "" : entry.substr(eq + 1);
+      if (!name.empty()) {
+        result[name] = aux;
+      }
+    }
+    if (sep == std::string::npos) {
+      break;
+    }
+    start = sep + 1;
+  }
+  return result;
+}
+
 template<typename DDSEntityQos>
 bool
 fill_data_entity_qos_from_profile(
   const rmw_qos_profile_t & qos_policies,
   const rosidl_type_hash_t & type_hash,
   DDSEntityQos & entity_qos,
-  const rosidl_type_hash_t * ser_type_hash = nullptr)
+  const rosidl_type_hash_t * ser_type_hash = nullptr,
+  const std::unordered_map<std::string, std::string> * buffer_backends = nullptr)
 {
   if (!fill_entity_qos_from_profile(qos_policies, entity_qos)) {
     return false;
@@ -167,8 +230,6 @@ fill_data_entity_qos_from_profile(
       "rmw_fastrtps_shared_cpp",
       "Failed to encode type hash for topic, will not distribute it in USER_DATA.");
     user_data_str.clear();
-    // Since we are going to go on without a hash, we clear the error so other
-    // code won't overwrite it.
     rmw_reset_error();
   }
   if (ser_type_hash) {
@@ -178,6 +239,9 @@ fill_data_entity_qos_from_profile(
     {
       user_data_str += typehash_str;
     }
+  }
+  if (buffer_backends && !buffer_backends->empty()) {
+    user_data_str += encode_buffer_backends_for_user_data(*buffer_backends);
   }
   std::vector<uint8_t> user_data(user_data_str.begin(), user_data_str.end());
   entity_qos.user_data().resize(user_data.size());
@@ -190,9 +254,12 @@ get_datareader_qos(
   const rmw_qos_profile_t & qos_policies,
   const rosidl_type_hash_t & type_hash,
   eprosima::fastdds::dds::DataReaderQos & datareader_qos,
-  const rosidl_type_hash_t * ser_type_hash)
+  const rosidl_type_hash_t * ser_type_hash,
+  const std::unordered_map<std::string, std::string> * buffer_backends)
 {
-  if (fill_data_entity_qos_from_profile(qos_policies, type_hash, datareader_qos, ser_type_hash)) {
+  if (fill_data_entity_qos_from_profile(
+      qos_policies, type_hash, datareader_qos, ser_type_hash, buffer_backends))
+  {
     // The type support in the RMW implementation is always XCDR1.
     constexpr auto rep = eprosima::fastdds::dds::XCDR_DATA_REPRESENTATION;
     datareader_qos.representation().clear();
@@ -208,9 +275,12 @@ get_datawriter_qos(
   const rmw_qos_profile_t & qos_policies,
   const rosidl_type_hash_t & type_hash,
   eprosima::fastdds::dds::DataWriterQos & datawriter_qos,
-  const rosidl_type_hash_t * ser_type_hash)
+  const rosidl_type_hash_t * ser_type_hash,
+  const std::unordered_map<std::string, std::string> * buffer_backends)
 {
-  if (fill_data_entity_qos_from_profile(qos_policies, type_hash, datawriter_qos, ser_type_hash)) {
+  if (fill_data_entity_qos_from_profile(
+      qos_policies, type_hash, datawriter_qos, ser_type_hash, buffer_backends))
+  {
     // The type support in the RMW implementation is always XCDR1.
     constexpr auto rep = eprosima::fastdds::dds::XCDR_DATA_REPRESENTATION;
     datawriter_qos.representation().clear();

--- a/rmw_fastrtps_shared_cpp/src/rmw_wait.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_wait.cpp
@@ -85,6 +85,11 @@ static bool has_triggered_condition(
       {
         return true;
       }
+      if (custom_subscriber_info->buffer_data_guard_ &&
+        custom_subscriber_info->buffer_data_guard_->get_trigger_value())
+      {
+        return true;
+      }
     }
   }
 
@@ -160,6 +165,9 @@ __rmw_wait(
         auto custom_subscriber_info = static_cast<CustomSubscriberInfo *>(data);
         attached_conditions.push_back(
           &custom_subscriber_info->data_reader_->get_statuscondition());
+        if (custom_subscriber_info->buffer_data_guard_) {
+          attached_conditions.push_back(custom_subscriber_info->buffer_data_guard_.get());
+        }
       }
     }
 
@@ -231,10 +239,20 @@ __rmw_wait(
       void * data = subscriptions->subscribers[i];
       auto custom_subscriber_info = static_cast<CustomSubscriberInfo *>(data);
 
+      bool has_data = false;
       eprosima::fastdds::dds::SampleInfo sample_info;
-      if (eprosima::fastdds::dds::RETCODE_OK !=
+      if (eprosima::fastdds::dds::RETCODE_OK ==
         custom_subscriber_info->data_reader_->get_first_untaken_info(&sample_info))
       {
+        has_data = true;
+      }
+      if (!has_data && custom_subscriber_info->buffer_data_guard_ &&
+        custom_subscriber_info->buffer_data_guard_->get_trigger_value())
+      {
+        has_data = true;
+        custom_subscriber_info->buffer_data_guard_->set_trigger_value(false);
+      }
+      if (!has_data) {
         subscriptions->subscribers[i] = 0;
       }
     }


### PR DESCRIPTION
## Description

This pull request adds full `rosidl::Buffer` support to `rmw_fastrtps_cpp`, enabling per-endpoint DDS DataWriters/DataReaders for zero-copy buffer transport between compatible backends. Backend discovery uses DDS `user_data` QoS to advertise and detect supported backends.

This pull request modifies the following packages:

### `rmw_fastrtps_shared_cpp` -- shared types and QoS

- **`custom_participant_info.hpp`**: Added `BufferDiscoveryCallback` type and `buffer_discovery_cb_` field for participant-level buffer discovery.
- **`custom_publisher_info.hpp`**: Added `BufferPublisherEndpoint` struct and buffer-related fields (`is_buffer_aware_`, `backend_aux_info_`, `local_endpoint_info_`, `buffer_mutex_`, `buffer_endpoints_`, `pending_buffer_endpoints_`, `buffer_alive_flag_`, `participant_`, `dds_publisher_`).
- **`custom_subscriber_info.hpp`**: Added `BufferSubscriptionEndpoint` struct (with `owns_topic` flag for single-process topic reuse) and buffer-related fields. Added `RMWSubscriptionEvent::notify_buffer_data_available()`.
- **`qos.hpp`/`qos.cpp`**: Added optional `buffer_backends` parameter to QoS functions; added `encode_buffer_backends_for_user_data()` / `parse_buffer_backends_from_user_data()` (format: `BUFBE:name=aux;name2=aux2`).
- **`rmw_wait.cpp`**: Extended WaitSet to also check `buffer_data_guard_`; wakes subscription when buffer data is available.

### `rmw_fastrtps_cpp` -- buffer-aware per-endpoint pub/sub

- **Backend lifecycle**: Calls `initialize_buffer_backends()` / `shutdown_buffer_backends()` during `rmw_init`/`rmw_shutdown`.
- **`buffer_endpoint_registry`**: Per-process singleton mapping topic names to discovery callbacks; publishers register subscriber-discovery callbacks and vice versa. Maintains known endpoints so late-registering callbacks see already-discovered peers.
- **Publisher creation**: Detects buffer-aware types via `callbacks->has_buffer_fields`; encodes backend names in DDS `user_data` with `"cpu"` always present. Registers subscriber-discovery callbacks that create per-subscriber DataWriters on unique topics (`{topic}/_buf/{pub_gid}_{sub_gid}`) with reliable QoS, synchronous publish mode, and data sharing off. Discovery callbacks use `buffer_alive_flag_` to prevent use-after-free.
- **Subscription creation**: Parses `acceptable_buffer_backends` (`NULL`/empty/`"cpu"`: CPU-only; `"any"`: all; specific names: filtered). Creates per-publisher DataReaders with `BufferDataReaderListener` that triggers `buffer_data_guard_`. **Topic reuse**: In single-process scenarios, uses `lookup_topicdescription()` to reuse existing topics (`owns_topic = false`).
- **Buffer-aware publish** (`rmw_publish.cpp`): Iterates per-subscriber endpoints, calls `cdr_serialize_with_endpoint()`. Conditionally publishes to the main DataWriter only when non-buffer-aware subscribers exist, avoiding unnecessary CPU conversion.
- **Buffer-aware take** (`rmw_take.cpp`): Iterates per-publisher DataReaders, takes raw CDR bytes and calls `cdr_deserialize_with_endpoint()`. Falls back to main DataReader when no buffer endpoint data is available. **Guard condition re-arm**: Re-sets `buffer_data_guard_` when remaining data exists.
- **Lock-ordering safety**: Both publisher and subscriber discovery use a three-phase pattern matching `rmw_zenoh_cpp`: (1) acquire `buffer_mutex_` to check duplicates and mark pending; (2) call DDS create/delete APIs without holding the lock; (3) re-acquire to store endpoints. Destroy functions move endpoints to local lists under lock and clean up DDS resources after releasing.

### Is this user-facing behavior change?

This pull request does not change existing `rmw_fastrtps` behavior for standard messages. For messages with `uint8[]` fields, the per-endpoint transport is transparent -- publishers and subscribers share backend info via DDS `user_data`, and CPU fallback ensures correctness when backends are incompatible.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

Yes. Claude (claude-4.6-opus) via Cursor was used to assist with creating an initial prototype version of the changes contained in this PR.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

This PR is part of the broader ROS 2 native buffer feature introduced in this [post](https://discourse.openrobotics.org/t/working-prototype-of-native-buffers-accelerated-memory-transport/52399).
