### PR TITLE
fix: move history_memory_policy outside leave_middleware_default_qos guard

### DIFF
--- a/rmw_fastrtps_cpp/src/publisher.cpp
+++ b/rmw_fastrtps_cpp/src/publisher.cpp
@@ -242,15 +242,15 @@ rmw_fastrtps_cpp::create_publisher(
   publisher->get_datawriter_qos_from_profile(topic_name, writer_qos);
 
   // Modify specific DataWriter Qos
+  writer_qos.endpoint().history_memory_policy =
+    eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+
   if (!participant_info->leave_middleware_default_qos) {
     if (participant_info->publishing_mode == publishing_mode_t::ASYNCHRONOUS) {
       writer_qos.publish_mode().kind = eprosima::fastdds::dds::ASYNCHRONOUS_PUBLISH_MODE;
     } else if (participant_info->publishing_mode == publishing_mode_t::SYNCHRONOUS) {
       writer_qos.publish_mode().kind = eprosima::fastdds::dds::SYNCHRONOUS_PUBLISH_MODE;
     }
-
-    writer_qos.endpoint().history_memory_policy =
-      eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
 
     writer_qos.data_sharing().off();
   }

--- a/rmw_fastrtps_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_client.cpp
@@ -312,10 +312,10 @@ rmw_create_client(
   subscriber->get_datareader_qos_from_profile(topic_name_fallback, reader_qos);
   subscriber->get_datareader_qos_from_profile(response_topic_name, reader_qos);
 
-  if (!participant_info->leave_middleware_default_qos) {
-    reader_qos.endpoint().history_memory_policy =
-      eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  reader_qos.endpoint().history_memory_policy =
+    eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
 
+  if (!participant_info->leave_middleware_default_qos) {
     reader_qos.data_sharing().off();
   }
 
@@ -374,15 +374,15 @@ rmw_create_client(
   publisher->get_datawriter_qos_from_profile(request_topic_name, writer_qos);
 
   // Modify specific DataWriter Qos
+  writer_qos.endpoint().history_memory_policy =
+    eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+
   if (!participant_info->leave_middleware_default_qos) {
     if (participant_info->publishing_mode == publishing_mode_t::ASYNCHRONOUS) {
       writer_qos.publish_mode().kind = eprosima::fastdds::dds::ASYNCHRONOUS_PUBLISH_MODE;
     } else if (participant_info->publishing_mode == publishing_mode_t::SYNCHRONOUS) {
       writer_qos.publish_mode().kind = eprosima::fastdds::dds::SYNCHRONOUS_PUBLISH_MODE;
     }
-
-    writer_qos.endpoint().history_memory_policy =
-      eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
 
     writer_qos.data_sharing().off();
   }

--- a/rmw_fastrtps_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_service.cpp
@@ -308,10 +308,10 @@ rmw_create_service(
   subscriber->get_datareader_qos_from_profile(topic_name_fallback, reader_qos);
   subscriber->get_datareader_qos_from_profile(request_topic_name, reader_qos);
 
-  if (!participant_info->leave_middleware_default_qos) {
-    reader_qos.endpoint().history_memory_policy =
-      eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  reader_qos.endpoint().history_memory_policy =
+    eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
 
+  if (!participant_info->leave_middleware_default_qos) {
     reader_qos.data_sharing().off();
   }
 
@@ -374,15 +374,15 @@ rmw_create_service(
   publisher->get_datawriter_qos_from_profile(response_topic_name, writer_qos);
 
   // Modify specific DataWriter Qos
+  writer_qos.endpoint().history_memory_policy =
+    eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+
   if (!participant_info->leave_middleware_default_qos) {
     if (participant_info->publishing_mode == publishing_mode_t::ASYNCHRONOUS) {
       writer_qos.publish_mode().kind = eprosima::fastdds::dds::ASYNCHRONOUS_PUBLISH_MODE;
     } else if (participant_info->publishing_mode == publishing_mode_t::SYNCHRONOUS) {
       writer_qos.publish_mode().kind = eprosima::fastdds::dds::SYNCHRONOUS_PUBLISH_MODE;
     }
-
-    writer_qos.endpoint().history_memory_policy =
-      eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
 
     writer_qos.data_sharing().off();
   }

--- a/rmw_fastrtps_cpp/src/subscription.cpp
+++ b/rmw_fastrtps_cpp/src/subscription.cpp
@@ -416,10 +416,10 @@ __create_dynamic_subscription(
   // the QoS is already the default
   subscriber->get_datareader_qos_from_profile(topic_name, reader_qos);
 
-  if (!participant_info->leave_middleware_default_qos) {
-    reader_qos.endpoint().history_memory_policy =
-      eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  reader_qos.endpoint().history_memory_policy =
+    eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
 
+  if (!participant_info->leave_middleware_default_qos) {
     reader_qos.data_sharing().off();
   }
 
@@ -688,10 +688,10 @@ __create_subscription(
   // the QoS is already the default
   subscriber->get_datareader_qos_from_profile(topic_name, reader_qos);
 
-  if (!participant_info->leave_middleware_default_qos) {
-    reader_qos.endpoint().history_memory_policy =
-      eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  reader_qos.endpoint().history_memory_policy =
+    eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
 
+  if (!participant_info->leave_middleware_default_qos) {
     reader_qos.data_sharing().off();
   }
 

--- a/rmw_fastrtps_dynamic_cpp/src/publisher.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/publisher.cpp
@@ -249,15 +249,15 @@ rmw_fastrtps_dynamic_cpp::create_publisher(
   publisher->get_datawriter_qos_from_profile(topic_name, writer_qos);
 
   // Modify specific DataWriter Qos
+  writer_qos.endpoint().history_memory_policy =
+    eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+
   if (!participant_info->leave_middleware_default_qos) {
     if (participant_info->publishing_mode == publishing_mode_t::ASYNCHRONOUS) {
       writer_qos.publish_mode().kind = eprosima::fastdds::dds::ASYNCHRONOUS_PUBLISH_MODE;
     } else if (participant_info->publishing_mode == publishing_mode_t::SYNCHRONOUS) {
       writer_qos.publish_mode().kind = eprosima::fastdds::dds::SYNCHRONOUS_PUBLISH_MODE;
     }
-
-    writer_qos.endpoint().history_memory_policy =
-      eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
 
     writer_qos.data_sharing().off();
   }

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_client.cpp
@@ -341,10 +341,10 @@ rmw_create_client(
   subscriber->get_datareader_qos_from_profile(topic_name_fallback, reader_qos);
   subscriber->get_datareader_qos_from_profile(response_topic_name, reader_qos);
 
-  if (!participant_info->leave_middleware_default_qos) {
-    reader_qos.endpoint().history_memory_policy =
-      eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  reader_qos.endpoint().history_memory_policy =
+    eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
 
+  if (!participant_info->leave_middleware_default_qos) {
     reader_qos.data_sharing().off();
   }
 
@@ -403,15 +403,15 @@ rmw_create_client(
   publisher->get_datawriter_qos_from_profile(request_topic_name, writer_qos);
 
   // Modify specific DataWriter Qos
+  writer_qos.endpoint().history_memory_policy =
+    eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+
   if (!participant_info->leave_middleware_default_qos) {
     if (participant_info->publishing_mode == publishing_mode_t::ASYNCHRONOUS) {
       writer_qos.publish_mode().kind = eprosima::fastdds::dds::ASYNCHRONOUS_PUBLISH_MODE;
     } else if (participant_info->publishing_mode == publishing_mode_t::SYNCHRONOUS) {
       writer_qos.publish_mode().kind = eprosima::fastdds::dds::SYNCHRONOUS_PUBLISH_MODE;
     }
-
-    writer_qos.endpoint().history_memory_policy =
-      eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
 
     writer_qos.data_sharing().off();
   }

--- a/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/rmw_service.cpp
@@ -337,10 +337,10 @@ rmw_create_service(
   subscriber->get_datareader_qos_from_profile(topic_name_fallback, reader_qos);
   subscriber->get_datareader_qos_from_profile(request_topic_name, reader_qos);
 
-  if (!participant_info->leave_middleware_default_qos) {
-    reader_qos.endpoint().history_memory_policy =
-      eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  reader_qos.endpoint().history_memory_policy =
+    eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
 
+  if (!participant_info->leave_middleware_default_qos) {
     reader_qos.data_sharing().off();
   }
 
@@ -403,15 +403,15 @@ rmw_create_service(
   publisher->get_datawriter_qos_from_profile(response_topic_name, writer_qos);
 
   // Modify specific DataWriter Qos
+  writer_qos.endpoint().history_memory_policy =
+    eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+
   if (!participant_info->leave_middleware_default_qos) {
     if (participant_info->publishing_mode == publishing_mode_t::ASYNCHRONOUS) {
       writer_qos.publish_mode().kind = eprosima::fastdds::dds::ASYNCHRONOUS_PUBLISH_MODE;
     } else if (participant_info->publishing_mode == publishing_mode_t::SYNCHRONOUS) {
       writer_qos.publish_mode().kind = eprosima::fastdds::dds::SYNCHRONOUS_PUBLISH_MODE;
     }
-
-    writer_qos.endpoint().history_memory_policy =
-      eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
 
     writer_qos.data_sharing().off();
   }

--- a/rmw_fastrtps_dynamic_cpp/src/subscription.cpp
+++ b/rmw_fastrtps_dynamic_cpp/src/subscription.cpp
@@ -257,10 +257,10 @@ create_subscription(
   // the QoS is already the default
   subscriber->get_datareader_qos_from_profile(topic_name, reader_qos);
 
-  if (!participant_info->leave_middleware_default_qos) {
-    reader_qos.endpoint().history_memory_policy =
-      eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  reader_qos.endpoint().history_memory_policy =
+    eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
 
+  if (!participant_info->leave_middleware_default_qos) {
     reader_qos.data_sharing().off();
   }
 

--- a/rmw_fastrtps_shared_cpp/src/participant.cpp
+++ b/rmw_fastrtps_shared_cpp/src/participant.cpp
@@ -329,12 +329,10 @@ rmw_fastrtps_shared_cpp::create_participant(
     }
   }
   // allow reallocation to support discovery messages bigger than 5000 bytes
-  if (!leave_middleware_default_qos) {
-    domainParticipantQos.wire_protocol().builtin.readerHistoryMemoryPolicy =
-      eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
-    domainParticipantQos.wire_protocol().builtin.writerHistoryMemoryPolicy =
-      eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
-  }
+  domainParticipantQos.wire_protocol().builtin.readerHistoryMemoryPolicy =
+    eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+  domainParticipantQos.wire_protocol().builtin.writerHistoryMemoryPolicy =
+    eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
   if (security_options->security_root_path) {
     // if security_root_path provided, try to find the key and certificate files
 #if HAVE_SECURITY


### PR DESCRIPTION
Prevent NotEnoughMemoryException crash when RMW_FASTRTPS_USE_QOS_FROM_XML=1 with data_sharing. Move history_memory_policy to always apply PREALLOCATED_WITH_REALLOC. Fixes #878.