### PR TITLE
Expose discovered rosidle buffer backends through graph cache

### DIFF
--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp
@@ -265,6 +265,8 @@ private:
         {
           ser_type_hash_ptr = &ser_type_hash;
         }
+        auto buffer_backends = parse_buffer_backends_from_user_data(
+          userDataValue.data(), userDataValue.size());
         context->graph_cache.add_entity(
           rmw_fastrtps_shared_cpp::create_rmw_gid(
             identifier_,
@@ -277,13 +279,12 @@ private:
             proxyData.participant_guid),
           qos_profile,
           is_reader,
-          ser_type_hash_ptr);
+          ser_type_hash_ptr,
+          buffer_backends);
 
         // Parse buffer backend info and invoke callback if present.
         // Copy the callback outside the lock so buffer_cb_mutex_ is not held
         // during the callback (which may acquire other mutexes or do DDS work).
-        auto buffer_backends = parse_buffer_backends_from_user_data(
-          userDataValue.data(), userDataValue.size());
         if (!buffer_backends.empty()) {
           BufferDiscoveryCallback cb_copy;
           {


### PR DESCRIPTION
## Description

Pass discovered rosidl buffer backend metadata from Fast DDS user data into the shared graph cache.

Fast DDS already advertises and parses buffer backend metadata through endpoint user data. This change preserves that parsed metadata in graph endpoint info so tools such as `ros2 topic info -v` can display backend support for publishers and subscriptions.


### Is this user-facing behavior change?

Yes. Users can inspect Fast DDS topic endpoints and see advertised rosidl buffer backend support through ROS graph introspection tools.

### Did you use Generative AI?

Yes. GPT-5.5 in Cursor was used to help draft changes in this pull request.

### Additional Information

Depending on:
- https://github.com/ros2/rmw/pull/419
- https://github.com/ros2/rmw_dds_common/pull/88