### PR TITLE
fix: set collection header element_flags TryConstructFailAction::DISCARD instead of 0

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/TypeSupport_impl.cpp
+++ b/rmw_fastrtps_shared_cpp/src/TypeSupport_impl.cpp
@@ -552,7 +552,10 @@ MemberIdentifierName GetTypeIdentifier(const MembersType * members, uint32_t ind
               equiv_kind = xtypes::EK_BOTH;
             }
             xtypes::PlainCollectionHeader header {TypeObjectUtils::
-              build_plain_collection_header(equiv_kind, 0)};
+              build_plain_collection_header(
+                equiv_kind,
+                TypeObjectUtils::build_collection_element_flag(
+                  xtypes::TryConstructFailAction::DISCARD, false))};
             bool ec = false;
             TypeIdentifier * element_identifier = {new TypeIdentifier(
                 TypeObjectUtils::retrieve_complete_type_identifier(
@@ -604,7 +607,10 @@ MemberIdentifierName GetTypeIdentifier(const MembersType * members, uint32_t ind
               equiv_kind = xtypes::EK_BOTH;
             }
             xtypes::PlainCollectionHeader header {TypeObjectUtils::
-              build_plain_collection_header(equiv_kind, 0)};
+              build_plain_collection_header(
+                equiv_kind,
+                TypeObjectUtils::build_collection_element_flag(
+                  xtypes::TryConstructFailAction::DISCARD, false))};
             bool ec = false;
             TypeIdentifier * element_identifier = {new TypeIdentifier(
                 TypeObjectUtils::retrieve_complete_type_identifier(
@@ -648,7 +654,10 @@ MemberIdentifierName GetTypeIdentifier(const MembersType * members, uint32_t ind
             equiv_kind = xtypes::EK_BOTH;
           }
           xtypes::PlainCollectionHeader header {TypeObjectUtils::
-            build_plain_collection_header(equiv_kind, 0)};
+            build_plain_collection_header(
+              equiv_kind,
+              TypeObjectUtils::build_collection_element_flag(
+                xtypes::TryConstructFailAction::DISCARD, false))};
           bool ec = false;
           TypeIdentifier * element_identifier = {new TypeIdentifier(
               TypeObjectUtils::retrieve_complete_type_identifier(


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
set collection header element_flags TryConstructFailAction::DISCARD instead of 0
cyclonedds 11 treats 0 as invalid value.
```
1775381971.924340 [0] dq.builtin: type [PLAIN_SEQUENCE_SMALL 0000000000000000000000000000]: ddsi_xt_type_init_impl with invalid type object
1775381971.924364 [0] dq.builtin: type [COMPLETE e1511f550bc23ce73cbdebe3dd84]: ddsi_xt_type_add_typeobj with invalid type object
```

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->
yes, codex

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
