### PR TITLE
Fix buffer-aware subscriptions to preserve unread data across rmw_wait calls

### DIFF
--- a/rmw_fastrtps_cpp/src/rmw_subscription.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_subscription.cpp
@@ -138,7 +138,6 @@ rmw_create_subscription(
   // per-publisher metadata tracking, so skip the callback for them.
   if (info->is_buffer_aware_ && !info->is_cpu_only_) {
     auto state = info->buffer_state_;
-    auto * guard = info->buffer_data_guard_.get();
     auto * backend_context =
       static_cast<const rmw_fastrtps_cpp::BufferBackendContext *>(
       info->serialization_context_);
@@ -148,7 +147,7 @@ rmw_create_subscription(
       buf_registry->register_publisher_discovery_callback(
         subscription->topic_name,
         info->subscription_gid_,
-        [state, guard, backend_context](
+        [state, backend_context](
           const rmw_fastrtps_cpp::BufferEndpointInfo & pub_info)
         {
           if (!state->alive.load()) {
@@ -193,10 +192,6 @@ rmw_create_subscription(
             }
 
             state->publisher_metadata[pub_hex] = std::move(meta);
-
-            if (guard) {
-              guard->set_trigger_value(true);
-            }
           }
 
           RCUTILS_LOG_DEBUG_NAMED(

--- a/rmw_fastrtps_cpp/src/rmw_take.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_take.cpp
@@ -23,7 +23,6 @@
 
 #include "fastdds/dds/subscriber/SampleInfo.hpp"
 #include "fastdds/dds/core/StackAllocatedSequence.hpp"
-#include "fastdds/dds/core/condition/GuardCondition.hpp"
 
 #include "rcutils/logging_macros.h"
 
@@ -78,9 +77,6 @@ take_buffer_aware(
       cpu_vals.length(0);
       cpu_info_seq.length(0);
 
-      if (info->cpu_data_reader_->get_unread_count() > 0 && info->buffer_data_guard_) {
-        info->buffer_data_guard_->set_trigger_value(true);
-      }
       return RMW_RET_OK;
     }
     cpu_vals.length(0);
@@ -191,10 +187,6 @@ take_buffer_aware(
     }
   }
 
-  if (info->accel_data_reader_->get_unread_count() > 0 && info->buffer_data_guard_) {
-    info->buffer_data_guard_->set_trigger_value(true);
-  }
-
   return RMW_RET_OK;
 }
 
@@ -259,10 +251,6 @@ take_buffer_aware_serialized(
   }
 
   *taken = true;
-
-  if (info->cpu_data_reader_->get_unread_count() > 0 && info->buffer_data_guard_) {
-    info->buffer_data_guard_->set_trigger_value(true);
-  }
 
   return RMW_RET_OK;
 }

--- a/rmw_fastrtps_cpp/src/subscription.cpp
+++ b/rmw_fastrtps_cpp/src/subscription.cpp
@@ -19,7 +19,6 @@
 #include <utility>
 #include <vector>
 
-#include "fastdds/dds/core/condition/GuardCondition.hpp"
 #include "fastdds/dds/domain/DomainParticipant.hpp"
 #include "fastdds/dds/subscriber/Subscriber.hpp"
 #include "fastdds/dds/subscriber/qos/DataReaderQos.hpp"
@@ -74,19 +73,14 @@ using PropertyPolicyHelper = eprosima::fastdds::rtps::PropertyPolicyHelper;
 namespace
 {
 
-class CpuChannelDataReaderListener final : public eprosima::fastdds::dds::DataReaderListener
+class BufferChannelDataReaderListener final : public eprosima::fastdds::dds::DataReaderListener
 {
 public:
-  CpuChannelDataReaderListener(
-    eprosima::fastdds::dds::GuardCondition * guard,
-    RMWSubscriptionEvent * event)
-  : guard_(guard), event_(event) {}
+  explicit BufferChannelDataReaderListener(RMWSubscriptionEvent * event)
+  : event_(event) {}
 
   void on_data_available(eprosima::fastdds::dds::DataReader * reader) override
   {
-    if (guard_) {
-      guard_->set_trigger_value(true);
-    }
     auto unread = reader->get_unread_count();
     if (event_) {
       event_->notify_buffer_data_available(unread > 0 ? static_cast<size_t>(unread) : 1);
@@ -94,7 +88,6 @@ public:
   }
 
 private:
-  eprosima::fastdds::dds::GuardCondition * guard_;
   RMWSubscriptionEvent * event_;
 };
 
@@ -855,9 +848,6 @@ __create_subscription(
       info->local_endpoint_info_.endpoint_gid,
       info->subscription_gid_.data, RMW_GID_STORAGE_SIZE);
 
-    info->buffer_data_guard_ =
-      std::make_unique<eprosima::fastdds::dds::GuardCondition>();
-
     if (cpu_only) {
       // CPU-only: create a DataReader on the shared CPU channel.
       std::string cpu_topic_name = topic_name_mangled + "/_buf_cpu";
@@ -875,8 +865,7 @@ __create_subscription(
 
       eprosima::fastdds::dds::DataReaderQos cpu_rqos = info->datareader_qos_;
       info->cpu_data_reader_listener_ =
-        std::make_shared<CpuChannelDataReaderListener>(
-        info->buffer_data_guard_.get(), info->subscription_event_);
+        std::make_shared<BufferChannelDataReaderListener>(info->subscription_event_);
       info->cpu_data_reader_ = subscriber->create_datareader(
         info->cpu_topic_, cpu_rqos, info->cpu_data_reader_listener_.get(),
         eprosima::fastdds::dds::StatusMask::data_available());
@@ -887,6 +876,8 @@ __create_subscription(
         RMW_SET_ERROR_MSG("create_subscription() failed to create CPU channel DataReader");
         return nullptr;
       }
+      info->cpu_data_reader_->get_statuscondition().set_enabled_statuses(
+        eprosima::fastdds::dds::StatusMask::data_available());
     } else {
       // Accelerated: single shared DataReader for all buffer-aware publishers.
       std::string sub_hex = rmw_fastrtps_shared_cpp::gid_to_hex(info->subscription_gid_);
@@ -909,8 +900,7 @@ __create_subscription(
       accel_rqos.representation().m_value.push_back(rep);
 
       info->accel_data_reader_listener_ =
-        std::make_shared<CpuChannelDataReaderListener>(
-        info->buffer_data_guard_.get(), info->subscription_event_);
+        std::make_shared<BufferChannelDataReaderListener>(info->subscription_event_);
       info->accel_data_reader_ = subscriber->create_datareader(
         info->accel_topic_, accel_rqos, info->accel_data_reader_listener_.get(),
         eprosima::fastdds::dds::StatusMask::data_available());
@@ -921,6 +911,8 @@ __create_subscription(
         RMW_SET_ERROR_MSG("create_subscription() failed to create accelerated channel DataReader");
         return nullptr;
       }
+      info->accel_data_reader_->get_statuscondition().set_enabled_statuses(
+        eprosima::fastdds::dds::StatusMask::data_available());
     }
 
     auto * backend_context =

--- a/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
+++ b/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_subscriber_info.hpp
@@ -29,7 +29,6 @@
 
 #include "fastdds/dds/core/status/DeadlineMissedStatus.hpp"
 #include "fastdds/dds/core/status/LivelinessChangedStatus.hpp"
-#include "fastdds/dds/core/condition/GuardCondition.hpp"
 #include "fastdds/dds/core/status/SubscriptionMatchedStatus.hpp"
 #include "fastdds/dds/subscriber/DataReader.hpp"
 #include "fastdds/dds/subscriber/DataReaderListener.hpp"
@@ -146,10 +145,6 @@ struct CustomSubscriberInfo : public CustomEventInfo
   const void * serialization_context_{nullptr};
   std::shared_ptr<BufferSubscriptionState> buffer_state_{
     std::make_shared<BufferSubscriptionState>()};
-  /// Guard condition triggered when buffer channel DataReaders receive data.
-  /// Used by rmw_wait to detect data on buffer-aware subscriptions.
-  std::unique_ptr<eprosima::fastdds::dds::GuardCondition> buffer_data_guard_;
-
   // CPU-only shared channel reader (when acceptable_buffer_backends is CPU-only)
   eprosima::fastdds::dds::DataReader * cpu_data_reader_{nullptr};
   eprosima::fastdds::dds::Topic * cpu_topic_{nullptr};

--- a/rmw_fastrtps_shared_cpp/src/rmw_wait.cpp
+++ b/rmw_fastrtps_shared_cpp/src/rmw_wait.cpp
@@ -29,6 +29,26 @@
 
 namespace rmw_fastrtps_shared_cpp
 {
+static bool data_reader_has_data(
+  eprosima::fastdds::dds::DataReader * data_reader)
+{
+  if (!data_reader) {
+    return false;
+  }
+
+  eprosima::fastdds::dds::SampleInfo sample_info;
+  return eprosima::fastdds::dds::RETCODE_OK ==
+         data_reader->get_first_untaken_info(&sample_info);
+}
+
+static bool subscription_has_data(
+  const CustomSubscriberInfo * custom_subscriber_info)
+{
+  return data_reader_has_data(custom_subscriber_info->data_reader_) ||
+         data_reader_has_data(custom_subscriber_info->cpu_data_reader_) ||
+         data_reader_has_data(custom_subscriber_info->accel_data_reader_);
+}
+
 /// Check if any condition in the set of entities has a triggered condition.
 /**
  * If any condition is triggered before waiting, then we can skip some set-up,
@@ -79,15 +99,7 @@ static bool has_triggered_condition(
     for (size_t i = 0; i < subscriptions->subscriber_count; ++i) {
       void * data = subscriptions->subscribers[i];
       auto custom_subscriber_info = static_cast<CustomSubscriberInfo *>(data);
-      eprosima::fastdds::dds::SampleInfo sample_info;
-      if (eprosima::fastdds::dds::RETCODE_OK ==
-        custom_subscriber_info->data_reader_->get_first_untaken_info(&sample_info))
-      {
-        return true;
-      }
-      if (custom_subscriber_info->buffer_data_guard_ &&
-        custom_subscriber_info->buffer_data_guard_->get_trigger_value())
-      {
+      if (subscription_has_data(custom_subscriber_info)) {
         return true;
       }
     }
@@ -165,8 +177,13 @@ __rmw_wait(
         auto custom_subscriber_info = static_cast<CustomSubscriberInfo *>(data);
         attached_conditions.push_back(
           &custom_subscriber_info->data_reader_->get_statuscondition());
-        if (custom_subscriber_info->buffer_data_guard_) {
-          attached_conditions.push_back(custom_subscriber_info->buffer_data_guard_.get());
+        if (custom_subscriber_info->cpu_data_reader_) {
+          attached_conditions.push_back(
+            &custom_subscriber_info->cpu_data_reader_->get_statuscondition());
+        }
+        if (custom_subscriber_info->accel_data_reader_) {
+          attached_conditions.push_back(
+            &custom_subscriber_info->accel_data_reader_->get_statuscondition());
         }
       }
     }
@@ -239,20 +256,7 @@ __rmw_wait(
       void * data = subscriptions->subscribers[i];
       auto custom_subscriber_info = static_cast<CustomSubscriberInfo *>(data);
 
-      bool has_data = false;
-      eprosima::fastdds::dds::SampleInfo sample_info;
-      if (eprosima::fastdds::dds::RETCODE_OK ==
-        custom_subscriber_info->data_reader_->get_first_untaken_info(&sample_info))
-      {
-        has_data = true;
-      }
-      if (!has_data && custom_subscriber_info->buffer_data_guard_ &&
-        custom_subscriber_info->buffer_data_guard_->get_trigger_value())
-      {
-        has_data = true;
-        custom_subscriber_info->buffer_data_guard_->set_trigger_value(false);
-      }
-      if (!has_data) {
+      if (!subscription_has_data(custom_subscriber_info)) {
         subscriptions->subscribers[i] = 0;
       }
     }


### PR DESCRIPTION
## Description

  Buffer-aware subscriptions used a synthetic GuardCondition to wake rmw_wait() when data arrived. The guard was cleared after the first wait, even when the underlying CPU or accelerated DataReader still
  contained an unread sample.

  With a MultiThreadedExecutor, another worker may select the subscription but skip its callback because its mutually exclusive callback group is busy. A subsequent wait would then no longer see the
  unread sample, potentially delaying the callback until another event woke the executor.

  This change aligns buffer-aware subscriptions with the normal Fast DDS path:

  - Enable and attach the native DATA_AVAILABLE status conditions for CPU and accelerated buffer DataReaders.
  - Check the normal, CPU, and accelerated DataReaders directly for unread samples.
  - Keep subscriptions ready across repeated rmw_wait() calls until their data is taken.
  - Remove the synthetic buffer guard and its trigger/rearm logic.
  - Rename the shared buffer-channel listener to reflect its use by both CPU and accelerated channels.


  ### Is this user-facing behavior change?

  Yes. Buffer-aware subscriptions now remain ready while samples are unread. This prevents callbacks from stalling or timing out when a MultiThreadedExecutor temporarily skips a subscription because its
  mutually exclusive callback group is busy.

  There are no public API changes.

  ### Did you use Generative AI?

  Yes. OpenAI GPT-5.6 was used to draft the changes in this PR.

  ### Additional Information

  A regression test was created for this case in https://github.com/ros2/rmw_implementation/pull/282