### PR TITLE
Fix transient-local publishing for buffer-aware path

### DIFF
--- a/rmw_fastrtps_cpp/src/publisher.cpp
+++ b/rmw_fastrtps_cpp/src/publisher.cpp
@@ -255,10 +255,24 @@ rmw_fastrtps_cpp::create_publisher(
     writer_qos.data_sharing().off();
   }
 
-  // Detect buffer-aware message type
-  bool has_buffer_fields = callbacks->has_buffer_fields;
+  // Resolve the effective QoS before deciding whether to enable buffer endpoints.
+  const bool has_buffer_fields = callbacks->has_buffer_fields;
+  if (!get_datawriter_qos(
+      *qos_policies, *type_supports->get_type_hash_func(type_supports),
+      writer_qos, nullptr, nullptr))
+  {
+    RMW_SET_ERROR_MSG("create_publisher() failed setting data writer QoS");
+    return nullptr;
+  }
+
+  // Buffer backends do not support transient-local durability. Those publishers
+  // use only the base DataWriter, which provides the required history cache.
+  const bool use_buffer_endpoints = has_buffer_fields &&
+    writer_qos.durability().kind !=
+    eprosima::fastdds::dds::TRANSIENT_LOCAL_DURABILITY_QOS;
+
   std::unordered_map<std::string, std::string> backend_metadata;
