### PR TITLE
Add rmw_is_loaned_message_valid to rmw_fastrtps_shared_cpp

### DIFF
--- a/rmw_fastrtps_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_cpp/CMakeLists.txt
@@ -72,6 +72,7 @@ add_library(rmw_fastrtps_cpp
   src/rmw_get_topic_endpoint_info.cpp
   src/rmw_guard_condition.cpp
   src/rmw_init.cpp
+  src/rmw_is_loaned_message_valid.cpp
   src/rmw_node.cpp
   src/rmw_node_info_and_types.cpp
   src/rmw_node_names.cpp

--- a/rmw_fastrtps_cpp/src/rmw_is_loaned_message_valid.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_is_loaned_message_valid.cpp
@@ -1,0 +1,28 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "rmw/rmw.h"
+#include "rmw_fastrtps_shared_cpp/rmw_is_loaned_message_valid.hpp"
+#include "rmw_fastrtps_cpp/identifier.hpp"
+extern "C" {
+rmw_ret_t
+rmw_is_loaned_message_valid(
+  const rmw_subscription_t * subscription,
+  const void * loaned_message,
+  const rmw_message_info_t * message_info,
+  bool * is_valid)
+{
+  return rmw_fastrtps_shared_cpp::rmw_is_loaned_message_valid(
+    subscription, loaned_message, message_info, is_valid);
+}
+}  // extern "C"

--- a/rmw_fastrtps_dynamic_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_dynamic_cpp/CMakeLists.txt
@@ -70,6 +70,7 @@ add_library(rmw_fastrtps_dynamic_cpp
   src/rmw_get_topic_endpoint_info.cpp
   src/rmw_guard_condition.cpp
   src/rmw_init.cpp
+  src/rmw_is_loaned_message_valid.cpp
   src/rmw_logging.cpp
   src/rmw_node.cpp
   src/rmw_node_info_and_types.cpp

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_is_loaned_message_valid.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_is_loaned_message_valid.cpp
@@ -1,0 +1,28 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "rmw/rmw.h"
+#include "rmw_fastrtps_shared_cpp/rmw_is_loaned_message_valid.hpp"
+#include "rmw_fastrtps_dynamic_cpp/identifier.hpp"
+extern "C" {
+rmw_ret_t
+rmw_is_loaned_message_valid(
+  const rmw_subscription_t * subscription,
+  const void * loaned_message,
+  const rmw_message_info_t * message_info,
+  bool * is_valid)
+{
+  return rmw_fastrtps_shared_cpp::rmw_is_loaned_message_valid(
+    subscription, loaned_message, message_info, is_valid);
+}
+}  // extern "C"

--- a/rmw_fastrtps_shared_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_shared_cpp/CMakeLists.txt
@@ -75,6 +75,7 @@ add_library(rmw_fastrtps_shared_cpp
   src/rmw_get_topic_endpoint_info.cpp
   src/rmw_guard_condition.cpp
   src/rmw_init.cpp
+  src/rmw_is_loaned_message_valid.cpp
   src/rmw_logging.cpp
   src/rmw_node.cpp
   src/rmw_node_info_and_types.cpp

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/rmw_is_loaned_message_valid.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/rmw_is_loaned_message_valid.hpp
@@ -1,0 +1,44 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RMW_FASTRTPS_SHARED_CPP__RMW_IS_LOANED_MESSAGE_VALID_HPP_
+#define RMW_FASTRTPS_SHARED_CPP__RMW_IS_LOANED_MESSAGE_VALID_HPP_
+
+#include "rmw_fastrtps_shared_cpp/visibility_control.h"
+#include "rmw/rmw.h"
+
+namespace rmw_fastrtps_shared_cpp
+{
+/**
+ * Check if a loaned message is still valid (not overwritten by middleware).
+ *
+ * This function checks if the loaned message memory has been invalidated
+ * by the middleware (e.g., when using shared memory with Fast-DDS data-sharing).
+ *
+ * \param[in] subscription The rmw subscription handle
+ * \param[in] loaned_message Pointer to the loaned message data
+ * \param[in] message_info Message info containing publisher_gid and sequence_number
+ * \param[out] is_valid Output parameter indicating if the message is valid
+ * \return RMW_RET_OK if successful, RMW_RET_INVALID_ARGUMENT if parameters are invalid
+ */
+RMW_FASTRTPS_SHARED_CPP_PUBLIC
+rmw_ret_t
+rmw_is_loaned_message_valid(
+  const rmw_subscription_t * subscription,
+  const void * loaned_message,
+  const rmw_message_info_t * message_info,
+  bool * is_valid);
+}  // namespace rmw_fastrtps_shared_cpp
+
+#endif  // RMW_FASTRTPS_SHARED_CPP__RMW_IS_LOANED_MESSAGE_VALID_HPP_

--- a/rmw_fastrtps_shared_cpp/src/rmw_is_loaned_message_valid.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_is_loaned_message_valid.cpp
@@ -1,0 +1,62 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rmw_fastrtps_shared_cpp/rmw_is_loaned_message_valid.hpp"
+#include <cstdint>
+
+#include "fastdds/dds/subscriber/DataReader.hpp"
+#include "fastdds/dds/subscriber/SampleInfo.hpp"
+#include "fastdds/rtps/common/Guid.hpp"
+#include "fastdds/rtps/common/SequenceNumber.hpp"
+
+#include "rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp"
+#include "rmw_fastrtps_shared_cpp/guid_utils.hpp"
+
+namespace rmw_fastrtps_shared_cpp
+{
+
+rmw_ret_t
+rmw_is_loaned_message_valid(
+  const rmw_subscription_t * subscription,
+  const void * loaned_message,
+  const rmw_message_info_t * message_info,
+  bool * is_valid)
+{
+  if (!subscription || !loaned_message || !message_info || !is_valid) {
+    return RMW_RET_INVALID_ARGUMENT;
+  }
+
+  *is_valid = true;
+  auto * info = static_cast<CustomSubscriberInfo *>(subscription->data);
+  if (!info || !info->data_reader_) {
+    return RMW_RET_OK;
+  }
+
+  eprosima::fastdds::dds::SampleInfo sample_info{};
+  eprosima::fastdds::rtps::GUID_t writer_guid;
+  copy_from_byte_array_to_fastdds_guid(
+    message_info->publisher_gid.data, &writer_guid);
+  uint64_t seq = message_info->publication_sequence_number;
+  eprosima::fastdds::rtps::SequenceNumber_t seq_num;
+  seq_num.high = static_cast<int32_t>(seq >> 32);
+  seq_num.low = static_cast<uint32_t>(seq & 0xFFFFFFFF);
+  sample_info.sample_identity.writer_guid(writer_guid);
+  sample_info.sample_identity.sequence_number(seq_num);
+
+  *is_valid = info->data_reader_->is_sample_valid(loaned_message, &sample_info);
+
+  return RMW_RET_OK;
+}
+
+}  // namespace rmw_fastrtps_shared_cpp


### PR DESCRIPTION
## Summary
Exposes Fast-DDS's `is_sample_valid()` check through the rmw layer to allow users to verify if loaned message memory is still valid.
Addresses ros2/rclcpp#3119
## Description
When using loaned messages with zero-copy over shared memory, the middleware may overwrite previously loaned memory under certain conditions:
- The publisher and subscriber share a history cache in shared memory, so the publisher can cause changes in the subscriber's loaned memory even while the subscriber still holds a reference.
- With PREALLOCATED_WITH_REALLOC memory policy, shared memory still in use may be reissued to new incoming samples.
- The subscriber currently has no way to detect that its loaned data has been silently invalidated.
This function exposes Fast-DDS's internal validity check through the rmw layer, allowing users to detect if their loaned data has been silently invalidated.
**Files Added:**
- `rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/rmw_is_loaned_message_valid.hpp`
- `rmw_fastrtps_shared_cpp/src/rmw_is_loaned_message_valid.cpp`
**Function Signature:**
```c
rmw_ret_t rmw_is_loaned_message_valid(
  const rmw_subscription_t * subscription,
  const void * loaned_message,
  const rmw_message_info_t * message_info,
  bool * is_valid);
```
Fixes ros2/rclcpp#3119
## Is this user-facing behavior change?
No. This is a low-level RMW implementation. 
## Did you use Generative AI?
No.
## Additional Information
