### PR TITLE
Reuse FastBuffer managed buffer for each endpoint.

### DIFF
--- a/rmw_fastrtps_cpp/src/rmw_publish.cpp
+++ b/rmw_fastrtps_cpp/src/rmw_publish.cpp
@@ -171,13 +171,19 @@ publish_to_buffer_endpoints(
   }
 
   // Publish to per-subscriber peer-to-peer endpoints for non-CPU subscribers.
-  for (const auto & endpoint : state.endpoints) {
-    uint32_t serialized_size = callbacks->get_serialized_size(ros_message);
-    size_t buffer_size = serialized_size + 4;  // +4 for CDR encapsulation header
-    std::vector<uint8_t> buffer_data(buffer_size);
 
-    eprosima::fastcdr::FastBuffer fast_buffer(
-      reinterpret_cast<char *>(buffer_data.data()), buffer_size);
+  // Intentionally reuse an internally managed FastBuffer across endpoints. Each Cdr
+  // starts at the beginning and owns its cursor, and `write_w_timestamp()` copies
+  // the data before returning, so reuse is safe.
+  //
+  // Preallocating with `get_serialized_size()` is not recommended: for
+  // `rosidl::Buffer`, it may report the full CPU fallback size even when only a
+  // small descriptor is sent.
+  //
+  // The buffer grows automatically and lazily without zero-initialization.
+  eprosima::fastcdr::FastBuffer fast_buffer;
+
+  for (const auto & endpoint : state.endpoints) {
     eprosima::fastcdr::Cdr ser(
       fast_buffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
       eprosima::fastcdr::CdrVersion::XCDRv1);


### PR DESCRIPTION
## Description

Previously, heap allocation happend for each endpoint with std::vector<uint8_t>. This introduced extra memset via its constructor.

For recent ROS 2, where rosidl::Buffer was introduced, sometimes the actual payload size and message size may not match because only buffer descriptors may be sent. In such a case, now `get_serialized_size()` seems to be unreliable, and hard to pre-allocate the buffer in that path.

Fixes #903

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

Possibly yes.

Previously, it is guaranteed that the heap allocation only happens once per endpoint, through externally managed buffer (allocated with `std::vector<uint8_t>`). Now the number of allocations depends on combinations of buffer's strategies, and Cdr's usage. So, in small message cases, this patch will introduce an extra overhead of buffer reallocation.

For rosidl::Buffer usage, this patch will dramatically reduce extra allocation and zero-initialization when only the optimized message paths exist. 

### Did you use Generative AI?

I used CodeX to investigate the cause analysis, and FastBuffer/Cdr behavior.

### Additional Information

This patch is trying to resolve two issues at same time:

1. Reducing extra memory allocation when publishing rosidl::Buffer via optimized buf (carries only a descriptor) 
2. Removing extra memset caused by `std::vector<uint8_t>` constructor.

What I originally found is the second point, so if we wish more conservative way, it is possible to reserve the `fast_buffer` as previouslly. Still, I believe it is better to reuse that buffer accross endpoints, in my perspective...

Since this is my first PR to `rmw_fastrtps` repository, let me know if I missed anything.