### PR TITLE
Added tracepoint

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/rmw_take.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_take.cpp
@@ -629,6 +629,12 @@ __rmw_take_loaned_message_internal(
 
   // No data available, return loan information.
   *taken = false;
+  TRACETOOLS_TRACEPOINT(
+    rmw_take,
+    static_cast<const void *>(subscription),
+    static_cast<const void *>(*loaned_message),
+    (message_info ? message_info->source_timestamp : 0LL),
+    *taken);
   return RMW_RET_OK;
 }
 


### PR DESCRIPTION
## Description

It's difficult to fully trace a ROS2 system using zero-copy, because the message loaning functions don't invoke the rmw_take tracepoint, like the other rmw_take variants. This corrects for that.

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information

