### PR TITLE
Clean up logs for the rosidl::Buffer path

### DIFF
--- a/rmw_fastrtps_cpp/src/rmw_publish.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publish.cpp
@@ -111,12 +111,10 @@ create_pending_buffer_writers(CustomPublisherInfo * info)
     }
     endpoint->data_writer = data_writer;
 
-    RCUTILS_LOG_INFO_NAMED(
-      "rmw_fastrtps_cpp",
-      "Buffer publisher: created per-sub endpoint '%s'", p.unique_topic.c_str());
     RCUTILS_LOG_DEBUG_NAMED(
       "rmw_fastrtps_cpp",
-      "Buffer publisher endpoint '%s': reliability=%d, durability=%d, history=%d depth=%d",
+      "Buffer publisher: created per-sub endpoint '%s': "
+      "reliability=%d, durability=%d, history=%d depth=%d",
       p.unique_topic.c_str(),
       writer_qos.reliability().kind,
       writer_qos.durability().kind,

--- a/rmw_fastrtps_cpp/src/rmw_publisher.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publisher.cpp
@@ -201,7 +201,7 @@ rmw_create_publisher(
               // CPU-only subscriber: track its GID; the shared CPU channel
               // DataWriter will serve it -- no per-subscriber endpoint needed.
               state->cpu_only_subscribers.push_back(sub_info.gid);
-              RCUTILS_LOG_INFO_NAMED(
+              RCUTILS_LOG_DEBUG_NAMED(
                 "rmw_fastrtps_cpp",
                 "Buffer publisher: CPU-only subscriber discovered on '%s', "
                 "served by shared CPU channel",
@@ -262,7 +262,7 @@ rmw_create_publisher(
             pending.backend_metadata = sub_info.backend_metadata;
             state->pending.push_back(std::move(pending));
 
-            RCUTILS_LOG_INFO_NAMED(
+            RCUTILS_LOG_DEBUG_NAMED(
               "rmw_fastrtps_cpp",
               "Buffer publisher: non-CPU subscriber discovered, queued '%s'",
               unique_topic.c_str());

--- a/rmw_fastrtps_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_subscription.cpp
@@ -199,7 +199,7 @@ rmw_create_subscription(
             }
           }
 
-          RCUTILS_LOG_INFO_NAMED(
+          RCUTILS_LOG_DEBUG_NAMED(
             "rmw_fastrtps_cpp",
             "Buffer subscription: publisher discovered, recorded '%s'",
             pub_hex.c_str());


### PR DESCRIPTION
## Description

Change logs related to `rosidl::Buffer` path from `INFO` to `DEBUG`.
<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->


### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

Users now only see buffer relevant logs in DEBUG log level.

### Did you use Generative AI?

No.

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information
NA

<!--
If applicable, provide any additional context or details about the changes.
-->
