### PR TITLE
Serialize encapsulation header on buffer aware topics

### DIFF
--- a/rmw_fastrtps_cpp/src/rmw_publish.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publish.cpp
@@ -182,6 +182,7 @@ publish_to_buffer_endpoints(
       fast_buffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
       eprosima::fastcdr::CdrVersion::XCDRv1);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+    ser.serialize_encapsulation();
 
     auto * backend_context =
       static_cast<const rmw_fastrtps_cpp::BufferBackendContext *>(info->serialization_context_);

--- a/rmw_fastrtps_cpp/src/rmw_take.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_take.cpp
@@ -139,7 +139,7 @@ take_buffer_aware(
   eprosima::fastcdr::Cdr deser(
     receive_buffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN);
   try {
-    deser.deserialize_encapsulation();
+    deser.read_encapsulation();
   } catch (...) {
     RCUTILS_LOG_ERROR_ONCE_NAMED(
       "rmw_fastrtps_cpp",

--- a/rmw_fastrtps_cpp/src/rmw_take.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_take.cpp
@@ -137,9 +137,8 @@ take_buffer_aware(
   }
 
   eprosima::fastcdr::Cdr deser(
-    receive_buffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
-    eprosima::fastcdr::CdrVersion::XCDRv1);
-  deser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+    receive_buffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN);
+  deser.read_encapsulation();
 
   auto * backend_context =
     static_cast<const rmw_fastrtps_cpp::BufferBackendContext *>(info->serialization_context_);

--- a/rmw_fastrtps_cpp/src/rmw_take.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_take.cpp
@@ -144,7 +144,8 @@ take_buffer_aware(
     RCUTILS_LOG_ERROR_ONCE_NAMED(
       "rmw_fastrtps_cpp",
       "Failed to read encapsulation in buffer-aware topic from publisher '%s': "
-      "Please ensure that the publisher is using the last version of rmw_fastrtps_cpp", writer_hex.c_str());
+      "Please ensure that the publisher is using the last version of rmw_fastrtps_cpp",
+      writer_hex.c_str());
     return RMW_RET_OK;
   }
 

--- a/rmw_fastrtps_cpp/src/rmw_take.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_take.cpp
@@ -138,7 +138,15 @@ take_buffer_aware(
 
   eprosima::fastcdr::Cdr deser(
     receive_buffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN);
-  deser.read_encapsulation();
+  try {
+    deser.deserialize_encapsulation();
+  } catch (...) {
+    RCUTILS_LOG_ERROR_ONCE_NAMED(
+      "rmw_fastrtps_cpp",
+      "Failed to read encapsulation in buffer-aware topic from publisher '%s': "
+      "Please ensure that the publisher is using the last version of rmw_fastrtps_cpp", writer_hex.c_str());
+    return RMW_RET_OK;
+  }
 
   auto * backend_context =
     static_cast<const rmw_fastrtps_cpp::BufferBackendContext *>(info->serialization_context_);


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

While creating a native DDS consumer for rosidl buffer custom topics, I discovered that the encapsulation header required by the RTPS standard is not added for the reader-GUID-based topics.

This PR adds the encapsulation header when publishing, and consumes it when taking.

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

No, but the custom serialization changes.
I would nonetheless consider backporting to lyrical.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

No.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

I verified that the [GPU buffer transport tutorial](https://docs.ros.org/en/rolling/Tutorials/Demos/GPU-Buffer-Transport.html) works with these changes