### PR TITLE
Fixes in `rmw_wait`

### DIFF
--- a/rmw_fastrtps_shared_cpp/src/rmw_wait.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_wait.cpp
@@ -255,6 +255,10 @@ __rmw_wait(
       if (!has_data) {
         subscriptions->subscribers[i] = 0;
       }
+      else {
+        // We are returning a ready subscription, so we need to indicate that the wait was successful.
+        wait_result = true;
+      }
     }
   }
 
@@ -269,6 +273,10 @@ __rmw_wait(
       {
         clients->clients[i] = 0;
       }
+      else {
+        // We are returning a ready client, so we need to indicate that the wait was successful.
+        wait_result = true;
+      }
     }
   }
 
@@ -282,6 +290,10 @@ __rmw_wait(
         custom_service_info->request_reader_->get_first_untaken_info(&sample_info))
       {
         services->services[i] = 0;
+      }
+      else {
+        // We are returning a ready service, so we need to indicate that the wait was successful.
+        wait_result = true;
       }
     }
   }
@@ -318,6 +330,10 @@ __rmw_wait(
       if (!active) {
         events->events[i] = 0;
       }
+      else {
+        // We are returning a ready event, so we need to indicate that the wait was successful.
+        wait_result = true;
+      }
     }
   }
 
@@ -330,6 +346,8 @@ __rmw_wait(
       }
       else {
         condition->set_trigger_value(false);
+        // We are returning a ready guard condition, so we need to indicate that the wait was successful.
+        wait_result = true;
       }
     }
   }

--- a/rmw_fastrtps_shared_cpp/src/rmw_wait.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_wait.cpp
@@ -254,9 +254,9 @@ __rmw_wait(
       }
       if (!has_data) {
         subscriptions->subscribers[i] = 0;
-      }
-      else {
-        // We are returning a ready subscription, so we need to indicate that the wait was successful.
+      } else {
+        // We are returning a ready subscription,
+        // so we need to indicate that the wait was successful.
         wait_result = true;
       }
     }
@@ -272,9 +272,9 @@ __rmw_wait(
         custom_client_info->response_reader_->get_first_untaken_info(&sample_info))
       {
         clients->clients[i] = 0;
-      }
-      else {
-        // We are returning a ready client, so we need to indicate that the wait was successful.
+      } else {
+        // We are returning a ready client,
+        // so we need to indicate that the wait was successful.
         wait_result = true;
       }
     }
@@ -290,9 +290,9 @@ __rmw_wait(
         custom_service_info->request_reader_->get_first_untaken_info(&sample_info))
       {
         services->services[i] = 0;
-      }
-      else {
-        // We are returning a ready service, so we need to indicate that the wait was successful.
+      } else {
+        // We are returning a ready service,
+        // so we need to indicate that the wait was successful.
         wait_result = true;
       }
     }
@@ -329,9 +329,9 @@ __rmw_wait(
 
       if (!active) {
         events->events[i] = 0;
-      }
-      else {
-        // We are returning a ready event, so we need to indicate that the wait was successful.
+      } else {
+        // We are returning a ready event,
+        // so we need to indicate that the wait was successful.
         wait_result = true;
       }
     }
@@ -343,10 +343,10 @@ __rmw_wait(
       auto condition = static_cast<eprosima::fastdds::dds::GuardCondition *>(data);
       if (!condition->get_trigger_value()) {
         guard_conditions->guard_conditions[i] = 0;
-      }
-      else {
+      } else {
         condition->set_trigger_value(false);
-        // We are returning a ready guard condition, so we need to indicate that the wait was successful.
+        // We are returning a ready guard condition,
+        // so we need to indicate that the wait was successful.
         wait_result = true;
       }
     }

--- a/rmw_fastrtps_shared_cpp/src/rmw_wait.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_wait.cpp
@@ -328,7 +328,9 @@ __rmw_wait(
       if (!condition->get_trigger_value()) {
         guard_conditions->guard_conditions[i] = 0;
       }
-      condition->set_trigger_value(false);
+      else {
+        condition->set_trigger_value(false);
+      }
     }
   }
 


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

This fixes two things in `rmw_wait`:
* A race where a guard condition is triggered while traversing the collection of guard conditions, and is then untriggered during said traversal
* `RMW_RET_TIMEOUT` being returned when an element becomes ready after the wait set timed out

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

Related regression test in https://github.com/ros2/rmw_implementation/pull/280