### PR TITLE
Change the buffer-aware BUFBE: -> bufbe.

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/qos.cpp
+++ b/rmw_fastrtps_shared_cpp/src/qos.cpp
@@ -30,6 +30,7 @@
 #include "fastdds/dds/topic/qos/TopicQos.hpp"
 
 #include "rmw/error_handling.h"
+#include "rmw/impl/cpp/key_value.hpp"
 
 #include "rmw_dds_common/qos.hpp"
 
@@ -155,8 +156,14 @@ bool fill_entity_qos_from_profile(
   return true;
 }
 
-static const char * BUFFER_BACKEND_SENTINEL = "BUFBE:";
-static const size_t BUFFER_BACKEND_SENTINEL_LEN = 6;
+// Encoded as a regular key=value;-style user_data entry so that the shared
+// rmw::impl::cpp::parse_key_value parser (which only accepts alnum keys and
+// stops at the first non-alnum byte in a key) does not abort on the rest of
+// the user_data string. Inside the bufbe value, backends are joined by ',' and
+// each backend is `<name>:<aux>` (neither ',' nor ':' may appear in a name or
+// aux). The value cannot contain ';' (parse_key_value treats it as a
+// terminator).
+static const char * BUFFER_BACKEND_KEY = "bufbe";
 
 std::string
 encode_buffer_backends_for_user_data(
@@ -166,15 +173,16 @@ encode_buffer_backends_for_user_data(
     return {};
   }
   std::ostringstream ss;
-  ss << BUFFER_BACKEND_SENTINEL;
+  ss << BUFFER_BACKEND_KEY << '=';
   bool first = true;
   for (const auto & [name, aux] : backends) {
     if (!first) {
-      ss << ';';
+      ss << ',';
     }
-    ss << name << '=' << aux;
+    ss << name << ':' << aux;
     first = false;
   }
+  ss << ';';
   return ss.str();
 }
 
