### PR TITLE
Enable content filtering flag

### DIFF
--- a/rmw_fastrtps_cpp/src/subscription.cpp
+++ b/rmw_fastrtps_cpp/src/subscription.cpp
@@ -458,6 +458,7 @@ __create_dynamic_subscription(
   rmw_subscription->options = *subscription_options;
   rmw_fastrtps_shared_cpp::__init_subscription_for_loans(rmw_subscription);
   rmw_subscription->is_cft_enabled = info->filtered_topic_ != nullptr;
+  rmw_subscription->is_cft_supported = true;
 
   cleanup_rmw_subscription.cancel();
   cleanup_datareader.cancel();
@@ -729,6 +730,7 @@ __create_subscription(
   rmw_subscription->options = *subscription_options;
   rmw_fastrtps_shared_cpp::__init_subscription_for_loans(rmw_subscription);
   rmw_subscription->is_cft_enabled = info->filtered_topic_ != nullptr;
+  rmw_subscription->is_cft_supported = true;
 
   cleanup_rmw_subscription.cancel();
   cleanup_datareader.cancel();


### PR DESCRIPTION
## Description

In ros2/rcl#1293, It is not good way to determine whether the current rmw implementation supports content filtering at the rcl layer. This PR moves enabling content filter flag to the rmw layer.

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information