-  if (has_buffer_fields) {
+  if (use_buffer_endpoints) {
     auto * backend_context =
       static_cast<rmw_fastrtps_cpp::BufferBackendContext *>(
       participant_info->buffer_serialization_context_);
@@ -271,16 +285,15 @@ rmw_fastrtps_cpp::create_publisher(
     if (backend_metadata.find("cpu") == backend_metadata.end()) {
       backend_metadata["cpu"] = "";
     }
-  }
 
-  // Get QoS from RMW, optionally encoding buffer backend info in user_data
-  if (!get_datawriter_qos(
-      *qos_policies, *type_supports->get_type_hash_func(type_supports),
-      writer_qos, nullptr,
-      has_buffer_fields ? &backend_metadata : nullptr))
-  {
-    RMW_SET_ERROR_MSG("create_publisher() failed setting data writer QoS");
-    return nullptr;
+    // Rebuild user_data with buffer backend metadata for discovery.
+    if (!get_datawriter_qos(
+        *qos_policies, *type_supports->get_type_hash_func(type_supports),
+        writer_qos, nullptr, &backend_metadata))
+    {
+      RMW_SET_ERROR_MSG("create_publisher() failed setting buffer-aware data writer QoS");
+      return nullptr;
+    }
   }
 
   // Apply resource limits QoS if the type is keyed
@@ -348,8 +361,8 @@ rmw_fastrtps_cpp::create_publisher(
   rmw_publisher->options = *publisher_options;
 
   // Buffer-aware publisher setup
-  info->is_buffer_aware_ = has_buffer_fields;
-  if (has_buffer_fields) {
+  info->is_buffer_aware_ = use_buffer_endpoints;
+  if (use_buffer_endpoints) {
     info->serialization_context_ = participant_info->buffer_serialization_context_;
     info->backend_metadata_ = backend_metadata;
     info->participant_ = dds_participant;

--- a/rmw_fastrtps_cpp/src/rmw_publish.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publish.cpp
@@ -250,7 +250,12 @@ rmw_publish(
     return RMW_RET_INVALID_ARGUMENT);
 
   auto info = static_cast<CustomPublisherInfo *>(publisher->data);
-  if (info->is_buffer_aware_) {
+  // Route transient-local publishers through the main DataWriter below as
+  // transient-local is not supported by buffer backends.
+  if (info->is_buffer_aware_ &&
+    info->data_writer_->get_qos().durability().kind !=
+    eprosima::fastdds::dds::TRANSIENT_LOCAL_DURABILITY_QOS)
+  {
     // Check whether any non-backend-aware (legacy) subscribers exist.
     // If so, skip buffer channels entirely and fall through to the main
     // DataWriter so old RMW endpoints receive the message.  Buffer-aware
@@ -268,9 +273,6 @@ rmw_publish(
       publish_to_buffer_endpoints(info, ros_message, publisher);
       return RMW_RET_OK;
     }
-    // Legacy subscribers present — publish via main (legacy) DataWriter.
-    return rmw_fastrtps_shared_cpp::__rmw_publish(
-      eprosima_fastrtps_identifier, publisher, ros_message, allocation);
   }
 
   return rmw_fastrtps_shared_cpp::__rmw_publish(

--- a/rmw_fastrtps_cpp/src/rmw_publish.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publish.cpp
@@ -250,12 +250,7 @@ rmw_publish(
     return RMW_RET_INVALID_ARGUMENT);
 
   auto info = static_cast<CustomPublisherInfo *>(publisher->data);
-  // Route transient-local publishers through the main DataWriter below as
-  // transient-local is not supported by buffer backends.
-  if (info->is_buffer_aware_ &&
-    info->data_writer_->get_qos().durability().kind !=
-    eprosima::fastdds::dds::TRANSIENT_LOCAL_DURABILITY_QOS)
-  {
+  if (info->is_buffer_aware_) {
     // Check whether any non-backend-aware (legacy) subscribers exist.
     // If so, skip buffer channels entirely and fall through to the main
     // DataWriter so old RMW endpoints receive the message.  Buffer-aware

--- a/rmw_fastrtps_cpp/src/subscription.cpp
+++ b/rmw_fastrtps_cpp/src/subscription.cpp
@@ -695,13 +695,27 @@ __create_subscription(
     reader_qos.data_sharing().off();
   }
 
-  // Detect buffer-aware message type
-  bool has_buffer_fields = callbacks->has_buffer_fields;
+  // Resolve the effective QoS before deciding whether to enable buffer endpoints.
+  const bool has_buffer_fields = callbacks->has_buffer_fields;
+  if (!get_datareader_qos(
+      *qos_policies, *type_supports->get_type_hash_func(type_supports),
+      reader_qos, nullptr, nullptr))
+  {
+    RMW_SET_ERROR_MSG("create_subscription() failed setting data reader QoS");
+    return nullptr;
+  }
+
+  // A transient-local subscription can only match publishers that use the base
+  // DataWriter, so its custom buffer endpoints would never receive data.
+  const bool use_buffer_endpoints = has_buffer_fields &&
+    reader_qos.durability().kind !=
+    eprosima::fastdds::dds::TRANSIENT_LOCAL_DURABILITY_QOS;
+
   std::unordered_map<std::string, std::string> filtered_backends;
   std::vector<std::string> my_backend_types;
   bool cpu_only = false;
 
-  if (has_buffer_fields) {
+  if (use_buffer_endpoints) {
     std::unordered_map<std::string, std::string> all_backends;
     auto * backend_context =
       static_cast<rmw_fastrtps_cpp::BufferBackendContext *>(
@@ -764,15 +778,15 @@ __create_subscription(
         }
       }
     }
-  }
 
-  if (!get_datareader_qos(
-      *qos_policies, *type_supports->get_type_hash_func(type_supports),
-      reader_qos, nullptr,
-      has_buffer_fields ? &filtered_backends : nullptr))
-  {
-    RMW_SET_ERROR_MSG("create_subscription() failed setting data reader QoS");
-    return nullptr;
+    // Rebuild user_data with buffer backend metadata for discovery.
+    if (!get_datareader_qos(
+        *qos_policies, *type_supports->get_type_hash_func(type_supports),
+        reader_qos, nullptr, &filtered_backends))
+    {
+      RMW_SET_ERROR_MSG("create_subscription() failed setting buffer-aware data reader QoS");
+      return nullptr;
+    }
   }
 
   // Apply resource limits QoS if the type is keyed
@@ -844,9 +858,9 @@ __create_subscription(
   rmw_subscription->is_cft_supported = true;
 
   // Buffer-aware subscription setup
-  info->is_buffer_aware_ = has_buffer_fields;
-  info->is_cpu_only_ = has_buffer_fields && cpu_only;
-  if (has_buffer_fields) {
+  info->is_buffer_aware_ = use_buffer_endpoints;
+  info->is_cpu_only_ = use_buffer_endpoints && cpu_only;
+  if (use_buffer_endpoints) {
     info->serialization_context_ = participant_info->buffer_serialization_context_;
     info->my_backend_types_ = std::move(my_backend_types);
     info->local_endpoint_info_ = rmw_get_zero_initialized_topic_endpoint_info();


### PR DESCRIPTION
## Description                      

Currently transient-local setting is silently denied on buffer-aware publishers as buffer backends do not support transient-local.

This PR enables transient-local on the buffer-aware publishers by routing them to the CPU-based, main DataWriter (in contrast to the buffer-aware backend/cpu DataWriter on the buffer-aware path). Volatile buffer-aware publishers remain the same going through the existing buffer-aware path.

As a result, hardware accelerated buffer backend transport is effectively disabled (by converting to CPU-based buffer) on the (buffer-aware) publishers configured with transient-local.

Fixes #897

### Is this user-facing behavior change?

Yes. Transient-local buffer-aware publishers now explicitly go through the main CPU-based DataWriter even when buffer backends are enabled.

### Did you use Generative AI?

Yes. OpenAI GPT-5.6 was used to draft the fix for this PR.

### Additional Information

Regression coverage is provided by a new test in https://github.com/ros2/rclcpp/pull/3195.