@@ -182,27 +190,25 @@ std::unordered_map<std::string, std::string>
 parse_buffer_backends_from_user_data(const uint8_t * data, size_t size)
 {
   std::unordered_map<std::string, std::string> result;
-  if (!data || size < BUFFER_BACKEND_SENTINEL_LEN) {
+  if (!data || size == 0) {
     return result;
   }
-  std::string str(reinterpret_cast<const char *>(data), size);
-  auto pos = str.find(BUFFER_BACKEND_SENTINEL);
-  if (pos == std::string::npos) {
+  std::vector<uint8_t> udvec(data, data + size);
+  auto kv = rmw::impl::cpp::parse_key_value(udvec);
+  auto it = kv.find(BUFFER_BACKEND_KEY);
+  if (it == kv.end()) {
     return result;
   }
-  std::string backends_str = str.substr(pos + BUFFER_BACKEND_SENTINEL_LEN);
-  if (backends_str.empty()) {
-    return result;
-  }
+  std::string backends_str(it->second.begin(), it->second.end());
   std::istringstream ss(backends_str);
   std::string entry;
-  while (std::getline(ss, entry, ';')) {
+  while (std::getline(ss, entry, ',')) {
     if (entry.empty()) {
       continue;
     }
-    size_t eq = entry.find('=');
-    std::string name = entry.substr(0, eq);
-    std::string aux = (eq == std::string::npos) ? "" : entry.substr(eq + 1);
+    size_t colon = entry.find(':');
+    std::string name = entry.substr(0, colon);
+    std::string aux = (colon == std::string::npos) ? "" : entry.substr(colon + 1);
     if (!name.empty()) {
       result[name] = aux;
     }

--- a/rmw_fastrtps_shared_cpp/test/CMakeLists.txt
+++ b/rmw_fastrtps_shared_cpp/test/CMakeLists.txt
@@ -16,6 +16,16 @@ if(TARGET test_rmw_qos_to_dds_attributes)
   )
 endif()
 
+ament_add_gtest(test_buffer_backend_user_data test_buffer_backend_user_data.cpp)
+if(TARGET test_buffer_backend_user_data)
+  target_link_libraries(test_buffer_backend_user_data
+    ${PROJECT_NAME}
+    rmw::rmw
+    rmw_dds_common::rmw_dds_common_library
+    rosidl_runtime_c::rosidl_runtime_c
+  )
+endif()
+
 ament_add_gmock(test_security_logging test_security_logging.cpp)
 if(TARGET test_security_logging)
   target_link_libraries(test_security_logging

--- a/rmw_fastrtps_shared_cpp/test/test_buffer_backend_user_data.cpp
+++ b/rmw_fastrtps_shared_cpp/test/test_buffer_backend_user_data.cpp
@@ -1,0 +1,168 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "rmw/ret_types.h"
+#include "rmw_dds_common/qos.hpp"
+#include "rmw_fastrtps_shared_cpp/qos.hpp"
+#include "rosidl_runtime_c/type_hash.h"
+
+namespace
+{
+
+rosidl_type_hash_t make_test_type_hash()
+{
+  rosidl_type_hash_t h{};
+  h.version = 1;
+  for (size_t i = 0; i < sizeof(h.value); ++i) {
+    h.value[i] = static_cast<uint8_t>(i + 1);
+  }
+  return h;
+}
+
+std::vector<uint8_t> to_bytes(const std::string & s)
+{
+  return std::vector<uint8_t>(s.begin(), s.end());
+}
+
+}  // namespace
+
+// Regression test for the bug where buffer-aware publishers appended a
+// non-alnum sentinel to user_data, causing the shared parse_key_value parser
+// to abort and return an empty map. That made parse_type_hash_from_user_data
+// fall back to a zero-initialized hash, which `ros2 topic info -v` rendered
+// as "INVALID" for any message containing a `uint8[]` field
+// (sensor_msgs/Image, std_msgs/UInt8MultiArray, ...).
+TEST(test_buffer_backend_user_data, type_hash_round_trips_with_buffer_backends)
+{
+  const rosidl_type_hash_t expected_hash = make_test_type_hash();
+
+  std::string user_data_str;
+  ASSERT_EQ(
+    RMW_RET_OK,
+    rmw_dds_common::encode_type_hash_for_user_data_qos(expected_hash, user_data_str));
+
+  std::unordered_map<std::string, std::string> backends{
+    {"cpu", ""},
+  };
+  user_data_str += encode_buffer_backends_for_user_data(backends);
+
+  const auto bytes = to_bytes(user_data_str);
+
+  rosidl_type_hash_t parsed_hash = rosidl_get_zero_initialized_type_hash();
+  ASSERT_EQ(
+    RMW_RET_OK,
+    rmw_dds_common::parse_type_hash_from_user_data(
+      bytes.data(), bytes.size(), parsed_hash));
+
+  EXPECT_EQ(parsed_hash.version, expected_hash.version);
+  EXPECT_EQ(
+    0,
+    std::memcmp(parsed_hash.value, expected_hash.value, sizeof(expected_hash.value)));
+}
+
+TEST(test_buffer_backend_user_data, buffer_backends_round_trip_after_type_hash)
+{
+  const rosidl_type_hash_t expected_hash = make_test_type_hash();
+
+  std::string user_data_str;
+  ASSERT_EQ(
+    RMW_RET_OK,
+    rmw_dds_common::encode_type_hash_for_user_data_qos(expected_hash, user_data_str));
+
+  const std::unordered_map<std::string, std::string> expected_backends{
+    {"cpu", ""},
+    {"gpu", "device=0"},
+  };
+  user_data_str += encode_buffer_backends_for_user_data(expected_backends);
+
+  const auto bytes = to_bytes(user_data_str);
+  auto parsed = parse_buffer_backends_from_user_data(bytes.data(), bytes.size());
+
+  EXPECT_EQ(parsed, expected_backends);
+}
+
+TEST(test_buffer_backend_user_data, type_hash_round_trips_with_sertype_hash_and_buffers)
+{
+  const rosidl_type_hash_t expected_type_hash = make_test_type_hash();
+  rosidl_type_hash_t expected_ser_type_hash = make_test_type_hash();
+  expected_ser_type_hash.value[0] = 0xAA;
+
+  std::string user_data_str;
+  ASSERT_EQ(
+    RMW_RET_OK,
+    rmw_dds_common::encode_type_hash_for_user_data_qos(expected_type_hash, user_data_str));
+
+  std::string ser_str;
+  ASSERT_EQ(
+    RMW_RET_OK,
+    rmw_dds_common::encode_sertype_hash_for_user_data_qos(expected_ser_type_hash, ser_str));
+  user_data_str += ser_str;
+
+  const std::unordered_map<std::string, std::string> backends{
+    {"cpu", ""},
+  };
+  user_data_str += encode_buffer_backends_for_user_data(backends);
+
+  const auto bytes = to_bytes(user_data_str);
+
+  rosidl_type_hash_t parsed_type_hash = rosidl_get_zero_initialized_type_hash();
+  ASSERT_EQ(
+    RMW_RET_OK,
+    rmw_dds_common::parse_type_hash_from_user_data(
+      bytes.data(), bytes.size(), parsed_type_hash));
+  EXPECT_EQ(parsed_type_hash.version, expected_type_hash.version);
+  EXPECT_EQ(
+    0,
+    std::memcmp(
+      parsed_type_hash.value, expected_type_hash.value, sizeof(expected_type_hash.value)));
+
+  rosidl_type_hash_t parsed_ser_type_hash = rosidl_get_zero_initialized_type_hash();
+  ASSERT_EQ(
+    RMW_RET_OK,
+    rmw_dds_common::parse_sertype_hash_from_user_data(
+      bytes.data(), bytes.size(), parsed_ser_type_hash));
+  EXPECT_EQ(parsed_ser_type_hash.version, expected_ser_type_hash.version);
+  EXPECT_EQ(
+    0,
+    std::memcmp(
+      parsed_ser_type_hash.value,
+      expected_ser_type_hash.value,
+      sizeof(expected_ser_type_hash.value)));
+
+  auto parsed_backends = parse_buffer_backends_from_user_data(bytes.data(), bytes.size());
+  EXPECT_EQ(parsed_backends, backends);
+}
+
+TEST(test_buffer_backend_user_data, empty_backends_emit_nothing)
+{
+  const std::unordered_map<std::string, std::string> empty_backends;
+  EXPECT_EQ(encode_buffer_backends_for_user_data(empty_backends), std::string{});
+}
+
+TEST(test_buffer_backend_user_data, parse_returns_empty_when_key_absent)
+{
+  const std::string user_data = "typehash=RIHS01_"
+    "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20;";
+  const auto bytes = to_bytes(user_data);
+  auto parsed = parse_buffer_backends_from_user_data(bytes.data(), bytes.size());
+  EXPECT_TRUE(parsed.empty());
+}


### PR DESCRIPTION
## Description

The buffer-aware work appends a BUFBE: sentinel to the publisher's user_data QoS field.  But parse_key_value does not support colons in keys, so all type hashes for buffers using this would be INVALID.

Fix this by dropping the colon from the sentinel, which makes it pass parse_key_value and keep type hashes working.

Also add in a regression test here.

This should be merged at approximately the same time as https://github.com/ros2/rmw_fastrtps/pull/879 , https://github.com/ros2/rmw_fastrtps/pull/881 , and https://github.com/ros2/system_tests/pull/592

### Is this user-facing behavior change?

No.

### Did you use Generative AI?

Yes, Claude Opus 4.7

### Additional Information

This should be backported to Lyrical.